### PR TITLE
Fix Wasm test directory paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preinstall": "go get ./...",
     "test:all": "yarn test:go && yarn test:wasm",
     "test:go": "go test ./... -race",
-    "test:wasm": "GOOS=js GOARCH=wasm go test -exec=\"./test-wasm/go_js_wasm_exec\" -v ."
+    "test:wasm": "export ZEROEX_MESH_ROOT_DIR=$(pwd); GOOS=js GOARCH=wasm go test -exec=\"$ZEROEX_MESH_ROOT_DIR/test-wasm/go_js_wasm_exec\" -v ./..."
   },
   "description": "A peer-to-peer network for sharing orders",
   "main": "index.js",

--- a/test-wasm/go_js_wasm_exec
+++ b/test-wasm/go_js_wasm_exec
@@ -20,4 +20,4 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 # We changed this line to require our node_shim.js.
-exec node --require=./test-wasm/node_shim.js "$(go env GOROOT)/misc/wasm/wasm_exec.js" "$@"
+exec node --require=$ZEROEX_MESH_ROOT_DIR/test-wasm/node_shim.js "$(go env GOROOT)/misc/wasm/wasm_exec.js" "$@"


### PR DESCRIPTION
Previously, the __go_js_wasm_exec__ bash script was not working properly for any tests that existed in nested directories. This PR updates the code so that the script will work for tests in any directory. We do this by setting the environment variable `ZEROEX_MESH_ROOT_DIR` to the root of the project and then using that to find the files we need to execute/require.