### PR TITLE
Implement peer discovery

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,29 +10,31 @@
   version = "v2.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:e574dab86697e4e3a8e2e815e0e932cfbf3618e74d6379d8732b33757e11b23d"
+  digest = "1:f96ba6ecca7ba87b1dddd70ae38cfc4ce5ea844f58d1f728e121d2e29cdfb8a2"
   name = "github.com/allegro/bigcache"
   packages = [
     ".",
     "queue",
   ]
   pruneopts = "UT"
-  revision = "e24eb225f15679bbe54f91bfa7da3b00e59b9768"
+  revision = "84a0ff3f153cbd7e280a19029a864bb04b504e62"
+  version = "v1.2.0"
 
 [[projects]]
-  digest = "1:f5322546f652db78b7a8efd35047a61d1e492abca2263e1c647eca49e1c8a354"
+  branch = "master"
+  digest = "1:7d191fd0c54ff370eaf6116a14dafe2a328df487baea280699f597aae858d00d"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
   pruneopts = "UT"
-  revision = "ea17b1a17847fb6e4c0a91de0b674704693469b0"
+  revision = "004c259faaebbfec6dd9f9e23daad4027d8ba4f1"
 
 [[projects]]
-  digest = "1:477f6df8a1915abb180d730179a4a45212328effdf98cc6ca5b0e5741db00125"
+  branch = "master"
+  digest = "1:093bf93a65962e8191e3e8cd8fc6c363f83d43caca9739c906531ba7210a9904"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
   pruneopts = "UT"
-  revision = "2e60448ffcc6bf78332d1fe590260095f554dd78"
+  revision = "96897255fd17525dd12426345d279533780bc4e1"
 
 [[projects]]
   digest = "1:05ffeeed3f0f05520de0679f6aa3219ffee69cfd6d9fb6c194879d4c818ad670"
@@ -51,11 +53,12 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:1aeb4854a1c278e842712cd6684f48d595cbdd7839655d37a77248efa08c9fc0"
+  digest = "1:e47d51dab652d26c3fba6f8cba403f922d02757a82abdc77e90df7948daf296e"
   name = "github.com/deckarep/golang-set"
   packages = ["."]
   pruneopts = "UT"
-  revision = "504e848d77ea4752b3057b8fb46da0e7f746ccf3"
+  revision = "cbaa98ba5575e67703b32b4b19f73c91f3c4159e"
+  version = "v1.7.1"
 
 [[projects]]
   digest = "1:edb569dd02419a41ddd98768cc0e7aec922ef19dae139731e5ca750afcf6f4c5"
@@ -127,7 +130,6 @@
   source = "github.com/0xProject/go-ethereum"
 
 [[projects]]
-  branch = "master"
   digest = "1:c52ac440c00e8b404a713a2de487b7b5e0e93a89a758832d9fc15b2817d6d5d6"
   name = "github.com/gballet/go-libpcsclite"
   packages = ["."]
@@ -135,12 +137,12 @@
   revision = "312b5175032f98274685a4dd81935a92ad2412a5"
 
 [[projects]]
-  digest = "1:33542eaf895b5489ccfb059502a721f0e8875379da8b3ff60fdd9212d503705c"
+  digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
   name = "github.com/go-stack/stack"
   packages = ["."]
   pruneopts = "UT"
-  revision = "54be5f394ed2c3e19dac9134a40a95ba5a017f7b"
-  version = "v1.5.4"
+  revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
+  version = "v1.8.0"
 
 [[projects]]
   digest = "1:760b2447d30444b6c2da7f77b677921f095fe19e6ed423b2edc1cd47a8507789"
@@ -216,12 +218,25 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:ff780041e005869242b2cf977f1d4fa3b8f9bdd302fd254b4a19f78502a6ee10"
+  digest = "1:664cf1fc1e6ec05988cc6b8f52a61fca914279a92dcd0bc1b8be5507fb3b0c8a"
   name = "github.com/ipfs/go-cid"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e7e67e08cfba888a4297224402e12832bdc15ea0"
-  version = "v0.0.1"
+  revision = "b1cc3e404d48791056147f118ea7e7ea94eb946f"
+  version = "v0.0.2"
+
+[[projects]]
+  digest = "1:cfea9f0d7922f624c9cc312a6fed0bd5a0fe63f5ec728df09b796484b3696d0a"
+  name = "github.com/ipfs/go-datastore"
+  packages = [
+    ".",
+    "autobatch",
+    "query",
+    "sync",
+  ]
+  pruneopts = "UT"
+  revision = "aa9190c18f1576be98e974359fd08c64ca0b5a94"
+  version = "v0.0.5"
 
 [[projects]]
   digest = "1:0b4439ae69776549e6489b261f66894a1390140dad53f1c3b1fbfc074478590d"
@@ -245,6 +260,14 @@
   version = "v0.0.1"
 
 [[projects]]
+  digest = "1:5d5961815f8e4f1fbad28f6c7ff5e42fcd9527aa823a5daa19b622b9cc41d1ed"
+  name = "github.com/ipfs/go-todocounter"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "bc75efcf13e6e50fbba27679ba5451585d70c954"
+  version = "v0.0.1"
+
+[[projects]]
   digest = "1:b352ae8b1a77cc6b48fc8e314e34a522cfc76d6ca3a06c93b29c9cde5de6771e"
   name = "github.com/jackpal/gateway"
   packages = ["."]
@@ -262,6 +285,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:62fe3a7ea2050ecbd753a71889026f83d73329337ada66325cbafd5dea5f713d"
+  name = "github.com/jbenet/go-context"
+  packages = ["io"]
+  pruneopts = "UT"
+  revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
+
+[[projects]]
+  branch = "master"
   digest = "1:8f4aedc183dc8dfef9a7a1f1ba205dc87ecd2675eea350a736bda889e3bcf8ea"
   name = "github.com/jbenet/go-temp-err-catcher"
   packages = ["."]
@@ -269,8 +300,7 @@
   revision = "aac704a3f4f27190b4ccc05f303a4931fd1241ff"
 
 [[projects]]
-  branch = "master"
-  digest = "1:a2a82ac6d7f2ab5966591f95612e3ecd9afed66051189e06876a29ed3744a3ea"
+  digest = "1:ee4b434dc3622e5c25a611ce314d40dd724495f27968797a2589a4d89eeed7eb"
   name = "github.com/jbenet/goprocess"
   packages = [
     ".",
@@ -279,7 +309,8 @@
     "ratelimit",
   ]
   pruneopts = "UT"
-  revision = "b497e2f366b8624394fb2e89c10ab607bebdde0b"
+  revision = "7f9d9ed286badffcf2122cfeb383ec37daf92508"
+  version = "v0.1.3"
 
 [[projects]]
   digest = "1:b6bbd2f9e0724bd81890c8644259f920c6d61c08453978faff0bebd25f3e7d3e"
@@ -291,11 +322,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:447562773a19dc1719359c2cd70d275c62c0b89f79d763f41d5deedb0e69873f"
+  digest = "1:d08d4c0e972c3d12679c3990d09f0ebed9f73d1860cebe05f16964983c1f02f1"
   name = "github.com/karalabe/hid"
   packages = ["."]
   pruneopts = "T"
-  revision = "d815e0c1a2e2082a287a2806bc90bc8fc7b276a9"
+  revision = "9e0a1cda727554082cdfce846792bdacf577b4f3"
 
 [[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
@@ -322,12 +353,12 @@
   version = "v0.0.1"
 
 [[projects]]
-  digest = "1:f9e8d1157f79aa5e81b34e0cdc7a6c99d6e44ad7a098f4e6869b8b83ef3d27bb"
+  digest = "1:b18a269f11ff51135d6f82987dbb53288f4d66098a6639b429f4f494a910155b"
   name = "github.com/libp2p/go-buffer-pool"
   packages = ["."]
   pruneopts = "UT"
-  revision = "eecb57f6a721b4a66062ebeb61d1da7ce1c38fbf"
-  version = "v0.0.1"
+  revision = "c4a5988a1e475884367015e1a2d0bd5fa4c491f4"
+  version = "v0.0.2"
 
 [[projects]]
   digest = "1:5810d7b1453ad0a085afc2afccbe88d606be67b8be1e12706158dbcbf95ae243"
@@ -357,7 +388,7 @@
   version = "v0.0.1"
 
 [[projects]]
-  digest = "1:8c59b7cfd2246d381cea6465cca92ea23dceafffd93423564e5dc21f5cf17368"
+  digest = "1:9dc1aaab226138d86deacb75da5b0ba29f1830a3136cd817b0785fdb70711b16"
   name = "github.com/libp2p/go-libp2p"
   packages = [
     ".",
@@ -370,65 +401,73 @@
     "p2p/protocol/ping",
   ]
   pruneopts = "UT"
-  revision = "d6f75224ebcad3a5056d42f7266080930d6765d8"
-  version = "v0.0.20"
+  revision = "58ac4c8110e465fa25b944fe3d75ae1c9caad833"
+  version = "v0.0.28"
 
 [[projects]]
-  digest = "1:7a9b53c8925819845e9ae47579cac5de87b66eddfc72988578f318504136a68c"
+  digest = "1:ad5558e9d7122e78b7a995a9860ea403976151d7f49c388636cef64c19076fd7"
   name = "github.com/libp2p/go-libp2p-autonat"
   packages = [
     ".",
     "pb",
   ]
   pruneopts = "UT"
-  revision = "c827b8ba68e6997431c27313efad33df19b5f6a3"
-  version = "v0.0.4"
+  revision = "2e9643fa1c5a5dfb31096fb844e332c7161bdcd3"
+  version = "v0.0.6"
 
 [[projects]]
-  digest = "1:1289f34bbc72cfe59de1528e793e27c67a44a9597e1537ef03597abef8641f6e"
+  digest = "1:886a124af6b511b708c6f59925c77142cea9d30adcfc7198134b6e9c4c099cd7"
   name = "github.com/libp2p/go-libp2p-circuit"
   packages = [
     ".",
     "pb",
   ]
   pruneopts = "UT"
-  revision = "d07cd5f739a7878121b10e54a8ead734f93e2ddf"
-  version = "v0.0.4"
+  revision = "1f1395c6c2fb98fe621aa68ce5a5f3cde3b38d67"
+  version = "v0.0.8"
 
 [[projects]]
-  digest = "1:83915d6b4485f9ca8727ad9195d0881f1eeea4c9f286b0c0fb4b0757c21d1bc2"
+  digest = "1:da6f99e1ceba62e937a92ceb06f3e3ab9f0722315e5f9a443ef5297ec3dc06db"
+  name = "github.com/libp2p/go-libp2p-connmgr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "22c4d8cb3d3d792524ccf951d984b336da5bf2bc"
+  version = "v0.0.5"
+
+[[projects]]
+  digest = "1:36f3501a4b8fa5904aedb56e8050ef523cfc99bc43fda281af0f70cf158fe812"
   name = "github.com/libp2p/go-libp2p-crypto"
   packages = [
     ".",
     "pb",
   ]
   pruneopts = "UT"
-  revision = "b0ed0e663e8b6832bad3f4502b2f6551ff2686cd"
-  version = "v0.0.1"
+  revision = "f41958289ed7d8fd2533b42bfbf144f54c0d763d"
+  version = "v0.0.2"
 
 [[projects]]
-  digest = "1:c8e13ce10e73ffc2c59e11fd62d85a1e516e33af6521ed337d2e4777bc7605d8"
+  digest = "1:49514adcb1c900fd6a27f6cdf9f16ebd91e640eb12891d1055a4c9ce3ce870c7"
   name = "github.com/libp2p/go-libp2p-discovery"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4cb4193d603389a75bccd07336de74d54bea6b00"
-  version = "v0.0.2"
+  revision = "96963560b14968e6ff5a7e362c03e29468f8dee3"
+  version = "v0.0.4"
 
 [[projects]]
-  digest = "1:1df10c788e75259f6ebae0612de30f0db09e690042b9db64551a188c6509cc8b"
+  digest = "1:51a39f106505e9de6ef0fd69e1c0e95532f512c839b52856dd3d6b182f3e2730"
   name = "github.com/libp2p/go-libp2p-host"
   packages = ["."]
   pruneopts = "UT"
-  revision = "df61f890baee33effc62473e65c0ce481407181d"
-  version = "v0.0.2"
+  revision = "520b4f10a059fd5c9a8e9473556709b64b0f66e4"
+  version = "v0.0.3"
 
 [[projects]]
-  digest = "1:bc58f4c83d59130bbef42bbd7ebb0d23ccd8cc9c1eecd63a57b5576f5f8effc2"
+  digest = "1:fe6e5853012354c0c6ee0356f08468603e728627771d244ed1ba88881a91c57e"
   name = "github.com/libp2p/go-libp2p-interface-connmgr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e80dd2e9f839e44febfcb7e6b38ded8761332eb6"
-  version = "v0.0.3"
+  revision = "c4683c4b3c007e9ae21a23b0778a1d5ada297504"
+  version = "v0.0.5"
 
 [[projects]]
   digest = "1:065f0484575f052b79972215142bb50ac634c5282bf85692192fc1dfc8752b8b"
@@ -437,6 +476,31 @@
   pruneopts = "UT"
   revision = "b02026130a4daafb8001e039e116121cb92ae1a9"
   version = "v0.0.1"
+
+[[projects]]
+  digest = "1:d031d822f66e4bfbb1f0ca6d0a8bd1f5c8ebaf6e65a263689a68bb09680425bf"
+  name = "github.com/libp2p/go-libp2p-kad-dht"
+  packages = [
+    ".",
+    "metrics",
+    "opts",
+    "pb",
+    "providers",
+  ]
+  pruneopts = "UT"
+  revision = "0d5dacd26d8ec4da18bfb113c0ba4f5e043bfddd"
+  version = "v0.0.13"
+
+[[projects]]
+  digest = "1:029a31918e966dba732de956af5af626c92d9e1296b2b34c6e68d4e6c5cf1b7e"
+  name = "github.com/libp2p/go-libp2p-kbucket"
+  packages = [
+    ".",
+    "keyspace",
+  ]
+  pruneopts = "UT"
+  revision = "0ac6a1f84ed8c7d05b204f9f09556b1e34e1253a"
+  version = "v0.1.1"
 
 [[projects]]
   digest = "1:401eaa568a08603ebcccd833d0d69c2ac1abe153f1260f7a82375c3a455c7223"
@@ -455,6 +519,14 @@
   version = "v0.0.1"
 
 [[projects]]
+  digest = "1:b09aac19888b66b0f3f7249848b5e6a461d2b446e30527e2b11c4a0c228b9609"
+  name = "github.com/libp2p/go-libp2p-mplex"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b7d2b038f8754851777af32be4bc12f009a037a4"
+  version = "v0.1.1"
+
+[[projects]]
   digest = "1:4614c7d351b9cc24ef6457107fad9830664615bb7d7de91de10c4a4ab1919545"
   name = "github.com/libp2p/go-libp2p-nat"
   packages = ["."]
@@ -471,24 +543,28 @@
   version = "v0.0.2"
 
 [[projects]]
-  digest = "1:5b3140f8ec492cfa868f3e9fe320f10c7788bd35bbbcd002b32c410c988a3fe6"
+  digest = "1:b3c290f06f93c1abf58e4aba2df719f233e7b7c2592a54263b4e2d53df1e9dd0"
   name = "github.com/libp2p/go-libp2p-peer"
-  packages = ["."]
+  packages = [
+    ".",
+    "peerset",
+  ]
   pruneopts = "UT"
-  revision = "96d6d7940e6fc555240a92d1b4615049cd451da2"
-  version = "v0.1.0"
+  revision = "badcaca9df8cb2887943c0a3d408fe07db160992"
+  version = "v0.1.1"
 
 [[projects]]
-  digest = "1:90ff4692c5f8b079c305654a8e5b0ec994dbed98aba118737b40b4bb8bc2cad1"
+  digest = "1:482f3d69fc3c245562137c7acc554d359a0ddb8c0b6489d6d0940968cc7f2f99"
   name = "github.com/libp2p/go-libp2p-peerstore"
   packages = [
     ".",
     "addr",
     "pstoremem",
+    "queue",
   ]
   pruneopts = "UT"
-  revision = "96639ef5f4c339131552acf2e283d2d041602798"
-  version = "v0.0.5"
+  revision = "80303a4b472a95e921a527377deeafa051230a61"
+  version = "v0.0.6"
 
 [[projects]]
   digest = "1:861a4351f79c9e2bca75407d8801b55da0526feec15ec98b433c2f800ad1f393"
@@ -499,21 +575,33 @@
   version = "v0.0.1"
 
 [[projects]]
-  digest = "1:e8d3d819fb8398e0945fbe5e55b519c3c76d952e0e33901a47fdadc0fd1874e7"
+  digest = "1:4a409e01710dc7ade773fda1a17e7cbc857b615aafe92ae20d4b27247562f5c9"
   name = "github.com/libp2p/go-libp2p-pubsub"
   packages = [
     ".",
     "pb",
   ]
   pruneopts = "UT"
-  revision = "25cbf38777e869acb77e8079c3c76d6b430e66ad"
+  revision = "1a2f55f6403ce452208ed062bcd780bcc95bdd17"
+  version = "v0.0.5"
+
+[[projects]]
+  digest = "1:712d8c0de8c227d80e589af33389c7c8b56b7ade75fa1d6b81963330ed7427e7"
+  name = "github.com/libp2p/go-libp2p-record"
+  packages = [
+    ".",
+    "pb",
+  ]
+  pruneopts = "UT"
+  revision = "4c2093f40950fe401a612a725ef0765c0c767b60"
   version = "v0.0.1"
 
 [[projects]]
-  digest = "1:b8a054611838e93f9be110353e3bffd85edfc91b58acccdd8a1c9b5840fbf5b8"
+  digest = "1:40536312550a2d67b11568a05e9885a3d7b728000a88a93d577f117fa0d2eef6"
   name = "github.com/libp2p/go-libp2p-routing"
   packages = [
     ".",
+    "notifications",
     "options",
   ]
   pruneopts = "UT"
@@ -532,44 +620,52 @@
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:178377b7082ad36e179e22d84a3b7d618f26bebcacb0a97b4480ac30d2341add"
+  digest = "1:46c846828a98fe8623e273f8c99789b9dae5946876c83b6877b698bce2ef7072"
   name = "github.com/libp2p/go-libp2p-swarm"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0fc01368da4ae9ce28fc261131494af3eda9aace"
-  version = "v0.0.3"
+  revision = "72a80131d0b21b83bb3d050e314792006338b6f7"
+  version = "v0.0.6"
 
 [[projects]]
-  digest = "1:3b26a897674c84976f9ee6d93d91d0fc503a4aada9c6b7a69b5ed4752452d035"
+  digest = "1:58344718dc55a785cdd1ae1f49ffe8379ebe28fcadf85742028fe31c5f40639e"
   name = "github.com/libp2p/go-libp2p-transport"
   packages = ["."]
   pruneopts = "UT"
-  revision = "760cba29c65701ce7b688f238f6c93cc1d899dde"
-  version = "v0.0.4"
+  revision = "045097a6a962aeccac5e06d672a9b2489cf4b68c"
+  version = "v0.0.5"
 
 [[projects]]
-  digest = "1:3fa03a4c7968f0851695e9840a89865ab41fc3275ade23d553d432cb2d3f5119"
+  digest = "1:b9f39036d7285616bdfd4612ce10978d02619ebf57387b6aaef56503cd7f26ac"
   name = "github.com/libp2p/go-libp2p-transport-upgrader"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5ddf5deb2271e43bf3c4ffa24841e13c69d4581f"
-  version = "v0.0.2"
+  revision = "dba55de7a167d84e310e2b2894ffc0875734efbe"
+  version = "v0.0.4"
 
 [[projects]]
-  digest = "1:56b76ab784de08c03549ce824b2f103390c744016cf22c7d3cacd7f4abb26e54"
+  digest = "1:96f3b07b6a925c0631277be539b5ed6ba7becbefe95aed9eda0c4e9116ab5ca6"
+  name = "github.com/libp2p/go-libp2p-yamux"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "fadb447a8f53a286d1c8a80e1c475193aacf904c"
+  version = "v0.1.3"
+
+[[projects]]
+  digest = "1:986c0c852c462da2cdc5d584dc2fd884cb898371cbc43cdc250149f40f8cd8fc"
   name = "github.com/libp2p/go-maddr-filter"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1258bb7e3e3a37bb9a93aaf77ef88f8405b39bce"
-  version = "v0.0.1"
+  revision = "e3cdd802c04babcbec2c4711721d105cfe822cd3"
+  version = "v0.0.4"
 
 [[projects]]
-  digest = "1:dca7a0779bc8c3052ff1760928da7fab1d6bdaa568de55c175cb96c83a6d20c4"
+  digest = "1:1ab5b44f5b05569e0ffb548dfd6b7308a366db4772fa4345e62c831e51a5af42"
   name = "github.com/libp2p/go-mplex"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b16006283f6036f9a461f78692c397b134a75393"
-  version = "v0.0.1"
+  revision = "aaf9be963d2109b98c0bc48724373bc5b36df482"
+  version = "v0.0.3"
 
 [[projects]]
   digest = "1:fec6c720509c1682df4e297899d23951d1b3ad3bcc124ecf734af34053a18982"
@@ -612,20 +708,36 @@
   version = "v0.0.1"
 
 [[projects]]
-  digest = "1:32b1b70c98be85d88229af2ba0cceb9954e7ef88c3f7e90f95a8ea2deb32c0d3"
+  digest = "1:24ba20904e88efeb9863cdd3cc0cb6feb8b5a6fcb84cdec3a9bda1453c5f4f3a"
+  name = "github.com/libp2p/go-stream-muxer-multistream"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "fed469e36607466ae5753b8d04bd03d54741da00"
+  version = "v0.1.1"
+
+[[projects]]
+  digest = "1:c95acfc10b10f2c03ff9d89a82dfc143fb5a1de3a4374ea3cd83b5159ccea07d"
   name = "github.com/libp2p/go-tcp-transport"
   packages = ["."]
   pruneopts = "UT"
-  revision = "42717ef323c6cd024d3196d18bc1b7657c453d6d"
-  version = "v0.0.2"
+  revision = "87de237344572d5a464541332b94b4df13ba79a4"
+  version = "v0.0.4"
 
 [[projects]]
-  digest = "1:fe4581341f14aba2ef06749c5f2fc6483d4354b25e3c6e0094a4135082a22ed2"
+  digest = "1:65806d2b9f352b4299a620c42b82f041db2d4c43f8e6e715e177ba9f282f53cf"
   name = "github.com/libp2p/go-ws-transport"
   packages = ["."]
   pruneopts = "UT"
-  revision = "93daaa611babb322b314d33c6c6ad26298f55f56"
-  version = "v0.0.2"
+  revision = "fcde1b265af4770e75e27ddde863e8a74ee791c5"
+  version = "v0.0.4"
+
+[[projects]]
+  digest = "1:76f80a9616bf81078251d7723312310702bf1c99e1298ccaf1602928747080bd"
+  name = "github.com/libp2p/go-yamux"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2610908e3ff2daa19a4d92ccffced86219c3ab2e"
+  version = "v1.2.2"
 
 [[projects]]
   digest = "1:2fa7b0155cd54479a755c629de26f888a918e13f8857a2c442205d825368e084"
@@ -636,12 +748,12 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:e150b5fafbd7607e2d638e4e5cf43aa4100124e5593385147b0a74e2733d8b0d"
+  digest = "1:9b90c7639a41697f3d4ad12d7d67dfacc9a7a4a6e0bbfae4fc72d0da57c28871"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c2a7a6ca930a4cd0bc33a3f298eb71960732a3a7"
-  version = "v0.0.7"
+  revision = "1311e847b0cb909da63b5fecfb5370aa66236465"
+  version = "v0.0.8"
 
 [[projects]]
   branch = "master"
@@ -676,12 +788,12 @@
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:4fb02614401f3511d3c76482b6bc626a307811d53df34610ce5ded5ad83fa05d"
+  digest = "1:c95537699dfc9ecc62c2bb273fd2fdf5810ce23ed50f25529c17f755a052a7c3"
   name = "github.com/multiformats/go-multiaddr"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ce21123d5172669bbf37a166078bc5f9d345ec2f"
-  version = "v0.0.2"
+  revision = "5b1de2f51ff2368d5ce94a659f15ef26be273cd0"
+  version = "v0.0.4"
 
 [[projects]]
   digest = "1:e7b7007612b49b368d5b505b624b399a1de5fe2764271b92145aa9ca0440ab4e"
@@ -716,12 +828,12 @@
   version = "v0.0.5"
 
 [[projects]]
-  digest = "1:894daf10008cdef37454571b584832b2a281a5709f6b80d7bd440ff3a627c962"
+  digest = "1:6bdad0b5c4cab724711aba36785ad093cd2ba8bf1f873d8c98f326d9d43dac63"
   name = "github.com/multiformats/go-multistream"
   packages = ["."]
   pruneopts = "UT"
-  revision = "f3f44044ac2444cd3a017c0b269f8da65b0012f1"
-  version = "v0.0.1"
+  revision = "277835d160f4821f43d57a5bc6322180e8f5e3c4"
+  version = "v0.0.4"
 
 [[projects]]
   branch = "master"
@@ -784,28 +896,39 @@
   version = "v0.9.2"
 
 [[projects]]
-  digest = "1:4b9bd28bbf14271f4b89a6c401589ea5939d14138e0399c253c1939cc4252d2f"
+  digest = "1:b0c25f00bad20d783d259af2af8666969e2fc343fa0dc9efe52936bbd67fb758"
   name = "github.com/rs/cors"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a62a804a8a009876ca59105f7899938a1349f4b3"
-  version = "v1.0"
+  revision = "9a47f48565a795472d43519dd49aac781f3034fb"
+  version = "v1.6.0"
 
 [[projects]]
-  digest = "1:9665a593c0199c193341b8b110e31b19c899923711fc70bde2c2f3eb2d337526"
-  name = "github.com/rs/xhandler"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "d9d9599b6aaf6a058cb7b1f48291ded2cbd13390"
-  version = "v1.0"
-
-[[projects]]
-  digest = "1:fd61cf4ae1953d55df708acb6b91492d538f49c305b364a014049914495db426"
+  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f"
-  version = "v1.4.1"
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
+  version = "v1.4.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:74aa99ef18406ebfdedfb2a07b9a01f9ff2b6d2547b27b33fcdf1007223d75cc"
+  name = "github.com/spacemonkeygo/openssl"
+  packages = [
+    ".",
+    "utils",
+  ]
+  pruneopts = "UT"
+  revision = "c2dcc5cca94ac8f7f3f0c20e20050d4cce9d9730"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d6956eb95db39859627c18e1dd425b2ddd1a0d6000b643a4d4ada8fc887c1e09"
+  name = "github.com/spacemonkeygo/spacelog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2296661a0572a51438413369004fa931c2641923"
 
 [[projects]]
   digest = "1:919bb3aa6d9d0b67648c219fa4925312bc3c2872da19e818fa769e9c97a2b643"
@@ -821,7 +944,7 @@
   name = "github.com/status-im/keycard-go"
   packages = ["derivationpath"]
   pruneopts = "UT"
-  revision = "8adf2b6627095127f26f77af865c056bb510097a"
+  revision = "d95853db0f480b9d6379009500acf44b21dc0be6"
 
 [[projects]]
   digest = "1:5da8ce674952566deae4dbc23d07c85caafc6cfa815b0b3e03e41979cedb8750"
@@ -857,12 +980,31 @@
   source = "github.com/0xProject/goleveldb"
 
 [[projects]]
-  digest = "1:98c7f8a39334cff11ba2402d7e940941b5fcb40e1dd93be6b633a0a6fbaf46e5"
+  digest = "1:73e0d2644cf33beeafbfb79804143ac9738bed3c28a12fd5e61bd3b13ac95407"
   name = "github.com/tyler-smith/go-bip39"
+  packages = [
+    ".",
+    "wordlists",
+  ]
+  pruneopts = "UT"
+  revision = "2af0a847066a4f2669040ccd44a79c8eca10806a"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:98fa13beefbf581ec173561adad6374c460631593b4bdcf03adc29cd18e5d2f5"
+  name = "github.com/whyrusleeping/base32"
   packages = ["."]
   pruneopts = "UT"
-  revision = "320452e9f0df352f7c65a459ab1a7ac987eec99a"
-  version = "v0.3.6"
+  revision = "c30ac30633ccdabefe87eb12465113f06f1bab75"
+
+[[projects]]
+  branch = "master"
+  digest = "1:b33eed6794f2b2d1a7d0b45cb705402f26af0f0ad6521667e144ffa71f52d9d9"
+  name = "github.com/whyrusleeping/go-keyspace"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5b898ac5add1da7178a4a98e69cb7b9205c085ee"
 
 [[projects]]
   branch = "master"
@@ -879,30 +1021,6 @@
   packages = ["."]
   pruneopts = "UT"
   revision = "097c5d47330ff6a823f67e3515faa13566a62c6f"
-
-[[projects]]
-  digest = "1:1c5b129f012e176d9cbcb173c67fef17698a2d0a8169e94c8db9e7beeb3ef716"
-  name = "github.com/whyrusleeping/go-smux-multiplex"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "2b855d4f3a3051b0133f7783bffe06e4b7833d1e"
-  version = "v3.0.16"
-
-[[projects]]
-  digest = "1:262e85ef9e2082fcb44335f6349699d61d5ac3672d24dcf3bf4cbc7377b51e96"
-  name = "github.com/whyrusleeping/go-smux-multistream"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "e799b10bc6eea2cc5ce18f7b7b4d8e1a0439476d"
-  version = "v2.0.2"
-
-[[projects]]
-  digest = "1:f1026ff0b15a5282885d6709582eba8d2faf261ffff4bac6960a8e97a4f6dfd5"
-  name = "github.com/whyrusleeping/go-smux-yamux"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "902adacdc02ba8fca64a0d0985576a1dc3138ee5"
-  version = "v2.0.9"
 
 [[projects]]
   digest = "1:6c96967502c55c555abfe560f561a124951345e713a8e87cc6e2c214976e6e75"
@@ -929,14 +1047,6 @@
   revision = "cfcb2f1abfee846c430233aef0b630a946e0a5a6"
 
 [[projects]]
-  digest = "1:1f186490a9ec1359604f041997996fb0caa98878bd53cdf0b89b6b6ec6803af9"
-  name = "github.com/whyrusleeping/yamux"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "5364a42fe4b5efa5967c11c8f9b0f049cac0c4a9"
-  version = "v1.1.5"
-
-[[projects]]
   branch = "master"
   digest = "1:7dca0da64f5937af74f21618cdb812c8f16a7d042316dd5bf2f1dfd086be3fc6"
   name = "github.com/wsddn/go-ecdh"
@@ -945,7 +1055,25 @@
   revision = "48726bab92085232373de4ec5c51ce7b441c63a0"
 
 [[projects]]
-  digest = "1:7808053ee19a598a9a631a9df9abb974f14776bef6c9b2983c930cd6d97826af"
+  digest = "1:e99f8ec6e9c0ad99ad6615409ce6588c77df8645ad4a5d9fc559fec95d7cae49"
+  name = "go.opencensus.io"
+  packages = [
+    "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricproducer",
+    "resource",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+  ]
+  pruneopts = "UT"
+  revision = "df6e2001952312404b06f5f6f03fcb4aec1648e5"
+  version = "v0.21.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:f4278aecfdbfcf34fba3a17b252bf34d9eed5d024c51fefc2676578bb984e900"
   name = "golang.org/x/crypto"
   packages = [
     "blake2s",
@@ -960,10 +1088,11 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "ff983b9c42bc9fbf91556e191cc8efb585c16908"
+  revision = "22d7a77e9e5f409e934ed268692e56707cd169e5"
 
 [[projects]]
-  digest = "1:c7362cd294ce86704076bb8b8c1b0130ac319556dbca253f4030abb98c76c8dd"
+  branch = "master"
+  digest = "1:c92a66932e2901f2acca97dd8be6a286075d3632c3949ae79db2166f5abfc8b2"
   name = "golang.org/x/net"
   packages = [
     "bpf",
@@ -972,16 +1101,16 @@
     "html/atom",
     "html/charset",
     "internal/iana",
-    "internal/netreflect",
+    "internal/socket",
     "ipv4",
     "websocket",
   ]
   pruneopts = "UT"
-  revision = "a6577fac2d73be281a500b310739095313165611"
+  revision = "f3200d17e092c607f615320ecaad13d87ad9a2b3"
 
 [[projects]]
   branch = "master"
-  digest = "1:7d66cc475c1a5fdde28caa9d9cd08a0b9baf6c9f5eb49eec6963a77174893c7d"
+  digest = "1:832105dfef7fb8befe37f774c2ab4db8eec28b0e05501dee908d5daac0afbd20"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
@@ -989,10 +1118,10 @@
     "windows",
   ]
   pruneopts = "UT"
-  revision = "12500544f89f9420afe9529ba8940bf72d294972"
+  revision = "8097e1b27ff5e40620836729a9584e91b094b062"
 
 [[projects]]
-  digest = "1:4392fcf42d5cf0e3ff78c96b2acf8223d49e4fdc53eb77c99d2f8dfe4680e006"
+  digest = "1:7570a3e4daa14b7627089e77ad8c714f5f36b4cf1b7dfd8510df7d6935dc42a0"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -1006,6 +1135,8 @@
     "encoding/traditionalchinese",
     "encoding/unicode",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -1017,8 +1148,19 @@
     "unicode/norm",
   ]
   pruneopts = "UT"
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c44a77760372a998be8d4656e8d3c865f68735ec4cad1743a245903a58f64249"
+  name = "golang.org/x/xerrors"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = "UT"
+  revision = "3ee3066db522c6628d440a3a91c4abdd7f5ef22f"
 
 [[projects]]
   branch = "v2"
@@ -1047,8 +1189,12 @@
     "github.com/google/uuid",
     "github.com/jpillora/backoff",
     "github.com/libp2p/go-libp2p",
+    "github.com/libp2p/go-libp2p-connmgr",
     "github.com/libp2p/go-libp2p-crypto",
+    "github.com/libp2p/go-libp2p-discovery",
     "github.com/libp2p/go-libp2p-host",
+    "github.com/libp2p/go-libp2p-kad-dht",
+    "github.com/libp2p/go-libp2p-net",
     "github.com/libp2p/go-libp2p-peer",
     "github.com/libp2p/go-libp2p-peerstore",
     "github.com/libp2p/go-libp2p-pubsub",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,24 +61,42 @@
 
 [[constraint]]
   name = "github.com/libp2p/go-libp2p"
-  version = "0.0.7"
+  version = "v0.0.28"
 
 [[constraint]]
   name = "github.com/libp2p/go-libp2p-peerstore"
-  version = "0.0.1"
+  version = "v0.0.6"
 
 [[constraint]]
   name = "github.com/multiformats/go-multiaddr"
-  version = "0.0.2"
+  version = "0.0.4"
 
 [[constraint]]
   name = "github.com/libp2p/go-libp2p-crypto"
-  version = "0.0.1"
-
-[[constraint]]
-  name = "github.com/libp2p/go-libp2p-host"
   version = "0.0.2"
 
 [[constraint]]
+  name = "github.com/libp2p/go-libp2p-host"
+  version = "0.0.3"
+
+[[constraint]]
   name = "github.com/libp2p/go-libp2p-pubsub"
-  version = "0.0.1"
+  version = "0.0.3"
+
+[[constraint]]
+  name = "github.com/libp2p/go-libp2p-kad-dht"
+  version = "0.0.13"
+
+[[constraint]]
+  name = "github.com/libp2p/go-libp2p-connmgr"
+  version = "0.0.4"
+
+[[constraint]]
+  name = "github.com/libp2p/go-libp2p-discovery"
+  version = "0.0.4"
+
+[[override]]
+  name = "github.com/gballet/go-libpcsclite"
+  revision = "312b5175032f98274685a4dd81935a92ad2412a5"
+  [metadata]
+    note = "go-ethereum depends on this package and they made a breaking API change"

--- a/blockwatch/watcher.go
+++ b/blockwatch/watcher.go
@@ -166,7 +166,7 @@ func (w *Watcher) pollNextBlock() error {
 		if err == ethereum.NotFound {
 			log.WithFields(log.Fields{
 				"blockNumber": nextBlockNumber,
-			}).Info("block header not found")
+			}).Trace("block header not found")
 			return nil // Noop and wait next polling interval
 		}
 		return err

--- a/core/node.go
+++ b/core/node.go
@@ -9,11 +9,16 @@ import (
 	"fmt"
 	"io"
 	mrand "math/rand"
+	"sync"
 	"time"
 
 	libp2p "github.com/libp2p/go-libp2p"
+	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	crypto "github.com/libp2p/go-libp2p-crypto"
+	discovery "github.com/libp2p/go-libp2p-discovery"
 	host "github.com/libp2p/go-libp2p-host"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	p2pnet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -28,19 +33,37 @@ const (
 	maxReceiveBatch = 100
 	// maxShareBatch is the maximum number of messages to share at once.
 	maxShareBatch = 10
+	// peerCountLow is the target number of peers to connect to at any given time.
+	peerCountLow = 10
+	// peerCountHigh is the maximum number of peers to be connected to. If the
+	// number of connections exceeds this number, we will prune connections until
+	// we reach peerCountLow.
+	peerCountHigh = 12
+	// peerGraceDuration is the amount of time a newly opened connection is given
+	// before it becomes subject to pruning.
+	peerGraceDuration = 10 * time.Second
+	// defaultNetworkTimeout is the default timeout for network requests (e.g.
+	// connecting to a new peer).
+	defaultNetworkTimeout = 30 * time.Second
+	// advertiseTTL is the TTL for our announcement to the discovery network.
+	advertiseTTL = 5 * time.Minute
 )
 
 // Node is the main type for the core package. It represents a particpant in the
 // 0x Mesh network who is capable of sending, receiving, validating, and storing
 // messages.
 type Node struct {
-	ctx            context.Context
-	cancel         context.CancelFunc
-	host           host.Host
-	pubsub         *pubsub.PubSub
-	sub            *pubsub.Subscription
-	config         Config
-	messageHandler MessageHandler
+	ctx              context.Context
+	cancel           context.CancelFunc
+	host             host.Host
+	dht              *dht.IpfsDHT
+	routingDiscovery discovery.Discovery
+	connManager      *connmgr.BasicConnMgr
+	pubsub           *pubsub.PubSub
+	sub              *pubsub.Subscription
+	config           Config
+	messageHandler   MessageHandler
+	notifee          p2pnet.Notifiee
 }
 
 // Config contains configuration options for a Node.
@@ -61,12 +84,24 @@ type Config struct {
 	// MessageHandler is an interface responsible for validating, storing, and
 	// finding new messages to share.
 	MessageHandler MessageHandler
+	// RendezvousString is a unique identifier for the rendezvous point. This node
+	// will attempt to find peers with the same Rendezvous string.
+	RendezvousString string
+	// UseBootstrapList determines whether or not to use the list of predetermined
+	// peers to bootstrap the DHT for peer discovery.
+	UseBootstrapList bool
 }
 
 // New creates a new Node with the given config.
 func New(config Config) (*Node, error) {
+	nodeCtx, cancel := context.WithCancel(context.Background())
+
 	if config.MessageHandler == nil {
+		cancel()
 		return nil, errors.New("config.MessageHandler is required")
+	} else if config.RendezvousString == "" {
+		cancel()
+		return nil, errors.New("config.RendezvousString is required")
 	}
 
 	// If the seed is zero, use real cryptographic randomness. Otherwise, use a
@@ -83,49 +118,69 @@ func New(config Config) (*Node, error) {
 	// to obtain a valid host ID.
 	priv, _, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, r)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
 	// Set up the transport and the host.
 	hostAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", config.ListenPort))
 	if err != nil {
+		cancel()
 		return nil, err
 	}
+	connManager := connmgr.NewConnManager(peerCountLow, peerCountHigh, peerGraceDuration)
 	opts := []libp2p.Option{
 		libp2p.ListenAddrs(hostAddr),
 		libp2p.Identity(priv),
 		libp2p.DisableRelay(),
+		libp2p.ConnectionManager(connManager),
 	}
 	if config.Insecure {
 		opts = append(opts, libp2p.NoSecurity)
 	}
-	basicHost, err := libp2p.New(context.Background(), opts...)
+	basicHost, err := libp2p.New(nodeCtx, opts...)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
+	// Set up DHT for peer discovery.
+	kadDHT, err := dht.New(nodeCtx, basicHost)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	routingDiscovery := discovery.NewRoutingDiscovery(kadDHT)
+
 	// Set up pubsub.
 	// TODO: Replace with WeijieSub. Using FloodSub for now.
-	ps, err := pubsub.NewFloodSub(context.Background(), basicHost)
+	ps, err := pubsub.NewFloodSub(nodeCtx, basicHost)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 	sub, err := ps.Subscribe(config.Topic)
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
 	// Create the Node.
-	ctx, cancel := context.WithCancel(context.Background())
 	node := &Node{
-		ctx:            ctx,
-		cancel:         cancel,
-		host:           basicHost,
-		config:         config,
-		pubsub:         ps,
-		sub:            sub,
-		messageHandler: config.MessageHandler,
+		ctx:              nodeCtx,
+		cancel:           cancel,
+		host:             basicHost,
+		dht:              kadDHT,
+		routingDiscovery: routingDiscovery,
+		connManager:      connManager,
+		config:           config,
+		pubsub:           ps,
+		sub:              sub,
+		messageHandler:   config.MessageHandler,
 	}
+
+	// Set up the notifee.
+	basicHost.Network().Notify(&notifee{node: node})
 
 	return node, nil
 }
@@ -143,7 +198,49 @@ func (n *Node) ID() peer.ID {
 // Start causes the Node to continuously send messages to and receive messages
 // from its peers. It blocks until an error is encountered or `Stop` is called.
 func (n *Node) Start() error {
+	// Note: dht.Bootstrap has a somewhat confusing name. It doesn't automatically
+	// connect to the bootstrap peers. It just starts the background process of
+	// searching for new peers.
+	if err := n.dht.Bootstrap(n.ctx); err != nil {
+		return err
+	}
+
+	// Advertise ourselves for the purposes of peer discovery.
+	discovery.Advertise(n.ctx, n.routingDiscovery, n.config.RendezvousString, discovery.TTL(advertiseTTL))
+
+	if n.config.UseBootstrapList {
+		if err := n.connectToBootstrapList(); err != nil {
+			return err
+		}
+	}
+
 	return n.mainLoop()
+}
+
+func (n *Node) connectToBootstrapList() error {
+	log.WithField("bootstrapPeers", dht.DefaultBootstrapPeers).Info("connecting to bootstrap peers")
+	connectCtx, cancel := context.WithTimeout(n.ctx, defaultNetworkTimeout)
+	defer cancel()
+	wg := sync.WaitGroup{}
+	// TODO(albrow): Replace default list with our own bootstrap peer list.
+	for _, addr := range dht.DefaultBootstrapPeers {
+		peerInfo, err := peerstore.InfoFromP2pAddr(addr)
+		if err != nil {
+			return err
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := n.host.Connect(connectCtx, *peerInfo); err != nil {
+				log.WithFields(map[string]interface{}{
+					"error":    err.Error(),
+					"peerInfo": peerInfo,
+				}).Warn("failed to connect to bootstrap peer")
+			}
+		}()
+	}
+	wg.Wait()
+	return nil
 }
 
 // Connect ensures there is a connection between this host and the peer with
@@ -154,7 +251,6 @@ func (n *Node) Connect(ctx context.Context, peerInfo peerstore.PeerInfo) error {
 	if err != nil {
 		return err
 	}
-	log.WithField("peerInfo", peerInfo).Debug("connected to peer")
 	return nil
 }
 
@@ -175,6 +271,13 @@ func (n *Node) mainLoop() error {
 
 // runOnce runs a single iteration of the main loop.
 func (n *Node) runOnce() error {
+	peerCount := n.connManager.GetInfo().ConnCount
+	if peerCount < peerCountLow {
+		if err := n.findNewPeers(peerCountLow - peerCount); err != nil {
+			return err
+		}
+	}
+
 	// Receive up to maxReceiveBatch messages.
 	incoming, err := n.receiveBatch()
 	if err != nil {
@@ -188,6 +291,35 @@ func (n *Node) runOnce() error {
 	// Send up to maxSendBatch messages.
 	if err := n.shareBatch(); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (n *Node) findNewPeers(max int) error {
+	log.WithFields(map[string]interface{}{
+		"max": max,
+	}).Debug("looking for new peers")
+	findPeersCtx, cancel := context.WithTimeout(n.ctx, defaultNetworkTimeout)
+	defer cancel()
+	peerChan, err := n.routingDiscovery.FindPeers(findPeersCtx, n.config.RendezvousString, discovery.Limit(max))
+	if err != nil {
+		return err
+	}
+
+	connectCtx, cancel := context.WithTimeout(n.ctx, defaultNetworkTimeout)
+	defer cancel()
+	for peer := range peerChan {
+		if peer.ID == n.host.ID() {
+			continue
+		}
+		if err := n.host.Connect(connectCtx, peer); err != nil {
+			// If we fail to connect to a single peer we should still keep trying the
+			// others. Log instead of returning the error.
+			log.WithFields(map[string]interface{}{
+				"error":    err.Error(),
+				"peerInfo": peer,
+			}).Warn("could not connect to peer")
+		}
 	}
 	return nil
 }

--- a/core/node.go
+++ b/core/node.go
@@ -23,6 +23,7 @@ import (
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	protocol "github.com/libp2p/go-libp2p-protocol"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
 	log "github.com/sirupsen/logrus"
 )
@@ -51,6 +52,32 @@ const (
 	// pubsubProtocolID is the protocol ID to use for pubsub.
 	pubsubProtocolID = protocol.ID("/0x-mesh-floodsub/0.0.1")
 )
+
+// bootstrapPeers is a list of peers to use for bootstrapping the DHT. Based on
+// the default IPFS bootstrap list but with some removals for peers which we
+// could not consistently connect to.
+// TODO(albrow): Replace this with our own bootstrap peer list.
+var bootstrapPeers []multiaddr.Multiaddr
+
+func init() {
+	for _, s := range []string{
+		"/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",  // mars.i.ipfs.io
+		"/ip4/104.236.179.241/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM", // pluto.i.ipfs.io
+		"/ip4/128.199.219.111/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu", // saturn.i.ipfs.io
+		"/ip4/104.236.76.40/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",   // venus.i.ipfs.io
+		// "/ip4/178.62.158.247/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",            // earth.i.ipfs.io
+		"/ip6/2604:a880:1:20::203:d001/tcp/4001/ipfs/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",  // pluto.i.ipfs.io
+		"/ip6/2400:6180:0:d0::151:6001/tcp/4001/ipfs/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",  // saturn.i.ipfs.io
+		"/ip6/2604:a880:800:10::4a:5001/tcp/4001/ipfs/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64", // venus.i.ipfs.io
+		// "/ip6/2a03:b0c0:0:1010::23:1001/tcp/4001/ipfs/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd", // earth.i.ipfs.io
+	} {
+		ma, err := multiaddr.NewMultiaddr(s)
+		if err != nil {
+			panic(err)
+		}
+		bootstrapPeers = append(bootstrapPeers, ma)
+	}
+}
 
 // Node is the main type for the core package. It represents a particpant in the
 // 0x Mesh network who is capable of sending, receiving, validating, and storing
@@ -222,12 +249,11 @@ func (n *Node) Start() error {
 }
 
 func (n *Node) connectToBootstrapList() error {
-	log.WithField("bootstrapPeers", dht.DefaultBootstrapPeers).Info("connecting to bootstrap peers")
+	log.WithField("bootstrapPeers", bootstrapPeers).Info("connecting to bootstrap peers")
 	connectCtx, cancel := context.WithTimeout(n.ctx, defaultNetworkTimeout)
 	defer cancel()
 	wg := sync.WaitGroup{}
-	// TODO(albrow): Replace default list with our own bootstrap peer list.
-	for _, addr := range dht.DefaultBootstrapPeers {
+	for _, addr := range bootstrapPeers {
 		peerInfo, err := peerstore.InfoFromP2pAddr(addr)
 		if err != nil {
 			return err

--- a/core/node.go
+++ b/core/node.go
@@ -312,6 +312,9 @@ func (n *Node) findNewPeers(max int) error {
 		if peer.ID == n.host.ID() {
 			continue
 		}
+		log.WithFields(map[string]interface{}{
+			"peerInfo": peer,
+		}).Debug("found peer via rendezvous")
 		if err := n.host.Connect(connectCtx, peer); err != nil {
 			// If we fail to connect to a single peer we should still keep trying the
 			// others. Log instead of returning the error.
@@ -385,6 +388,5 @@ func (n *Node) receive(ctx context.Context) (*Message, error) {
 // Close closes the Node and any active connections.
 func (n *Node) Close() error {
 	n.cancel()
-	n.sub.Cancel()
 	return n.host.Close()
 }

--- a/core/node.go
+++ b/core/node.go
@@ -44,7 +44,7 @@ const (
 	peerGraceDuration = 10 * time.Second
 	// defaultNetworkTimeout is the default timeout for network requests (e.g.
 	// connecting to a new peer).
-	defaultNetworkTimeout = 30 * time.Second
+	defaultNetworkTimeout = 5 * time.Second
 	// advertiseTTL is the TTL for our announcement to the discovery network.
 	advertiseTTL = 5 * time.Minute
 )

--- a/core/node_test.go
+++ b/core/node_test.go
@@ -306,16 +306,11 @@ func TestPeerDiscovery(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Create a test notifee for both node0 and node1 which will be used to detect
-	// new connections.
-	node0Notif := &testNotifee{
+	// Create a test notifee which will be used to detect new connections.
+	notif := &testNotifee{
 		conns: make(chan p2pnet.Conn),
 	}
-	node0.host.Network().Notify(node0Notif)
-	node2Notif := &testNotifee{
-		conns: make(chan p2pnet.Conn),
-	}
-	node2.host.Network().Notify(node2Notif)
+	node0.host.Network().Notify(notif)
 
 	// Start all the nodes (this also starts the peer discovery process).
 	go func() {
@@ -335,12 +330,8 @@ loop:
 		select {
 		case <-timeout:
 			t.Fatal("timed out waiting for node0 to discover node2")
-		case conn := <-node0Notif.conns:
+		case conn := <-notif.conns:
 			if conn.RemotePeer() == node2.ID() {
-				break loop
-			}
-		case conn := <-node2Notif.conns:
-			if conn.RemotePeer() == node0.ID() {
 				break loop
 			}
 		}

--- a/core/notifee.go
+++ b/core/notifee.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package core
 
 import (

--- a/core/notifee.go
+++ b/core/notifee.go
@@ -50,8 +50,12 @@ func (n *notifee) Disconnected(network p2pnet.Network, conn p2pnet.Conn) {
 // OpenedStream is called when a stream opened
 func (n *notifee) OpenedStream(network p2pnet.Network, stream p2pnet.Stream) {
 	go func() {
-		// HACK(albrow): When the stream is initially opened, the protocol is not set.
-		// For now, we have to manually poll until it is set.
+		// HACK(albrow): When the stream is initially opened, the protocol is not
+		// set. For now, we have to manually poll until it is set.
+		// https://github.com/libp2p/go-libp2p/issues/467 mentions an internal
+		// event bus which could potentially be used to detect when the protocol is
+		// set or offer a different way to detect peers who speak the protocol we're
+		// looking for.
 		timeout := time.After(5 * time.Second)
 		for stream.Protocol() == "" {
 			select {

--- a/core/notifee.go
+++ b/core/notifee.go
@@ -31,7 +31,7 @@ func (n *notifee) Connected(network p2pnet.Network, conn p2pnet.Conn) {
 	log.WithFields(map[string]interface{}{
 		"peerID":       conn.RemotePeer(),
 		"multiaddress": conn.RemoteMultiaddr(),
-	}).Debug("connected to peer")
+	}).Trace("connected to peer")
 	if isLocalConn(conn) {
 		// Protect local connections. This is a temporary measure which helps us do
 		// ad hoc tests in a local environment by ensuring we don't disconnect from
@@ -51,7 +51,7 @@ func (n *notifee) Disconnected(network p2pnet.Network, conn p2pnet.Conn) {
 	log.WithFields(map[string]interface{}{
 		"peerID":       conn.RemotePeer(),
 		"multiaddress": conn.RemoteMultiaddr(),
-	}).Debug("disconnected from peer")
+	}).Trace("disconnected from peer")
 }
 
 // OpenedStream is called when a stream opened

--- a/core/notifee.go
+++ b/core/notifee.go
@@ -14,6 +14,7 @@ import (
 // connections.
 const localConnTag = "local-connection"
 
+// notifee receives notifications for network-related events.
 type notifee struct {
 	node *Node
 }

--- a/core/notifee.go
+++ b/core/notifee.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"strings"
+
+	p2pnet "github.com/libp2p/go-libp2p-net"
+	ma "github.com/multiformats/go-multiaddr"
+	log "github.com/sirupsen/logrus"
+)
+
+// localConnTag is the tag used with the Connection Manager to mark local
+// connections.
+const localConnTag = "local-connection"
+
+type notifee struct {
+	node *Node
+}
+
+var _ p2pnet.Notifiee = &notifee{}
+
+// Listen is called when network starts listening on an addr
+func (n *notifee) Listen(p2pnet.Network, ma.Multiaddr) {}
+
+// ListenClose is called when network stops listening on an addr
+func (n *notifee) ListenClose(p2pnet.Network, ma.Multiaddr) {}
+
+// Connected is called when a connection opened
+func (n *notifee) Connected(network p2pnet.Network, conn p2pnet.Conn) {
+	log.WithFields(map[string]interface{}{
+		"peerID":       conn.RemotePeer(),
+		"multiaddress": conn.RemoteMultiaddr(),
+	}).Debug("connected to peer")
+	if isLocalConn(conn) {
+		// Protect local connections. This is a temporary measure which helps us do
+		// ad hoc tests in a local environment by ensuring we don't disconnect from
+		// any local peers.
+		// TODO(albrow): Remove this once we have proper peer scoring/tagging in
+		// place.
+		log.WithFields(map[string]interface{}{
+			"peerID":       conn.RemotePeer(),
+			"multiaddress": conn.RemoteMultiaddr(),
+		}).Debug("protecting local connection")
+		n.node.connManager.Protect(conn.RemotePeer(), localConnTag)
+	}
+}
+
+// Disconnected is called when a connection closed
+func (n *notifee) Disconnected(network p2pnet.Network, conn p2pnet.Conn) {
+	log.WithFields(map[string]interface{}{
+		"peerID":       conn.RemotePeer(),
+		"multiaddress": conn.RemoteMultiaddr(),
+	}).Debug("disconnected from peer")
+}
+
+// OpenedStream is called when a stream opened
+func (n *notifee) OpenedStream(p2pnet.Network, p2pnet.Stream) {}
+
+// ClosedStream is called when a stream closed
+func (n *notifee) ClosedStream(p2pnet.Network, p2pnet.Stream) {}
+
+func isLocalConn(conn p2pnet.Conn) bool {
+	ipv4Addr, err := conn.RemoteMultiaddr().ValueForProtocol(ma.P_IP4)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(ipv4Addr, "localhost") || strings.Contains(ipv4Addr, "127.0.0.1")
+}

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func newApp() (*application, error) {
 		"P2P_LISTEN_PORT":     env.P2PListenPort,
 		"ETHEREUM_RPC_URL":    env.EthereumRPCURL,
 		"ETHEREUM_NETWORK_ID": env.EthereumNetworkID,
+		"USE_BOOTSTRAP_LIST":  env.UseBootstrapList,
 	}).Info("parsed environment variables")
 
 	// Initialize db

--- a/main.go
+++ b/main.go
@@ -56,6 +56,9 @@ type meshEnvVars struct {
 	// EthereumNetworkID is the network ID to use when communicating with
 	// Ethereum.
 	EthereumNetworkID int `envvar:"ETHEREUM_NETWORK_ID"`
+	// UseBootstrapList is whether to use the predetermined list of peers to
+	// bootstrap the DHT and peer discovery.
+	UseBootstrapList bool `envvar:"USE_BOOTSTRAP_LIST" default:"false"`
 }
 
 type application struct {
@@ -163,11 +166,13 @@ func newApp() (*application, error) {
 
 	// Initialize the core node.
 	nodeConfig := core.Config{
-		Topic:          pubsubTopic,
-		ListenPort:     env.P2PListenPort,
-		Insecure:       false,
-		RandSeed:       0,
-		MessageHandler: app,
+		Topic:            pubsubTopic,
+		ListenPort:       env.P2PListenPort,
+		Insecure:         false,
+		RandSeed:         0,
+		MessageHandler:   app,
+		RendezvousString: "0x-mesh:v0.0.1",
+		UseBootstrapList: env.UseBootstrapList,
 	}
 	node, err := core.New(nodeConfig)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	pubsubTopic                 = "0x-orders:v0"
+	pubsubTopic                 = "/0x-orders/0.0.1"
 	blockWatcherPollingInterval = 5 * time.Second
 	blockWatcherRetentionLimit  = 20
 	ethereumRPCRequestTimeout   = 30 * time.Second
@@ -172,7 +172,7 @@ func newApp() (*application, error) {
 		Insecure:         false,
 		RandSeed:         0,
 		MessageHandler:   app,
-		RendezvousString: "0x-mesh:v0.0.1",
+		RendezvousString: "/0x-mesh/0.0.1",
 		UseBootstrapList: env.UseBootstrapList,
 	}
 	node, err := core.New(nodeConfig)


### PR DESCRIPTION
This PR adds support for peer discovery via [go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht) and [go-libp2p-discovery](https://github.com/libp2p/go-libp2p-discovery). It also adds a new environment variable `USE_BOOTSTRAP_LIST`. If set to "true", it uses the IPFS default bootstrap list to bootstrap the DHT.

WIP right now because of some weird behavior when using the bootstrap list. If you set it to "false", you can test peer discovery by following these steps:

1. Create three 0x Mesh nodes (A, B, and C).
2. Manually connect A to B via the `AddPeer` RPC method.
3. Manually connect B to C via the `AddPeer` RPC method.
4. Observe that A is introduced to C through B and they will connect to each other.