### PR TITLE
ethereum/zeroex: Pass network ID instead of contract addresses

### DIFF
--- a/ethereum/eth_watcher.go
+++ b/ethereum/eth_watcher.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/ethereum/wrappers"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -44,8 +45,9 @@ type ETHWatcher struct {
 }
 
 // NewETHWatcher creates a new instance of ETHWatcher
-func NewETHWatcher(minPollingInterval time.Duration, ethClient *ethclient.Client, ethBalanceCheckerAddress common.Address) (*ETHWatcher, error) {
-	ethBalanceChecker, err := wrappers.NewEthBalanceChecker(ethBalanceCheckerAddress, ethClient)
+func NewETHWatcher(minPollingInterval time.Duration, ethClient *ethclient.Client, networkID int) (*ETHWatcher, error) {
+	contractNameToAddress := constants.NetworkIDToContractAddresses[networkID]
+	ethBalanceChecker, err := wrappers.NewEthBalanceChecker(contractNameToAddress.EthBalanceChecker, ethClient)
 	if err != nil {
 		return nil, err
 	}

--- a/ethereum/eth_watcher_test.go
+++ b/ethereum/eth_watcher_test.go
@@ -44,7 +44,7 @@ func TestAddingAddressToETHWatcher(t *testing.T) {
 	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
 
-	ethWatcher, err := NewETHWatcher(pollingInterval, ethClient, GanacheEthBalanceCheckerAddress)
+	ethWatcher, err := NewETHWatcher(pollingInterval, ethClient, constants.TestNetworkID)
 	require.NoError(t, err)
 
 	for address := range ethAccountToBalance {
@@ -64,7 +64,7 @@ func TestUpdateBalancesETHWatcher(t *testing.T) {
 	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
 
-	ethWatcher, err := NewETHWatcher(pollingInterval, ethClient, GanacheEthBalanceCheckerAddress)
+	ethWatcher, err := NewETHWatcher(pollingInterval, ethClient, constants.TestNetworkID)
 	require.NoError(t, err)
 
 	for address := range ethAccountToBalance {
@@ -91,7 +91,7 @@ func TestUpdateChangedBalancesOnlyETHWatcher(t *testing.T) {
 	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
 
-	ethWatcher, err := NewETHWatcher(pollingInterval, ethClient, GanacheEthBalanceCheckerAddress)
+	ethWatcher, err := NewETHWatcher(pollingInterval, ethClient, constants.TestNetworkID)
 	require.NoError(t, err)
 
 	// Add the first account with the correct initial balance. We expect no event to be emitted for
@@ -121,7 +121,7 @@ func TestStartStopETHWatcher(t *testing.T) {
 	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
 
-	ethWatcher, err := NewETHWatcher(pollingInterval, ethClient, GanacheEthBalanceCheckerAddress)
+	ethWatcher, err := NewETHWatcher(pollingInterval, ethClient, constants.TestNetworkID)
 	require.NoError(t, err)
 
 	for address := range ethAccountToBalance {

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/ethereum/wrappers"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -49,8 +50,9 @@ type OrderValidator struct {
 }
 
 // NewOrderValidator instantiates a new order validator
-func NewOrderValidator(orderValidatorAddress common.Address, ethClient *ethclient.Client) (*OrderValidator, error) {
-	orderValidator, err := wrappers.NewOrderValidator(orderValidatorAddress, ethClient)
+func NewOrderValidator(ethClient *ethclient.Client, networkID int) (*OrderValidator, error) {
+	contractNameToAddress := constants.NetworkIDToContractAddresses[networkID]
+	orderValidator, err := wrappers.NewOrderValidator(contractNameToAddress.OrderValidator, ethClient)
 	if err != nil {
 		return nil, err
 	}

--- a/zeroex/order_validator_test.go
+++ b/zeroex/order_validator_test.go
@@ -45,7 +45,7 @@ func TestBatchValidate(t *testing.T) {
 	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
 
-	orderValidator, err := NewOrderValidator(GanacheOrderValidatorAddress, ethClient)
+	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID)
 	require.NoError(t, err)
 
 	orderInfos := orderValidator.BatchValidate(signedOrders)

--- a/zeroex/orderwatch/watcher.go
+++ b/zeroex/orderwatch/watcher.go
@@ -65,13 +65,13 @@ func New(meshDB *meshdb.MeshDB, blockWatcher *blockwatch.Watcher, ethClient *eth
 	if err != nil {
 		return nil, err
 	}
-	contractNameToAddress := constants.NetworkIDToContractAddresses[networkId]
-	orderValidator, err := zeroex.NewOrderValidator(contractNameToAddress.OrderValidator, ethClient)
+	orderValidator, err := zeroex.NewOrderValidator(ethClient, networkId)
 	if err != nil {
 		return nil, err
 	}
 	cleanupCtx, cleanupCancelFunc := context.WithCancel(context.Background())
 	var expirationBuffer int64 = 0
+	contractNameToAddress := constants.NetworkIDToContractAddresses[networkId]
 	w := &Watcher{
 		meshDB:                     meshDB,
 		blockWatcher:               blockWatcher,


### PR DESCRIPTION
With the newly introduced `constants.NetworkIDToContractAddresses` it makes a lot more sense to pass around a `networkID` and have the contract address to looked up accordingly.