### PR TITLE
ethereum/zeroex: Implement signing utilities

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -44,3 +44,6 @@ var NetworkIDToContractAddresses = map[int]ContractNameToAddress{
 
 // NullAddress is an Ethereum address with all zeroes.
 var NullAddress = common.HexToAddress("0x0000000000000000000000000000000000000000")
+
+// GanacheAccount0 is the first account exposed on the Ganache test Ethereum node
+var GanacheAccount0 = common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631")

--- a/demo/add_order/main.go
+++ b/demo/add_order/main.go
@@ -56,7 +56,7 @@ func main() {
 		log.WithError(err).Fatal("could not create Ethereum rpc client")
 	}
 
-	signedTestOrder, err := zeroex.ConvertToSignedOrder(testOrder, rpcClient)
+	signedTestOrder, err := zeroex.SignOrder(testOrder, rpcClient)
 	if err != nil {
 		log.WithError(err).Fatal("could not sign 0x order")
 	}

--- a/ethereum/sign.go
+++ b/ethereum/sign.go
@@ -1,0 +1,39 @@
+package ethereum
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// ECSignature contains the parameters of an elliptic curve signature
+type ECSignature struct {
+	V byte
+	R []byte
+	S []byte
+}
+
+// ECSign signs an order and generates an EthSign signature type
+func ECSign(message []byte, signerAddress common.Address, rpcClient *rpc.Client) (*ECSignature, error) {
+	// Set an ETH_SIGN JSON-RPC request
+	var signatureHex string
+	if err := rpcClient.Call(&signatureHex, "eth_sign", signerAddress.Hex(), common.Bytes2Hex(message)); err != nil {
+		return nil, err
+	}
+	// eth_sign returns the signature as r+s+v
+	signatureBytes := common.Hex2Bytes(signatureHex[2:])
+	vParam := signatureBytes[64]
+	if vParam == byte(0) {
+		vParam = byte(27)
+	} else if vParam == byte(1) {
+		vParam = byte(28)
+	}
+	rParam := signatureBytes[0:32]
+	sParam := signatureBytes[32:64]
+
+	ecSignature := &ECSignature{
+		V: vParam,
+		R: rParam,
+		S: sParam,
+	}
+	return ecSignature, nil
+}

--- a/ethereum/sign.go
+++ b/ethereum/sign.go
@@ -8,8 +8,8 @@ import (
 // ECSignature contains the parameters of an elliptic curve signature
 type ECSignature struct {
 	V byte
-	R []byte
-	S []byte
+	R common.Hash
+	S common.Hash
 }
 
 // ECSign signs a message via the `eth_sign` Ethereum JSON-RPC call
@@ -26,13 +26,11 @@ func ECSign(message []byte, signerAddress common.Address, rpcClient *rpc.Client)
 	} else if vParam == byte(1) {
 		vParam = byte(28)
 	}
-	rParam := signatureBytes[0:32]
-	sParam := signatureBytes[32:64]
 
 	ecSignature := &ECSignature{
 		V: vParam,
-		R: rParam,
-		S: sParam,
+		R: common.BytesToHash(signatureBytes[0:32]),
+		S: common.BytesToHash(signatureBytes[32:64]),
 	}
 	return ecSignature, nil
 }

--- a/ethereum/sign.go
+++ b/ethereum/sign.go
@@ -12,14 +12,13 @@ type ECSignature struct {
 	S []byte
 }
 
-// ECSign signs an order and generates an EthSign signature type
+// ECSign signs a message via the `eth_sign` Ethereum JSON-RPC call
 func ECSign(message []byte, signerAddress common.Address, rpcClient *rpc.Client) (*ECSignature, error) {
-	// Set an ETH_SIGN JSON-RPC request
 	var signatureHex string
 	if err := rpcClient.Call(&signatureHex, "eth_sign", signerAddress.Hex(), common.Bytes2Hex(message)); err != nil {
 		return nil, err
 	}
-	// eth_sign returns the signature as r+s+v
+	// `eth_sign` returns the signature as r+s+v and the `v` parameter as 0/1 instead of 27/28
 	signatureBytes := common.Hex2Bytes(signatureHex[2:])
 	vParam := signatureBytes[64]
 	if vParam == byte(0) {

--- a/ethereum/sign_test.go
+++ b/ethereum/sign_test.go
@@ -18,8 +18,8 @@ func TestECSign(t *testing.T) {
 	message := common.Hex2Bytes("6927e990021d23b1eb7b8789f6a6feaf98fe104bb0cf8259421b79f9a34222b0")
 	expectedSignature := &ECSignature{
 		V: byte(27),
-		R: common.Hex2Bytes("61a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"),
-		S: common.Hex2Bytes("40349190569279751135161d22529dc25add4f6069af05be04cacbda2ace2254"),
+		R: common.HexToHash("61a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"),
+		S: common.HexToHash("40349190569279751135161d22529dc25add4f6069af05be04cacbda2ace2254"),
 	}
 
 	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)

--- a/ethereum/sign_test.go
+++ b/ethereum/sign_test.go
@@ -1,0 +1,29 @@
+package ethereum
+
+import (
+	"testing"
+
+	"github.com/0xProject/0x-mesh/constants"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestECSign(t *testing.T) {
+	// Test parameters lifted from @0x/order-utils' `signature_utils_test.ts`
+	signerAddress := common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631")
+	message := common.Hex2Bytes("6927e990021d23b1eb7b8789f6a6feaf98fe104bb0cf8259421b79f9a34222b0")
+	expectedSignature := &ECSignature{
+		V: byte(27),
+		R: common.Hex2Bytes("61a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33"),
+		S: common.Hex2Bytes("40349190569279751135161d22529dc25add4f6069af05be04cacbda2ace2254"),
+	}
+
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+	actualSignature, err := ECSign(message, signerAddress, rpcClient)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedSignature, actualSignature)
+}

--- a/ethereum/sign_test.go
+++ b/ethereum/sign_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package ethereum
 
 import (

--- a/meshdb/meshdb_test.go
+++ b/meshdb/meshdb_test.go
@@ -42,7 +42,7 @@ func TestOrderCRUDOperations(t *testing.T) {
 		ExpirationTimeSeconds: big.NewInt(1548619325),
 		ExchangeAddress:       contractNameToAddress.Exchange,
 	}
-	signedOrder, err := zeroex.ConvertToSignedOrder(o, rpcClient)
+	signedOrder, err := zeroex.SignOrder(o, rpcClient)
 	require.NoError(t, err)
 
 	orderHash, err := o.ComputeOrderHash()

--- a/meshdb/meshdb_test.go
+++ b/meshdb/meshdb_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package meshdb
 
 import (
@@ -8,6 +10,7 @@ import (
 	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/zeroex"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,9 +22,12 @@ func TestOrderCRUDOperations(t *testing.T) {
 
 	contractNameToAddress := constants.NetworkIDToContractAddresses[constants.TestNetworkID]
 
-	makerAddress := common.HexToAddress("0x6924a03bb710eaf199ab6ac9f2bb148215ae9b5d")
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+
+	makerAddress := constants.GanacheAccount0
 	salt := big.NewInt(1548619145450)
-	signedOrder := &zeroex.SignedOrder{
+	o := &zeroex.Order{
 		MakerAddress:          makerAddress,
 		TakerAddress:          constants.NullAddress,
 		SenderAddress:         constants.NullAddress,
@@ -36,7 +42,10 @@ func TestOrderCRUDOperations(t *testing.T) {
 		ExpirationTimeSeconds: big.NewInt(1548619325),
 		ExchangeAddress:       contractNameToAddress.Exchange,
 	}
-	orderHash, err := signedOrder.ComputeOrderHash()
+	signedOrder, err := zeroex.ConvertToSignedOrder(o, rpcClient)
+	require.NoError(t, err)
+
+	orderHash, err := o.ComputeOrderHash()
 	require.NoError(t, err)
 
 	currentTime := time.Now().UTC()

--- a/ws/client_server_test.go
+++ b/ws/client_server_test.go
@@ -86,7 +86,7 @@ var testOrder = &zeroex.Order{
 func TestAddOrder(t *testing.T) {
 	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
-	signedTestOrder, err := zeroex.ConvertToSignedOrder(testOrder, rpcClient)
+	signedTestOrder, err := zeroex.SignOrder(testOrder, rpcClient)
 	require.NoError(t, err)
 
 	// Set up the dummy handler with an addOrderHandler

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -45,6 +45,21 @@ type SignedOrder struct {
 	Signature             []byte         `json:"signature"`
 }
 
+// SignatureType represents the type of 0x signature encountered
+type SignatureType uint8
+
+// SignatureType values
+const (
+	IllegalSignature SignatureType = iota
+	InvalidSignature
+	EIP712Signature
+	EthSignSignature
+	WalletSignature
+	ValidatorSignature
+	PreSignedSignature
+	NSignatureTypesSignature
+)
+
 var eip712OrderTypes = signer.Types{
 	"EIP712Domain": {
 		{
@@ -171,8 +186,7 @@ func (s *SignedOrder) ECSign(rpcClient *rpc.Client) ([]byte, error) {
 	signature = append(signature, ecSignature.V)
 	signature = append(signature, ecSignature.R...)
 	signature = append(signature, ecSignature.S...)
-	ethSignType := byte(3)
-	signature = append(signature, ethSignType)
+	signature = append(signature, byte(EthSignSignature))
 	return signature, nil
 }
 

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -176,8 +176,7 @@ func (o *Order) ComputeOrderHash() (common.Hash, error) {
 	return hash, nil
 }
 
-// ECSign signs the order with it's `makerAddress` and formats it to be a valid 0x order signature
-func (o *Order) ECSign(rpcClient *rpc.Client) ([]byte, error) {
+func (o *Order) ecSign(rpcClient *rpc.Client) ([]byte, error) {
 	orderHash, err := o.ComputeOrderHash()
 	if err != nil {
 		return nil, err
@@ -215,9 +214,9 @@ func (s *SignedOrder) ConvertToOrderWithoutExchangeAddress() wrappers.OrderWitho
 	return orderWithoutExchangeAddress
 }
 
-// ConvertToSignedOrder converts an order to a signed 0x order
-func ConvertToSignedOrder(order *Order, rpcClient *rpc.Client) (*SignedOrder, error) {
-	signature, err := order.ECSign(rpcClient)
+// SignOrder converts an order to a signed 0x order
+func SignOrder(order *Order, rpcClient *rpc.Client) (*SignedOrder, error) {
+	signature, err := order.ecSign(rpcClient)
 	if err != nil {
 		return nil, err
 	}

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -182,11 +182,11 @@ func (s *SignedOrder) ECSign(rpcClient *rpc.Client) ([]byte, error) {
 		return nil, err
 	}
 
-	signature := []byte{}
-	signature = append(signature, ecSignature.V)
-	signature = append(signature, ecSignature.R...)
-	signature = append(signature, ecSignature.S...)
-	signature = append(signature, byte(EthSignSignature))
+	signature := make([]byte, 66)
+	signature[0] = ecSignature.V
+	copy(signature[1:33], ecSignature.R[:])
+	copy(signature[33:65], ecSignature.S[:])
+	signature[65] = byte(EthSignSignature)
 	return signature, nil
 }
 

--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -17,7 +17,7 @@ import (
 func TestGenerateOrderHash(t *testing.T) {
 	fakeExchangeContractAddress := common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c48")
 
-	order := SignedOrder{
+	order := Order{
 		MakerAddress:          constants.NullAddress,
 		TakerAddress:          constants.NullAddress,
 		SenderAddress:         constants.NullAddress,
@@ -43,7 +43,7 @@ func TestGenerateOrderHash(t *testing.T) {
 func TestECSignOrder(t *testing.T) {
 	fakeExchangeContractAddress := common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c48")
 
-	order := SignedOrder{
+	order := Order{
 		MakerAddress:          common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631"),
 		TakerAddress:          constants.NullAddress,
 		SenderAddress:         constants.NullAddress,

--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -42,7 +42,7 @@ func TestECSignOrder(t *testing.T) {
 	fakeExchangeContractAddress := common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c48")
 
 	order := SignedOrder{
-		MakerAddress:          constants.NullAddress,
+		MakerAddress:          common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631"),
 		TakerAddress:          constants.NullAddress,
 		SenderAddress:         constants.NullAddress,
 		FeeRecipientAddress:   constants.NullAddress,
@@ -57,13 +57,12 @@ func TestECSignOrder(t *testing.T) {
 		ExpirationTimeSeconds: big.NewInt(0),
 	}
 
-	signerAddress := common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631")
 	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
-	signatureBytes, err := order.ECSign(signerAddress, rpcClient)
+	signatureBytes, err := order.ECSign(rpcClient)
 	require.NoError(t, err)
 
-	expectedSignature := "0x1c5df471fd3ab082ef46b6d258e7f0e76a04aabbab6801b031cd4dc260d2677c13373fad62139cbae182350f91c630ee2125a7b811650229575fcc5492444b7be003"
+	expectedSignature := "0x1c3582f06356a1314dbf1c0e534c4d8e92e59b056ee607a7ff5a825f5f2cc5e6151c5cc7fdd420f5608e4d5bef108e42ad90c7a4b408caef32e24374cf387b0d7603"
 	actualSignature := fmt.Sprintf("0x%s", common.Bytes2Hex(signatureBytes))
 	assert.Equal(t, expectedSignature, actualSignature)
 }

--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package zeroex
 
 import (

--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -61,7 +61,7 @@ func TestECSignOrder(t *testing.T) {
 
 	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
-	signatureBytes, err := order.ECSign(rpcClient)
+	signatureBytes, err := order.ecSign(rpcClient)
 	require.NoError(t, err)
 
 	expectedSignature := "0x1c3582f06356a1314dbf1c0e534c4d8e92e59b056ee607a7ff5a825f5f2cc5e6151c5cc7fdd420f5608e4d5bef108e42ad90c7a4b408caef32e24374cf387b0d7603"

--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -1,11 +1,13 @@
 package zeroex
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/0xProject/0x-mesh/constants"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,4 +36,34 @@ func TestGenerateOrderHash(t *testing.T) {
 	actualOrderHash, err := order.ComputeOrderHash()
 	require.NoError(t, err)
 	assert.Equal(t, expectedOrderHash, actualOrderHash)
+}
+
+func TestECSignOrder(t *testing.T) {
+	fakeExchangeContractAddress := common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c48")
+
+	order := SignedOrder{
+		MakerAddress:          constants.NullAddress,
+		TakerAddress:          constants.NullAddress,
+		SenderAddress:         constants.NullAddress,
+		FeeRecipientAddress:   constants.NullAddress,
+		MakerAssetData:        constants.NullAddress.Bytes(),
+		TakerAssetData:        constants.NullAddress.Bytes(),
+		ExchangeAddress:       fakeExchangeContractAddress,
+		Salt:                  big.NewInt(0),
+		MakerFee:              big.NewInt(0),
+		TakerFee:              big.NewInt(0),
+		MakerAssetAmount:      big.NewInt(0),
+		TakerAssetAmount:      big.NewInt(0),
+		ExpirationTimeSeconds: big.NewInt(0),
+	}
+
+	signerAddress := common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631")
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+	signatureBytes, err := order.ECSign(signerAddress, rpcClient)
+	require.NoError(t, err)
+
+	expectedSignature := "0x1c5df471fd3ab082ef46b6d258e7f0e76a04aabbab6801b031cd4dc260d2677c13373fad62139cbae182350f91c630ee2125a7b811650229575fcc5492444b7be003"
+	actualSignature := fmt.Sprintf("0x%s", common.Bytes2Hex(signatureBytes))
+	assert.Equal(t, expectedSignature, actualSignature)
 }

--- a/zeroex/order_validator_test.go
+++ b/zeroex/order_validator_test.go
@@ -38,7 +38,7 @@ func TestBatchValidate(t *testing.T) {
 		ExpirationTimeSeconds: big.NewInt(1548619325),
 		ExchangeAddress:       contractNameToAddress.Exchange,
 	}
-	signedOrder, err := ConvertToSignedOrder(order, rpcClient)
+	signedOrder, err := SignOrder(order, rpcClient)
 	require.NoError(t, err)
 
 	orderHash, err := order.ComputeOrderHash()
@@ -84,7 +84,7 @@ func TestCalculateRemainingFillableTakerAmount(t *testing.T) {
 		ExpirationTimeSeconds: big.NewInt(99548619325),
 		ExchangeAddress:       contractNameToAddress.Exchange,
 	}
-	signedOrder, err := ConvertToSignedOrder(order, rpcClient)
+	signedOrder, err := SignOrder(order, rpcClient)
 	require.NoError(t, err)
 
 	orderHash, err := order.ComputeOrderHash()


### PR DESCRIPTION
This PR:
- Implements utility for signing a message via `eth_sign` and associated tests
- Add convenience method for signing a 0x order and returning the signature in the format expected by the smart contracts.