### PR TITLE
Add the ability to add new peers over RPC

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1039,6 +1039,7 @@
     "github.com/ethereum/go-ethereum/common",
     "github.com/ethereum/go-ethereum/common/math",
     "github.com/ethereum/go-ethereum/core/types",
+    "github.com/ethereum/go-ethereum/crypto",
     "github.com/ethereum/go-ethereum/ethclient",
     "github.com/ethereum/go-ethereum/event",
     "github.com/ethereum/go-ethereum/rpc",
@@ -1061,7 +1062,6 @@
     "github.com/syndtr/goleveldb/leveldb/iterator",
     "github.com/syndtr/goleveldb/leveldb/util",
     "golang.org/x/crypto/sha3",
-    "golang.org/x/net/websocket",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/core/node.go
+++ b/core/node.go
@@ -15,8 +15,10 @@ import (
 	crypto "github.com/libp2p/go-libp2p-crypto"
 	host "github.com/libp2p/go-libp2p-host"
 	peer "github.com/libp2p/go-libp2p-peer"
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	ma "github.com/multiformats/go-multiaddr"
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -142,6 +144,18 @@ func (n *Node) ID() peer.ID {
 // from its peers. It blocks until an error is encountered or `Stop` is called.
 func (n *Node) Start() error {
 	return n.mainLoop()
+}
+
+// Connect ensures there is a connection between this host and the peer with
+// given peerInfo. If there is not an active connection, Connect will dial the
+// peer, and block until a connection is open, or an error is returned.
+func (n *Node) Connect(ctx context.Context, peerInfo peerstore.PeerInfo) error {
+	err := n.host.Connect(ctx, peerInfo)
+	if err != nil {
+		return err
+	}
+	log.WithField("peerInfo", peerInfo).Debug("connected to peer")
+	return nil
 }
 
 // mainLoop is where the core logic for a Node is implemented. On each iteration

--- a/core/node_test.go
+++ b/core/node_test.go
@@ -53,14 +53,13 @@ func createTwoConnectedTestNodes(t *testing.T) (*Node, *Node) {
 	// them.
 	node0 := newTestNode(t)
 	node1 := newTestNode(t)
-	node0.host.Peerstore().AddAddrs(node1.host.ID(), node1.host.Addrs(), peerstore.PermanentAddrTTL)
-	node1.host.Peerstore().AddAddrs(node0.host.ID(), node0.host.Addrs(), peerstore.PermanentAddrTTL)
-	node1PeerInfo := node0.host.Peerstore().PeerInfo(node1.host.ID())
-	node0PeerInfo := node1.host.Peerstore().PeerInfo(node0.host.ID())
-	connectContext, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	connectCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	require.NoError(t, node0.host.Connect(connectContext, node1PeerInfo))
-	require.NoError(t, node1.host.Connect(connectContext, node0PeerInfo))
+	node1PeerInfo := peerstore.PeerInfo{
+		ID:    node1.ID(),
+		Addrs: node1.Multiaddrs(),
+	}
+	require.NoError(t, node0.Connect(connectCtx, node1PeerInfo))
 	return node0, node1
 }
 

--- a/demo/add_order/main.go
+++ b/demo/add_order/main.go
@@ -1,5 +1,4 @@
-// demo/client is a short program that can be used for ad hoc integration
-// testing.
+// demo/add_order is a short program that adds an order to 0x Mesh via RPC
 package main
 
 import (

--- a/demo/add_peer/main.go
+++ b/demo/add_peer/main.go
@@ -1,0 +1,52 @@
+// demo/add_peer is a short program that adds a new peer to 0x Mesh via RPC.
+package main
+
+import (
+	"github.com/0xProject/0x-mesh/ws"
+	peer "github.com/libp2p/go-libp2p-peer"
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/plaid/go-envvar/envvar"
+	log "github.com/sirupsen/logrus"
+)
+
+type clientEnvVars struct {
+	// RPCAddress is the address of the 0x Mesh node to communicate with.
+	RPCAddress string `envvar:"RPC_ADDRESS"`
+	// PeerID is the base58-encoded peer ID of the peer to connect to.
+	PeerID string `envvar:"PEER_ID"`
+	// PeerAddr is the Multiaddress of the peer to connect to.
+	PeerAddr string `envvar:"PEER_ADDR"`
+}
+
+func main() {
+	env := clientEnvVars{}
+	if err := envvar.Parse(&env); err != nil {
+		panic(err)
+	}
+
+	// Parse peer ID and peer address.
+	parsedPeerID, err := peer.IDB58Decode(env.PeerID)
+	if err != nil {
+		log.Fatal(err)
+	}
+	parsedMultiAddr, err := ma.NewMultiaddr(env.PeerAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	peerInfo := peerstore.PeerInfo{
+		ID:    parsedPeerID,
+		Addrs: []ma.Multiaddr{parsedMultiAddr},
+	}
+
+	client, err := ws.NewClient(env.RPCAddress)
+	if err != nil {
+		log.WithError(err).Fatal("could not create client")
+	}
+
+	if err := client.AddPeer(peerInfo); err != nil {
+		log.WithError(err).Fatal("error from AddPeer")
+	} else {
+		log.Printf("successfully added peer: %s", env.PeerID)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
+
 	"github.com/0xProject/0x-mesh/blockwatch"
 	"github.com/0xProject/0x-mesh/core"
 	"github.com/0xProject/0x-mesh/ethereum"
@@ -385,6 +387,12 @@ func (app *application) AddOrder(order *zeroex.SignedOrder) error {
 	}
 
 	return nil
+}
+
+// AddPeer is called when an RPC client sends an AddPeer request.
+func (app *application) AddPeer(peerinfo peerstore.PeerInfo) error {
+	// TODO(albrow): Implement this
+	return errors.New("Not yet implemented")
 }
 
 func (app *application) close() {

--- a/main.go
+++ b/main.go
@@ -3,14 +3,13 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
 	"strings"
 	"time"
-
-	peerstore "github.com/libp2p/go-libp2p-peerstore"
 
 	"github.com/0xProject/0x-mesh/blockwatch"
 	"github.com/0xProject/0x-mesh/core"
@@ -22,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	"github.com/plaid/go-envvar/envvar"
 	log "github.com/sirupsen/logrus"
 )
@@ -32,6 +32,7 @@ const (
 	blockWatcherRetentionLimit  = 20
 	ethereumRPCRequestTimeout   = 30 * time.Second
 	ethWatcherPollingInterval   = 5 * time.Second
+	peerConnectTimeout          = 60 * time.Second
 )
 
 var (
@@ -210,7 +211,7 @@ func (app *application) GetMessagesToShare(max int) ([][]byte, error) {
 	log.WithFields(map[string]interface{}{
 		"maxNumberToShare":    max,
 		"actualNumberToShare": len(selectedOrders),
-	}).Debug("preparing to share orders with peers")
+	}).Trace("preparing to share orders with peers")
 
 	// After we have selected all the orders to share, we need to encode them to
 	// the message data format.
@@ -218,7 +219,7 @@ func (app *application) GetMessagesToShare(max int) ([][]byte, error) {
 	for i, order := range selectedOrders {
 		log.WithFields(map[string]interface{}{
 			"order": order,
-		}).Debug("selected order to share")
+		}).Trace("selected order to share")
 		encoded, err := encodeOrder(order.SignedOrder)
 		if err != nil {
 			return nil, err
@@ -249,7 +250,7 @@ func (app *application) ValidateAndStore(messages []*core.Message) ([]*core.Mess
 			"order":     order,
 			"orderHash": orderHash,
 			"from":      msg.From.String(),
-		}).Debug("received order from peer")
+		}).Trace("received order from peer")
 		orders = append(orders, order)
 		orderHashToMessage[orderHash] = msg
 	}
@@ -275,7 +276,7 @@ func (app *application) ValidateAndStore(messages []*core.Message) ([]*core.Mess
 				log.WithFields(map[string]interface{}{
 					"orderInfo": orderInfo,
 					"from":      msg.From.String(),
-				}).Debug("order received from peer is valid but already stored")
+				}).Trace("order received from peer is valid but already stored")
 			} else {
 				log.WithFields(map[string]interface{}{
 					"orderInfo": orderInfo,
@@ -290,7 +291,7 @@ func (app *application) ValidateAndStore(messages []*core.Message) ([]*core.Mess
 			log.WithFields(map[string]interface{}{
 				"orderInfo": orderInfo,
 				"from":      msg.From.String(),
-			}).Debug("not storing invalid order received from peer")
+			}).Warn("not storing invalid order received from peer")
 		}
 	}
 	return validMessages, nil
@@ -346,7 +347,7 @@ func (app *application) start() error {
 
 // AddOrder is called when an RPC client sends an AddOrder request.
 func (app *application) AddOrder(order *zeroex.SignedOrder) error {
-	log.Info("received order via RPC")
+	log.Debug("received AddOrder request via RPC")
 	orderHash, err := order.ComputeOrderHash()
 	if err != nil {
 		log.WithField("order", order).Error("received order via RPC but could not compute order hash")
@@ -390,9 +391,11 @@ func (app *application) AddOrder(order *zeroex.SignedOrder) error {
 }
 
 // AddPeer is called when an RPC client sends an AddPeer request.
-func (app *application) AddPeer(peerinfo peerstore.PeerInfo) error {
-	// TODO(albrow): Implement this
-	return errors.New("Not yet implemented")
+func (app *application) AddPeer(peerInfo peerstore.PeerInfo) error {
+	log.Debug("received AddPeer request via RPC")
+	ctx, cancel := context.WithTimeout(context.Background(), peerConnectTimeout)
+	defer cancel()
+	return app.node.Connect(ctx, peerInfo)
 }
 
 func (app *application) close() {

--- a/ws/client.go
+++ b/ws/client.go
@@ -38,10 +38,10 @@ func (c *Client) AddOrder(order *zeroex.SignedOrder) (common.Hash, error) {
 
 // AddPeer adds the peer to the node's list of peers. The node will attempt to
 // connect to this new peer and return an error if it cannot.
-func (c *Client) AddPeer(peerinfo peerstore.PeerInfo) error {
-	peerIDString := peer.IDB58Encode(peerinfo.ID)
-	multiAddrStrings := make([]string, len(peerinfo.Addrs))
-	for i, addr := range peerinfo.Addrs {
+func (c *Client) AddPeer(peerInfo peerstore.PeerInfo) error {
+	peerIDString := peer.IDB58Encode(peerInfo.ID)
+	multiAddrStrings := make([]string, len(peerInfo.Addrs))
+	for i, addr := range peerInfo.Addrs {
 		multiAddrStrings[i] = addr.String()
 	}
 	if err := c.rpcClient.Call(nil, "mesh_addPeer", peerIDString, multiAddrStrings); err != nil {

--- a/ws/client.go
+++ b/ws/client.go
@@ -4,6 +4,8 @@ import (
 	"github.com/0xProject/0x-mesh/zeroex"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	peer "github.com/libp2p/go-libp2p-peer"
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
 )
 
 // Client is a JSON RPC 2.0 client implementation over WebSockets. It can be
@@ -32,4 +34,18 @@ func (c *Client) AddOrder(order *zeroex.SignedOrder) (common.Hash, error) {
 		return common.Hash{}, err
 	}
 	return common.HexToHash(orderHashHex), nil
+}
+
+// AddPeer adds the peer to the node's list of peers. The node will attempt to
+// connect to this new peer and return an error if it cannot.
+func (c *Client) AddPeer(peerinfo peerstore.PeerInfo) error {
+	peerIDString := peer.IDB58Encode(peerinfo.ID)
+	multiAddrStrings := make([]string, len(peerinfo.Addrs))
+	for i, addr := range peerinfo.Addrs {
+		multiAddrStrings[i] = addr.String()
+	}
+	if err := c.rpcClient.Call(nil, "mesh_addPeer", peerIDString, multiAddrStrings); err != nil {
+		return err
+	}
+	return nil
 }

--- a/ws/client_server_test.go
+++ b/ws/client_server_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/zeroex"
 	"github.com/ethereum/go-ethereum/common"
+	peer "github.com/libp2p/go-libp2p-peer"
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,6 +23,7 @@ import (
 // for some requests or all of them, depending on testing needs.
 type dummyRPCHandler struct {
 	addOrderHandler func(order *zeroex.SignedOrder) error
+	addPeerHandler  func(peerInfo peerstore.PeerInfo) error
 }
 
 func (d *dummyRPCHandler) AddOrder(order *zeroex.SignedOrder) error {
@@ -29,14 +33,21 @@ func (d *dummyRPCHandler) AddOrder(order *zeroex.SignedOrder) error {
 	return d.addOrderHandler(order)
 }
 
+func (d *dummyRPCHandler) AddPeer(peerInfo peerstore.PeerInfo) error {
+	if d.addPeerHandler == nil {
+		return errors.New("dummyRPCHandler: no handler set for AddPeer")
+	}
+	return d.addPeerHandler(peerInfo)
+}
+
 // newTestServerAndClient returns a server and client which have been connected
 // to one another on the local network. The server will use the given
 // orderHandler to handle incoming requests. Useful for testing purposes. Will
 // block until both the server and client are running and connected to one
 // another.
-func newTestServerAndClient(t *testing.T, orderHandler *dummyRPCHandler) (*Server, *Client) {
+func newTestServerAndClient(t *testing.T, rpcHandler *dummyRPCHandler) (*Server, *Client) {
 	// Start a new server.
-	server, err := NewServer(":0", orderHandler)
+	server, err := NewServer(":0", rpcHandler)
 	require.NoError(t, err)
 	go func() {
 		_ = server.Listen()
@@ -75,7 +86,7 @@ func TestAddOrder(t *testing.T) {
 	// Set up the dummy handler with an addOrderHandler
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	orderHandler := &dummyRPCHandler{
+	rpcHandler := &dummyRPCHandler{
 		addOrderHandler: func(order *zeroex.SignedOrder) error {
 			assert.Equal(t, testOrder, order, "AddOrder was called with an unexpected order argument")
 			wg.Done()
@@ -83,7 +94,7 @@ func TestAddOrder(t *testing.T) {
 		},
 	}
 
-	server, client := newTestServerAndClient(t, orderHandler)
+	server, client := newTestServerAndClient(t, rpcHandler)
 	defer server.Close()
 
 	actualOrderHash, err := client.AddOrder(testOrder)
@@ -93,5 +104,38 @@ func TestAddOrder(t *testing.T) {
 	assert.Equal(t, expectedOrderHash.String(), actualOrderHash.String(), "returned orderHash did not match")
 
 	// The WaitGroup signals that AddOrder was called on the server-side.
+	wg.Wait()
+}
+
+func TestAddPeer(t *testing.T) {
+	// Create the expected PeerInfo
+	addr0, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1234")
+	require.NoError(t, err)
+	addr1, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/5678")
+	require.NoError(t, err)
+	peerID, err := peer.IDB58Decode("QmagLpXZHNrTraqWpY49xtFmZMTLBWctx2PF96s4aFrj9f")
+	require.NoError(t, err)
+	expectedPeerInfo := peerstore.PeerInfo{
+		ID:    peerID,
+		Addrs: []ma.Multiaddr{addr0, addr1},
+	}
+
+	// Set up the dummy handler with an addPeerHandler
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	rpcHandler := &dummyRPCHandler{
+		addPeerHandler: func(peerInfo peerstore.PeerInfo) error {
+			assert.Equal(t, expectedPeerInfo, peerInfo, "AddPeer was called with an unexpected peerInfo argument")
+			wg.Done()
+			return nil
+		},
+	}
+
+	server, client := newTestServerAndClient(t, rpcHandler)
+	defer server.Close()
+
+	require.NoError(t, client.AddPeer(expectedPeerInfo))
+
+	// The WaitGroup signals that AddPeer was called on the server-side.
 	wg.Wait()
 }

--- a/ws/client_server_test.go
+++ b/ws/client_server_test.go
@@ -16,15 +16,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// dummyOrderHandler is used for testing purposes. It allows declaring handlers
+// dummyRPCHandler is used for testing purposes. It allows declaring handlers
 // for some requests or all of them, depending on testing needs.
-type dummyOrderHandler struct {
+type dummyRPCHandler struct {
 	addOrderHandler func(order *zeroex.SignedOrder) error
 }
 
-func (d *dummyOrderHandler) AddOrder(order *zeroex.SignedOrder) error {
+func (d *dummyRPCHandler) AddOrder(order *zeroex.SignedOrder) error {
 	if d.addOrderHandler == nil {
-		return errors.New("dummyOrderHandler: no handler set for AddOrder")
+		return errors.New("dummyRPCHandler: no handler set for AddOrder")
 	}
 	return d.addOrderHandler(order)
 }
@@ -34,7 +34,7 @@ func (d *dummyOrderHandler) AddOrder(order *zeroex.SignedOrder) error {
 // orderHandler to handle incoming requests. Useful for testing purposes. Will
 // block until both the server and client are running and connected to one
 // another.
-func newTestServerAndClient(t *testing.T, orderHandler *dummyOrderHandler) (*Server, *Client) {
+func newTestServerAndClient(t *testing.T, orderHandler *dummyRPCHandler) (*Server, *Client) {
 	// Start a new server.
 	server, err := NewServer(":0", orderHandler)
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestAddOrder(t *testing.T) {
 	// Set up the dummy handler with an addOrderHandler
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	orderHandler := &dummyOrderHandler{
+	orderHandler := &dummyRPCHandler{
 		addOrderHandler: func(order *zeroex.SignedOrder) error {
 			assert.Equal(t, testOrder, order, "AddOrder was called with an unexpected order argument")
 			wg.Done()

--- a/ws/rpc_service.go
+++ b/ws/rpc_service.go
@@ -6,23 +6,23 @@ import (
 
 // rpcService is an /ethereum/go-ethereum/rpc compatible service.
 type rpcService struct {
-	orderHandler OrderHandler
+	rpcHandler RPCHandler
 }
 
-// OrderHandler is used to respond to incoming requests from the client.
-type OrderHandler interface {
+// RPCHandler is used to respond to incoming requests from the client.
+type RPCHandler interface {
 	// AddOrder is called when the client sends an AddOrder request.
 	AddOrder(order *zeroex.SignedOrder) error
 }
 
-// AddOrder calls orderHandler.AddOrder and returns the computed order hash.
+// AddOrder calls rpcHandler.AddOrder and returns the computed order hash.
 // TODO(albrow): Add the ability to send multiple orders at once.
 func (s *rpcService) AddOrder(order *zeroex.SignedOrder) (orderHashHex string, err error) {
 	orderHash, err := order.ComputeOrderHash()
 	if err != nil {
 		return "", err
 	}
-	if err := s.orderHandler.AddOrder(order); err != nil {
+	if err := s.rpcHandler.AddOrder(order); err != nil {
 		return "", err
 	}
 	return orderHash.Hex(), nil

--- a/ws/server.go
+++ b/ws/server.go
@@ -17,18 +17,18 @@ type Server struct {
 	mut          sync.Mutex
 	addr         string
 	listenerAddr net.Addr
-	orderHandler OrderHandler
+	rpcHandler   RPCHandler
 	listener     net.Listener
 	rpcServer    *rpc.Server
 }
 
 // NewServer creates and returns a new server which will listen for new
-// connections on the given addr and use the orderHandler to handle incoming
+// connections on the given addr and use the rpcHandler to handle incoming
 // requests.
-func NewServer(addr string, orderHandler OrderHandler) (*Server, error) {
+func NewServer(addr string, rpcHandler RPCHandler) (*Server, error) {
 	return &Server{
-		addr:         addr,
-		orderHandler: orderHandler,
+		addr:       addr,
+		rpcHandler: rpcHandler,
 	}, nil
 }
 
@@ -38,7 +38,7 @@ func (s *Server) Listen() error {
 	s.mut.Lock()
 
 	rpcService := &rpcService{
-		orderHandler: s.orderHandler,
+		rpcHandler: s.rpcHandler,
 	}
 	s.rpcServer = rpc.NewServer()
 	if err := s.rpcServer.RegisterName("mesh", rpcService); err != nil {


### PR DESCRIPTION
- Add `Connect` method to `core.Node` which is a thin wrapper around `host.Connect`.
- Add `AddPeer` RPC method for both server and client.
- Implement the new `AddPeer` method for `RPCHandler` in __main.go__.
- Split __demo/client__ into __demo/add_order__ and __demo/add_peer__.

This is really only for demo/testing purposes. We might remove the `AddPeer` RPC method after we implement peer discovery.