### PR TITLE
Change blockwatch.Client to accept an ethclient.Client instead of a URL

### DIFF
--- a/blockwatch/client.go
+++ b/blockwatch/client.go
@@ -26,13 +26,10 @@ type RpcClient struct {
 	requestTimeout time.Duration
 }
 
-// NewRpcClient returns a new Client for fetching Ethereum blocks from a supplied JSON-RPC endpoint.
-func NewRpcClient(rpcURL string, requestTimeout time.Duration) (*RpcClient, error) {
-	client, err := ethclient.Dial(rpcURL)
-	if err != nil {
-		return nil, err
-	}
-	return &RpcClient{client, requestTimeout}, nil
+// NewRpcClient returns a new Client for fetching Ethereum blocks using the given
+// ethclient.Client.
+func NewRpcClient(ethClient *ethclient.Client, requestTimeout time.Duration) (*RpcClient, error) {
+	return &RpcClient{ethClient, requestTimeout}, nil
 }
 
 // HeaderByNumber fetches a block header by its number. If no `number` is supplied, it will return the latest

--- a/zeroex/orderwatch/watcher.go
+++ b/zeroex/orderwatch/watcher.go
@@ -25,7 +25,7 @@ type Watcher struct {
 }
 
 // New instantiates a new order watcher
-func New(blockWatcher *blockwatch.Watcher, rpcClient blockwatch.Client) (*Watcher, error) {
+func New(blockWatcher *blockwatch.Watcher) (*Watcher, error) {
 	decoder, err := NewDecoder()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change will allow us to re-use the same `ethclient.Client` in __main.go__.