### PR TITLE
Improve effeciency of blockwatch.Stack and make it goroutine safe

### DIFF
--- a/blockwatch/stack.go
+++ b/blockwatch/stack.go
@@ -1,15 +1,17 @@
 package blockwatch
 
 import (
-	"errors"
+	"sync"
 
 	"github.com/0xProject/0x-mesh/meshdb"
 )
 
-// TODO(albrow): Needs to be optimized and made goroutine-safe.
-
 // Stack allows performing basic stack operations on a stack of meshdb.MiniHeaders.
 type Stack struct {
+	// TODO(albrow): Use Transactions when db supports them instead of a mutex
+	// here. There are cases where we need to make sure no modifications are made
+	// to the database in between a read/write or read/delete.
+	mut    sync.Mutex
 	meshDB *meshdb.MeshDB
 	limit  int
 }
@@ -23,25 +25,29 @@ func NewStack(meshDB *meshdb.MeshDB, limit int) *Stack {
 	}
 }
 
-// Pop removes and returns the latest block header on the block stack.
+// Pop removes and returns the latest block header on the block stack. It
+// returns nil if the stack is empty.
 func (s *Stack) Pop() (*meshdb.MiniHeader, error) {
-	miniHeaders, err := s.meshDB.FindAllMiniHeadersSortedByNumber()
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	latestMiniHeader, err := s.meshDB.FindLatestMiniHeader()
 	if err != nil {
 		return nil, err
 	}
-	if len(miniHeaders) == 0 {
-		return nil, errors.New("Cannot pop from empty stack")
+	if latestMiniHeader == nil {
+		return nil, nil
 	}
-	latestMiniHeader := miniHeaders[len(miniHeaders)-1]
 	if err := s.meshDB.MiniHeaders.Delete(latestMiniHeader.ID()); err != nil {
 		return nil, err
 	}
 	return latestMiniHeader, nil
 }
 
-// Push pushes a block header onto the block stack. If the stack limit is reached,
-// it will remove the oldest block header and return it.
+// Push pushes a block header onto the block stack. If the stack limit is
+// reached, it will remove the oldest block header and return it.
 func (s *Stack) Push(block *meshdb.MiniHeader) (*meshdb.MiniHeader, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
 	miniHeaders, err := s.meshDB.FindAllMiniHeadersSortedByNumber()
 	if err != nil {
 		return nil, err
@@ -59,16 +65,10 @@ func (s *Stack) Push(block *meshdb.MiniHeader) (*meshdb.MiniHeader, error) {
 	return oldestMiniHeader, nil
 }
 
-// Peek returns the latest block header (if exists) from the block stack without removing it.
+// Peek returns the latest block header from the block stack without removing
+// it. It returns nil if the stack is empty.
 func (s *Stack) Peek() (*meshdb.MiniHeader, error) {
-	miniHeaders, err := s.meshDB.FindAllMiniHeadersSortedByNumber()
-	if err != nil {
-		return nil, err
-	}
-	if len(miniHeaders) == 0 {
-		return nil, nil
-	}
-	return miniHeaders[len(miniHeaders)-1], nil
+	return s.meshDB.FindLatestMiniHeader()
 }
 
 // Inspect returns all the block headers currently on the stack

--- a/meshdb/meshdb.go
+++ b/meshdb/meshdb.go
@@ -83,3 +83,18 @@ func (m *MeshDB) FindAllMiniHeadersSortedByNumber() ([]*MiniHeader, error) {
 	}
 	return miniHeaders, nil
 }
+
+// FindLatestMiniHeader returns the latest MiniHeader (i.e. the one with the
+// largest block number), or nil if there are none in the database.
+func (m *MeshDB) FindLatestMiniHeader() (*MiniHeader, error) {
+	miniHeaders := []*MiniHeader{}
+	query := m.MiniHeaders.NewQuery(m.MiniHeaders.numberIndex.All()).Reverse().Max(1)
+	err := query.Run(&miniHeaders)
+	if err != nil {
+		return nil, err
+	}
+	if len(miniHeaders) == 0 {
+		return nil, nil
+	}
+	return miniHeaders[0], nil
+}


### PR DESCRIPTION
Based on the improvements in #38. For `Peek` and `Pop` we can use a query to get only the latest `MiniHeader` instead of getting all of them.