### PR TITLE
Use Makefile instead of yarn for running scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ jobs:
           command: npm i -g yarn@^1.15
       - run:
           name: Install dependencies
-          command: yarn install
+          command: make deps
       - run:
           name: Run Go tests
-          command: yarn test:go
+          command: make test-go
       - run:
           name: Run WebAssembly tests
-          command: yarn test:wasm
+          command: make test-wasm

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: deps
+deps:
+	go get ./...
+	yarn install
+
+
+.PHONY: test-all
+test-all: test-go test-wasm
+
+
+.PHONY: test-go
+test-go:
+	go test ./... -v -race
+
+
+.PHONY: test-wasm
+test-wasm:
+	export ZEROEX_MESH_ROOT_DIR=$$(pwd); GOOS=js GOARCH=wasm go test -exec="$$ZEROEX_MESH_ROOT_DIR/test-wasm/go_js_wasm_exec" ./... -v

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ for more background on how this works.
 
 ### Prerequisites
 
+- [GNU Make](https://www.gnu.org/software/make/) If you are using a Unix-like OS, you probably already have this.
 - [Go version >= 1.12](https://golang.org/dl/) (or use [the version manager called "g"](https://github.com/stefanmaric/g))
 - [Node.js version >= 10](https://nodejs.org/en/download/) (or use the [nvm version manager](https://github.com/creationix/nvm))
 - [Yarn package manager](https://yarnpkg.com/en/)
@@ -17,7 +18,7 @@ for more background on how this works.
 ### Installing dependencies
 
 ```
-yarn install
+make deps
 ```
 
 ### Running tests
@@ -25,17 +26,17 @@ yarn install
 Run tests in a vanilla Go environment:
 
 ```
-yarn test:go
+make test-go
 ```
 
 Run tests in a Node.js/WebAssembly environment:
 
 ```
-yarn test:wasm
+make test-wasm
 ```
 
 Run tests in both environments:
 
 ```
-yarn test:all
+make test-all
 ```

--- a/package.json
+++ b/package.json
@@ -4,12 +4,6 @@
   "engines": {
     "node": ">=11"
   },
-  "scripts": {
-    "preinstall": "go get ./...",
-    "test:all": "yarn test:go && yarn test:wasm",
-    "test:go": "go test ./... -race",
-    "test:wasm": "export ZEROEX_MESH_ROOT_DIR=$(pwd); GOOS=js GOARCH=wasm go test -exec=\"$ZEROEX_MESH_ROOT_DIR/test-wasm/go_js_wasm_exec\" -v ./..."
-  },
   "description": "A peer-to-peer network for sharing orders",
   "main": "index.js",
   "repository": "git@github.com:0xProject/0x-mesh.git",


### PR DESCRIPTION
We were running into some issues with yarn not using the correct version of files and not passing flags correctly.