### PR TITLE
Improve test running instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ make deps
 
 ### Running tests
 
+Some of the tests depend on having a test Ethereum node running. Before running the tests, make sure you have [Docker](https://docs.docker.com/install/) installed locally and start [0xorg/mesh-ganache-cli](https://cloud.docker.com/u/0xorg/repository/docker/0xorg/mesh-ganache-cli):
+
+```
+docker pull 0xorg/mesh-ganache-cli
+docker run -ti -p 8545:8545 0xorg/mesh-ganache-cli
+```
+
 Run tests in a vanilla Go environment:
 
 ```


### PR DESCRIPTION
We are added tests that depend on Ganache running locally with a specific snapshot. Updated to the README to include instructions on getting setup.