### PR TITLE
Add support for MultiIndexes for one-to-many relationships

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:a8a7b3ab27d90a3c63b5d2fe6e23c80a79d2b68708490b90bb160ccc7836c831"
+  name = "github.com/albrow/stringset"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5cbcec770ff3993feab398d47a8c0ca9f0a812de"
+  version = "v2.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:e574dab86697e4e3a8e2e815e0e932cfbf3618e74d6379d8732b33757e11b23d"
   name = "github.com/allegro/bigcache"
@@ -108,7 +116,7 @@
   ]
   pruneopts = "T"
   revision = "aa34e00ba93924332ca55155ac5bde205017544d"
-  source = "github.com/0xproject/go-ethereum"
+  source = "github.com/0xProject/go-ethereum"
 
 [[projects]]
   branch = "master"
@@ -381,6 +389,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/albrow/stringset",
     "github.com/ethereum/go-ethereum",
     "github.com/ethereum/go-ethereum/accounts/abi",
     "github.com/ethereum/go-ethereum/accounts/abi/bind",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -54,3 +54,7 @@
   name = "github.com/syndtr/goleveldb"
   branch = "minimum-wasm-support"
   source = "github.com/0xProject/goleveldb"
+
+[[constraint]]
+  name = "github.com/albrow/stringset"
+  version = "2.1.0"


### PR DESCRIPTION
This feature is required as there is currently no good way to index orders that utilize the MultiAssetProxy. The new `AddMultiIndex` method will allow us to insert multiple values into the index (in our case makerAddress, makerAsset, and tokenId) for a given model.