### PR TITLE
orderwatch: Return relevant topics

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,17 +118,15 @@ func newApp() (*application, error) {
 	if err != nil {
 		return nil, err
 	}
+	topics := orderwatch.GetRelevantTopics()
 	blockWatcherConfig := blockwatch.Config{
 		MeshDB:              db,
 		PollingInterval:     blockWatcherPollingInterval,
 		StartBlockDepth:     rpc.LatestBlockNumber,
 		BlockRetentionLimit: blockWatcherRetentionLimit,
 		WithLogs:            true,
-		// TODO: The order watcher (and any other watchers that use
-		// blockwatch.Watcher should register topics so that main.go isn't
-		// responsible for it.
-		Topics: nil,
-		Client: blockWatcherClient,
+		Topics:              topics,
+		Client:              blockWatcherClient,
 	}
 	blockWatcher := blockwatch.New(blockWatcherConfig)
 

--- a/zeroex/orderwatch/topics.go
+++ b/zeroex/orderwatch/topics.go
@@ -1,0 +1,18 @@
+package orderwatch
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// GetRelevantTopics returns the OrderWatcher-relevant topics that should be used when filtering
+// the logs retrieved for Ethereum blocks
+func GetRelevantTopics() []common.Hash {
+	topics := []common.Hash{}
+	for _, signature := range EVENT_SIGNATURES {
+		topic := common.BytesToHash(crypto.Keccak256([]byte(signature)))
+		topics = append(topics, topic)
+	}
+
+	return topics
+}


### PR DESCRIPTION
This PR:
- Adds a function to `orderwatch` that returns the relevant topics to use. 
- Passes the result of the function into OrderWatcher at instantiation.