### PR TITLE
zeroex: Add order signature validation to `BatchValidate`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       BASH_ENV: ~/.nvm/nvm.sh
     docker:
       - image: circleci/golang:1.12
-      - image: 0xorg/mesh-ganache-cli:4.0.3
+      - image: 0xorg/mesh-ganache-cli:5.0.0
     working_directory: /go/src/github.com/0xProject/0x-mesh
     steps:
       - checkout

--- a/demo/add_order/main.go
+++ b/demo/add_order/main.go
@@ -25,7 +25,7 @@ type clientEnvVars struct {
 }
 
 var testOrder = &zeroex.Order{
-	MakerAddress:          common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631"),
+	MakerAddress:          constants.GanacheAccount0,
 	TakerAddress:          constants.NullAddress,
 	SenderAddress:         constants.NullAddress,
 	FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),

--- a/ethereum/eth_watcher_test.go
+++ b/ethereum/eth_watcher_test.go
@@ -21,7 +21,7 @@ import (
 
 // Values taken from Ganache snapshot
 var firstAccount = constants.GanacheAccount0
-var firstAccountBalance, _ = math.ParseBig256("99943881242000000000")
+var firstAccountBalance, _ = math.ParseBig256("99943793318000000000")
 var secondAccount = common.HexToAddress("0x6ecbe1db9ef729cbe972c83fb886247691fb6beb")
 var secondAccountBalance, _ = math.ParseBig256("49999822428000000000")
 var hundredEth, _ = math.ParseBig256("100000000000000000000")

--- a/ethereum/eth_watcher_test.go
+++ b/ethereum/eth_watcher_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Values taken from Ganache snapshot
-var firstAccount = common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631")
+var firstAccount = constants.GanacheAccount0
 var firstAccountBalance, _ = math.ParseBig256("99943881242000000000")
 var secondAccount = common.HexToAddress("0x6ecbe1db9ef729cbe972c83fb886247691fb6beb")
 var secondAccountBalance, _ = math.ParseBig256("49999822428000000000")

--- a/ethereum/sign_test.go
+++ b/ethereum/sign_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestECSign(t *testing.T) {
 	// Test parameters lifted from @0x/order-utils' `signature_utils_test.ts`
-	signerAddress := common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631")
+	signerAddress := constants.GanacheAccount0
 	message := common.Hex2Bytes("6927e990021d23b1eb7b8789f6a6feaf98fe104bb0cf8259421b79f9a34222b0")
 	expectedSignature := &ECSignature{
 		V: byte(27),

--- a/ethereum/wrappers/order_validator.go
+++ b/ethereum/wrappers/order_validator.go
@@ -30,7 +30,7 @@ var (
 )
 
 // OrderValidatorABI is the input ABI used to generate the binding from.
-const OrderValidatorABI = "[{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"makerAddress\",\"type\":\"address\"},{\"name\":\"takerAddress\",\"type\":\"address\"},{\"name\":\"feeRecipientAddress\",\"type\":\"address\"},{\"name\":\"senderAddress\",\"type\":\"address\"},{\"name\":\"makerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"takerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"makerFee\",\"type\":\"uint256\"},{\"name\":\"takerFee\",\"type\":\"uint256\"},{\"name\":\"expirationTimeSeconds\",\"type\":\"uint256\"},{\"name\":\"salt\",\"type\":\"uint256\"},{\"name\":\"makerAssetData\",\"type\":\"bytes\"},{\"name\":\"takerAssetData\",\"type\":\"bytes\"}],\"name\":\"order\",\"type\":\"tuple\"},{\"name\":\"takerAddress\",\"type\":\"address\"}],\"name\":\"getOrderAndTraderInfo\",\"outputs\":[{\"components\":[{\"name\":\"orderStatus\",\"type\":\"uint8\"},{\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"name\":\"orderTakerAssetFilledAmount\",\"type\":\"uint256\"}],\"name\":\"orderInfo\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"makerBalance\",\"type\":\"uint256\"},{\"name\":\"makerAllowance\",\"type\":\"uint256\"},{\"name\":\"takerBalance\",\"type\":\"uint256\"},{\"name\":\"takerAllowance\",\"type\":\"uint256\"},{\"name\":\"makerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"makerZrxAllowance\",\"type\":\"uint256\"},{\"name\":\"takerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"takerZrxAllowance\",\"type\":\"uint256\"}],\"name\":\"traderInfo\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"target\",\"type\":\"address\"},{\"name\":\"assetData\",\"type\":\"bytes\"}],\"name\":\"getBalanceAndAllowance\",\"outputs\":[{\"name\":\"balance\",\"type\":\"uint256\"},{\"name\":\"allowance\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"makerAddress\",\"type\":\"address\"},{\"name\":\"takerAddress\",\"type\":\"address\"},{\"name\":\"feeRecipientAddress\",\"type\":\"address\"},{\"name\":\"senderAddress\",\"type\":\"address\"},{\"name\":\"makerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"takerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"makerFee\",\"type\":\"uint256\"},{\"name\":\"takerFee\",\"type\":\"uint256\"},{\"name\":\"expirationTimeSeconds\",\"type\":\"uint256\"},{\"name\":\"salt\",\"type\":\"uint256\"},{\"name\":\"makerAssetData\",\"type\":\"bytes\"},{\"name\":\"takerAssetData\",\"type\":\"bytes\"}],\"name\":\"orders\",\"type\":\"tuple[]\"},{\"name\":\"takerAddresses\",\"type\":\"address[]\"}],\"name\":\"getOrdersAndTradersInfo\",\"outputs\":[{\"components\":[{\"name\":\"orderStatus\",\"type\":\"uint8\"},{\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"name\":\"orderTakerAssetFilledAmount\",\"type\":\"uint256\"}],\"name\":\"ordersInfo\",\"type\":\"tuple[]\"},{\"components\":[{\"name\":\"makerBalance\",\"type\":\"uint256\"},{\"name\":\"makerAllowance\",\"type\":\"uint256\"},{\"name\":\"takerBalance\",\"type\":\"uint256\"},{\"name\":\"takerAllowance\",\"type\":\"uint256\"},{\"name\":\"makerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"makerZrxAllowance\",\"type\":\"uint256\"},{\"name\":\"takerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"takerZrxAllowance\",\"type\":\"uint256\"}],\"name\":\"tradersInfo\",\"type\":\"tuple[]\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"makerAddress\",\"type\":\"address\"},{\"name\":\"takerAddress\",\"type\":\"address\"},{\"name\":\"feeRecipientAddress\",\"type\":\"address\"},{\"name\":\"senderAddress\",\"type\":\"address\"},{\"name\":\"makerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"takerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"makerFee\",\"type\":\"uint256\"},{\"name\":\"takerFee\",\"type\":\"uint256\"},{\"name\":\"expirationTimeSeconds\",\"type\":\"uint256\"},{\"name\":\"salt\",\"type\":\"uint256\"},{\"name\":\"makerAssetData\",\"type\":\"bytes\"},{\"name\":\"takerAssetData\",\"type\":\"bytes\"}],\"name\":\"orders\",\"type\":\"tuple[]\"},{\"name\":\"takerAddresses\",\"type\":\"address[]\"}],\"name\":\"getTradersInfo\",\"outputs\":[{\"components\":[{\"name\":\"makerBalance\",\"type\":\"uint256\"},{\"name\":\"makerAllowance\",\"type\":\"uint256\"},{\"name\":\"takerBalance\",\"type\":\"uint256\"},{\"name\":\"takerAllowance\",\"type\":\"uint256\"},{\"name\":\"makerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"makerZrxAllowance\",\"type\":\"uint256\"},{\"name\":\"takerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"takerZrxAllowance\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple[]\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"token\",\"type\":\"address\"},{\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"getERC721TokenOwner\",\"outputs\":[{\"name\":\"owner\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"target\",\"type\":\"address\"},{\"name\":\"assetData\",\"type\":\"bytes[]\"}],\"name\":\"getBalancesAndAllowances\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256[]\"},{\"name\":\"\",\"type\":\"uint256[]\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"makerAddress\",\"type\":\"address\"},{\"name\":\"takerAddress\",\"type\":\"address\"},{\"name\":\"feeRecipientAddress\",\"type\":\"address\"},{\"name\":\"senderAddress\",\"type\":\"address\"},{\"name\":\"makerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"takerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"makerFee\",\"type\":\"uint256\"},{\"name\":\"takerFee\",\"type\":\"uint256\"},{\"name\":\"expirationTimeSeconds\",\"type\":\"uint256\"},{\"name\":\"salt\",\"type\":\"uint256\"},{\"name\":\"makerAssetData\",\"type\":\"bytes\"},{\"name\":\"takerAssetData\",\"type\":\"bytes\"}],\"name\":\"order\",\"type\":\"tuple\"},{\"name\":\"takerAddress\",\"type\":\"address\"}],\"name\":\"getTraderInfo\",\"outputs\":[{\"components\":[{\"name\":\"makerBalance\",\"type\":\"uint256\"},{\"name\":\"makerAllowance\",\"type\":\"uint256\"},{\"name\":\"takerBalance\",\"type\":\"uint256\"},{\"name\":\"takerAllowance\",\"type\":\"uint256\"},{\"name\":\"makerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"makerZrxAllowance\",\"type\":\"uint256\"},{\"name\":\"takerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"takerZrxAllowance\",\"type\":\"uint256\"}],\"name\":\"traderInfo\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_exchange\",\"type\":\"address\"},{\"name\":\"_zrxAssetData\",\"type\":\"bytes\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"}]"
+const OrderValidatorABI = "[{\"constant\":true,\"inputs\":[{\"name\":\"target\",\"type\":\"address\"},{\"name\":\"assetData\",\"type\":\"bytes\"}],\"name\":\"getBalanceAndAllowance\",\"outputs\":[{\"name\":\"balance\",\"type\":\"uint256\"},{\"name\":\"allowance\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"makerAddress\",\"type\":\"address\"},{\"name\":\"takerAddress\",\"type\":\"address\"},{\"name\":\"feeRecipientAddress\",\"type\":\"address\"},{\"name\":\"senderAddress\",\"type\":\"address\"},{\"name\":\"makerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"takerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"makerFee\",\"type\":\"uint256\"},{\"name\":\"takerFee\",\"type\":\"uint256\"},{\"name\":\"expirationTimeSeconds\",\"type\":\"uint256\"},{\"name\":\"salt\",\"type\":\"uint256\"},{\"name\":\"makerAssetData\",\"type\":\"bytes\"},{\"name\":\"takerAssetData\",\"type\":\"bytes\"}],\"name\":\"orders\",\"type\":\"tuple[]\"},{\"name\":\"takerAddresses\",\"type\":\"address[]\"}],\"name\":\"getTradersInfo\",\"outputs\":[{\"components\":[{\"name\":\"makerBalance\",\"type\":\"uint256\"},{\"name\":\"makerAllowance\",\"type\":\"uint256\"},{\"name\":\"takerBalance\",\"type\":\"uint256\"},{\"name\":\"takerAllowance\",\"type\":\"uint256\"},{\"name\":\"makerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"makerZrxAllowance\",\"type\":\"uint256\"},{\"name\":\"takerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"takerZrxAllowance\",\"type\":\"uint256\"}],\"name\":\"\",\"type\":\"tuple[]\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"token\",\"type\":\"address\"},{\"name\":\"tokenId\",\"type\":\"uint256\"}],\"name\":\"getERC721TokenOwner\",\"outputs\":[{\"name\":\"owner\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"makerAddress\",\"type\":\"address\"},{\"name\":\"takerAddress\",\"type\":\"address\"},{\"name\":\"feeRecipientAddress\",\"type\":\"address\"},{\"name\":\"senderAddress\",\"type\":\"address\"},{\"name\":\"makerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"takerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"makerFee\",\"type\":\"uint256\"},{\"name\":\"takerFee\",\"type\":\"uint256\"},{\"name\":\"expirationTimeSeconds\",\"type\":\"uint256\"},{\"name\":\"salt\",\"type\":\"uint256\"},{\"name\":\"makerAssetData\",\"type\":\"bytes\"},{\"name\":\"takerAssetData\",\"type\":\"bytes\"}],\"name\":\"order\",\"type\":\"tuple\"},{\"name\":\"signature\",\"type\":\"bytes\"},{\"name\":\"takerAddress\",\"type\":\"address\"}],\"name\":\"getOrderAndTraderInfo\",\"outputs\":[{\"components\":[{\"name\":\"orderStatus\",\"type\":\"uint8\"},{\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"name\":\"orderTakerAssetFilledAmount\",\"type\":\"uint256\"}],\"name\":\"orderInfo\",\"type\":\"tuple\"},{\"components\":[{\"name\":\"makerBalance\",\"type\":\"uint256\"},{\"name\":\"makerAllowance\",\"type\":\"uint256\"},{\"name\":\"takerBalance\",\"type\":\"uint256\"},{\"name\":\"takerAllowance\",\"type\":\"uint256\"},{\"name\":\"makerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"makerZrxAllowance\",\"type\":\"uint256\"},{\"name\":\"takerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"takerZrxAllowance\",\"type\":\"uint256\"}],\"name\":\"traderInfo\",\"type\":\"tuple\"},{\"name\":\"isValidSignature\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"target\",\"type\":\"address\"},{\"name\":\"assetData\",\"type\":\"bytes[]\"}],\"name\":\"getBalancesAndAllowances\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256[]\"},{\"name\":\"\",\"type\":\"uint256[]\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"makerAddress\",\"type\":\"address\"},{\"name\":\"takerAddress\",\"type\":\"address\"},{\"name\":\"feeRecipientAddress\",\"type\":\"address\"},{\"name\":\"senderAddress\",\"type\":\"address\"},{\"name\":\"makerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"takerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"makerFee\",\"type\":\"uint256\"},{\"name\":\"takerFee\",\"type\":\"uint256\"},{\"name\":\"expirationTimeSeconds\",\"type\":\"uint256\"},{\"name\":\"salt\",\"type\":\"uint256\"},{\"name\":\"makerAssetData\",\"type\":\"bytes\"},{\"name\":\"takerAssetData\",\"type\":\"bytes\"}],\"name\":\"order\",\"type\":\"tuple\"},{\"name\":\"takerAddress\",\"type\":\"address\"}],\"name\":\"getTraderInfo\",\"outputs\":[{\"components\":[{\"name\":\"makerBalance\",\"type\":\"uint256\"},{\"name\":\"makerAllowance\",\"type\":\"uint256\"},{\"name\":\"takerBalance\",\"type\":\"uint256\"},{\"name\":\"takerAllowance\",\"type\":\"uint256\"},{\"name\":\"makerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"makerZrxAllowance\",\"type\":\"uint256\"},{\"name\":\"takerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"takerZrxAllowance\",\"type\":\"uint256\"}],\"name\":\"traderInfo\",\"type\":\"tuple\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"components\":[{\"name\":\"makerAddress\",\"type\":\"address\"},{\"name\":\"takerAddress\",\"type\":\"address\"},{\"name\":\"feeRecipientAddress\",\"type\":\"address\"},{\"name\":\"senderAddress\",\"type\":\"address\"},{\"name\":\"makerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"takerAssetAmount\",\"type\":\"uint256\"},{\"name\":\"makerFee\",\"type\":\"uint256\"},{\"name\":\"takerFee\",\"type\":\"uint256\"},{\"name\":\"expirationTimeSeconds\",\"type\":\"uint256\"},{\"name\":\"salt\",\"type\":\"uint256\"},{\"name\":\"makerAssetData\",\"type\":\"bytes\"},{\"name\":\"takerAssetData\",\"type\":\"bytes\"}],\"name\":\"orders\",\"type\":\"tuple[]\"},{\"name\":\"signatures\",\"type\":\"bytes[]\"},{\"name\":\"takerAddresses\",\"type\":\"address[]\"}],\"name\":\"getOrdersAndTradersInfo\",\"outputs\":[{\"components\":[{\"name\":\"orderStatus\",\"type\":\"uint8\"},{\"name\":\"orderHash\",\"type\":\"bytes32\"},{\"name\":\"orderTakerAssetFilledAmount\",\"type\":\"uint256\"}],\"name\":\"ordersInfo\",\"type\":\"tuple[]\"},{\"components\":[{\"name\":\"makerBalance\",\"type\":\"uint256\"},{\"name\":\"makerAllowance\",\"type\":\"uint256\"},{\"name\":\"takerBalance\",\"type\":\"uint256\"},{\"name\":\"takerAllowance\",\"type\":\"uint256\"},{\"name\":\"makerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"makerZrxAllowance\",\"type\":\"uint256\"},{\"name\":\"takerZrxBalance\",\"type\":\"uint256\"},{\"name\":\"takerZrxAllowance\",\"type\":\"uint256\"}],\"name\":\"tradersInfo\",\"type\":\"tuple[]\"},{\"name\":\"isValidSignature\",\"type\":\"bool[]\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_exchange\",\"type\":\"address\"},{\"name\":\"_zrxAssetData\",\"type\":\"bytes\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"}]"
 
 // OrderValidator is an auto generated Go binding around an Ethereum contract.
 type OrderValidator struct {
@@ -174,8 +174,8 @@ func (_OrderValidator *OrderValidatorTransactorRaw) Transact(opts *bind.Transact
 	return _OrderValidator.Contract.contract.Transact(opts, method, params...)
 }
 
-// Struct1 is an auto-generated struct
-type Struct1 struct {
+// Struct0 is an auto generated low-level Go binding around an user-defined struct.
+type Struct0 struct {
 	MakerAddress          common.Address
 	TakerAddress          common.Address
 	FeeRecipientAddress   common.Address
@@ -190,8 +190,8 @@ type Struct1 struct {
 	TakerAssetData        []byte
 }
 
-// Struct2 is an auto-generated struct
-type Struct2 struct {
+// Struct1 is an auto generated low-level Go binding around an user-defined struct.
+type Struct1 struct {
 	MakerBalance      *big.Int
 	MakerAllowance    *big.Int
 	TakerBalance      *big.Int
@@ -202,8 +202,8 @@ type Struct2 struct {
 	TakerZrxAllowance *big.Int
 }
 
-// Struct3 is an auto-generated struct
-type Struct3 struct {
+// Struct2 is an auto generated low-level Go binding around an user-defined struct.
+type Struct2 struct {
 	OrderStatus                 uint8
 	OrderHash                   [32]byte
 	OrderTakerAssetFilledAmount *big.Int
@@ -301,84 +301,92 @@ func (_OrderValidator *OrderValidatorCallerSession) GetERC721TokenOwner(token co
 	return _OrderValidator.Contract.GetERC721TokenOwner(&_OrderValidator.CallOpts, token, tokenId)
 }
 
-// GetOrderAndTraderInfo is a free data retrieval call binding the contract method 0x04ad1e53.
+// GetOrderAndTraderInfo is a free data retrieval call binding the contract method 0xc6319fc5.
 //
-// Solidity: function getOrderAndTraderInfo(OrderWithoutExchangeAddress order, address takerAddress) constant returns(OrderInfo orderInfo, TraderInfo traderInfo)
-func (_OrderValidator *OrderValidatorCaller) GetOrderAndTraderInfo(opts *bind.CallOpts, order OrderWithoutExchangeAddress, takerAddress common.Address) (struct {
-	OrderInfo  OrderInfo
-	TraderInfo TraderInfo
+// Solidity: function getOrderAndTraderInfo(Struct0 order, bytes signature, address takerAddress) constant returns(Struct2 orderInfo, Struct1 traderInfo, bool isValidSignature)
+func (_OrderValidator *OrderValidatorCaller) GetOrderAndTraderInfo(opts *bind.CallOpts, order Struct0, signature []byte, takerAddress common.Address) (struct {
+	OrderInfo        Struct2
+	TraderInfo       Struct1
+	IsValidSignature bool
 }, error) {
 	ret := new(struct {
-		OrderInfo  OrderInfo
-		TraderInfo TraderInfo
+		OrderInfo        Struct2
+		TraderInfo       Struct1
+		IsValidSignature bool
 	})
 	out := ret
-	err := _OrderValidator.contract.Call(opts, out, "getOrderAndTraderInfo", order, takerAddress)
+	err := _OrderValidator.contract.Call(opts, out, "getOrderAndTraderInfo", order, signature, takerAddress)
 	return *ret, err
 }
 
-// GetOrderAndTraderInfo is a free data retrieval call binding the contract method 0x04ad1e53.
+// GetOrderAndTraderInfo is a free data retrieval call binding the contract method 0xc6319fc5.
 //
-// Solidity: function getOrderAndTraderInfo(OrderWithoutExchangeAddress order, address takerAddress) constant returns(OrderInfo orderInfo, TraderInfo traderInfo)
-func (_OrderValidator *OrderValidatorSession) GetOrderAndTraderInfo(order OrderWithoutExchangeAddress, takerAddress common.Address) (struct {
-	OrderInfo  OrderInfo
-	TraderInfo TraderInfo
+// Solidity: function getOrderAndTraderInfo(Struct0 order, bytes signature, address takerAddress) constant returns(Struct2 orderInfo, Struct1 traderInfo, bool isValidSignature)
+func (_OrderValidator *OrderValidatorSession) GetOrderAndTraderInfo(order Struct0, signature []byte, takerAddress common.Address) (struct {
+	OrderInfo        Struct2
+	TraderInfo       Struct1
+	IsValidSignature bool
 }, error) {
-	return _OrderValidator.Contract.GetOrderAndTraderInfo(&_OrderValidator.CallOpts, order, takerAddress)
+	return _OrderValidator.Contract.GetOrderAndTraderInfo(&_OrderValidator.CallOpts, order, signature, takerAddress)
 }
 
-// GetOrderAndTraderInfo is a free data retrieval call binding the contract method 0x04ad1e53.
+// GetOrderAndTraderInfo is a free data retrieval call binding the contract method 0xc6319fc5.
 //
-// Solidity: function getOrderAndTraderInfo(OrderWithoutExchangeAddress order, address takerAddress) constant returns(OrderInfo orderInfo, TraderInfo traderInfo)
-func (_OrderValidator *OrderValidatorCallerSession) GetOrderAndTraderInfo(order OrderWithoutExchangeAddress, takerAddress common.Address) (struct {
-	OrderInfo  OrderInfo
-	TraderInfo TraderInfo
+// Solidity: function getOrderAndTraderInfo(Struct0 order, bytes signature, address takerAddress) constant returns(Struct2 orderInfo, Struct1 traderInfo, bool isValidSignature)
+func (_OrderValidator *OrderValidatorCallerSession) GetOrderAndTraderInfo(order Struct0, signature []byte, takerAddress common.Address) (struct {
+	OrderInfo        Struct2
+	TraderInfo       Struct1
+	IsValidSignature bool
 }, error) {
-	return _OrderValidator.Contract.GetOrderAndTraderInfo(&_OrderValidator.CallOpts, order, takerAddress)
+	return _OrderValidator.Contract.GetOrderAndTraderInfo(&_OrderValidator.CallOpts, order, signature, takerAddress)
 }
 
-// GetOrdersAndTradersInfo is a free data retrieval call binding the contract method 0x4b95de13.
+// GetOrdersAndTradersInfo is a free data retrieval call binding the contract method 0xf7c1c03f.
 //
-// Solidity: function getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[] orders, address[] takerAddresses) constant returns((uint8,bytes32,uint256)[] ordersInfo, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)[] tradersInfo)
-func (_OrderValidator *OrderValidatorCaller) GetOrdersAndTradersInfo(opts *bind.CallOpts, orders []OrderWithoutExchangeAddress, takerAddresses []common.Address) (struct {
-	OrdersInfo  []OrderInfo
-	TradersInfo []TraderInfo
+// Solidity: function getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[] orders, bytes[] signatures, address[] takerAddresses) constant returns((uint8,bytes32,uint256)[] ordersInfo, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)[] tradersInfo, bool[] isValidSignature)
+func (_OrderValidator *OrderValidatorCaller) GetOrdersAndTradersInfo(opts *bind.CallOpts, orders []Struct0, signatures [][]byte, takerAddresses []common.Address) (struct {
+	OrdersInfo       []Struct2
+	TradersInfo      []Struct1
+	IsValidSignature []bool
 }, error) {
 	ret := new(struct {
-		OrdersInfo  []OrderInfo
-		TradersInfo []TraderInfo
+		OrdersInfo       []Struct2
+		TradersInfo      []Struct1
+		IsValidSignature []bool
 	})
 	out := ret
-	err := _OrderValidator.contract.Call(opts, out, "getOrdersAndTradersInfo", orders, takerAddresses)
+	err := _OrderValidator.contract.Call(opts, out, "getOrdersAndTradersInfo", orders, signatures, takerAddresses)
 	return *ret, err
 }
 
-// GetOrdersAndTradersInfo is a free data retrieval call binding the contract method 0x4b95de13.
+// GetOrdersAndTradersInfo is a free data retrieval call binding the contract method 0xf7c1c03f.
 //
-// Solidity: function getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[] orders, address[] takerAddresses) constant returns((uint8,bytes32,uint256)[] ordersInfo, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)[] tradersInfo)
-func (_OrderValidator *OrderValidatorSession) GetOrdersAndTradersInfo(orders []OrderWithoutExchangeAddress, takerAddresses []common.Address) (struct {
-	OrdersInfo  []OrderInfo
-	TradersInfo []TraderInfo
+// Solidity: function getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[] orders, bytes[] signatures, address[] takerAddresses) constant returns((uint8,bytes32,uint256)[] ordersInfo, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)[] tradersInfo, bool[] isValidSignature)
+func (_OrderValidator *OrderValidatorSession) GetOrdersAndTradersInfo(orders []Struct0, signatures [][]byte, takerAddresses []common.Address) (struct {
+	OrdersInfo       []Struct2
+	TradersInfo      []Struct1
+	IsValidSignature []bool
 }, error) {
-	return _OrderValidator.Contract.GetOrdersAndTradersInfo(&_OrderValidator.CallOpts, orders, takerAddresses)
+	return _OrderValidator.Contract.GetOrdersAndTradersInfo(&_OrderValidator.CallOpts, orders, signatures, takerAddresses)
 }
 
-// GetOrdersAndTradersInfo is a free data retrieval call binding the contract method 0x4b95de13.
+// GetOrdersAndTradersInfo is a free data retrieval call binding the contract method 0xf7c1c03f.
 //
-// Solidity: function getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[] orders, address[] takerAddresses) constant returns((uint8,bytes32,uint256)[] ordersInfo, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)[] tradersInfo)
-func (_OrderValidator *OrderValidatorCallerSession) GetOrdersAndTradersInfo(orders []OrderWithoutExchangeAddress, takerAddresses []common.Address) (struct {
-	OrdersInfo  []OrderInfo
-	TradersInfo []TraderInfo
+// Solidity: function getOrdersAndTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[] orders, bytes[] signatures, address[] takerAddresses) constant returns((uint8,bytes32,uint256)[] ordersInfo, (uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)[] tradersInfo, bool[] isValidSignature)
+func (_OrderValidator *OrderValidatorCallerSession) GetOrdersAndTradersInfo(orders []Struct0, signatures [][]byte, takerAddresses []common.Address) (struct {
+	OrdersInfo       []Struct2
+	TradersInfo      []Struct1
+	IsValidSignature []bool
 }, error) {
-	return _OrderValidator.Contract.GetOrdersAndTradersInfo(&_OrderValidator.CallOpts, orders, takerAddresses)
+	return _OrderValidator.Contract.GetOrdersAndTradersInfo(&_OrderValidator.CallOpts, orders, signatures, takerAddresses)
 }
 
 // GetTraderInfo is a free data retrieval call binding the contract method 0xf241ffb0.
 //
-// Solidity: function getTraderInfo(OrderWithoutExchangeAddress order, address takerAddress) constant returns(TraderInfo traderInfo)
-func (_OrderValidator *OrderValidatorCaller) GetTraderInfo(opts *bind.CallOpts, order OrderWithoutExchangeAddress, takerAddress common.Address) (TraderInfo, error) {
+// Solidity: function getTraderInfo(Struct0 order, address takerAddress) constant returns(Struct1 traderInfo)
+func (_OrderValidator *OrderValidatorCaller) GetTraderInfo(opts *bind.CallOpts, order Struct0, takerAddress common.Address) (Struct1, error) {
 	var (
-		ret0 = new(TraderInfo)
+		ret0 = new(Struct1)
 	)
 	out := ret0
 	err := _OrderValidator.contract.Call(opts, out, "getTraderInfo", order, takerAddress)
@@ -387,24 +395,24 @@ func (_OrderValidator *OrderValidatorCaller) GetTraderInfo(opts *bind.CallOpts, 
 
 // GetTraderInfo is a free data retrieval call binding the contract method 0xf241ffb0.
 //
-// Solidity: function getTraderInfo(OrderWithoutExchangeAddress order, address takerAddress) constant returns(TraderInfo traderInfo)
-func (_OrderValidator *OrderValidatorSession) GetTraderInfo(order OrderWithoutExchangeAddress, takerAddress common.Address) (TraderInfo, error) {
+// Solidity: function getTraderInfo(Struct0 order, address takerAddress) constant returns(Struct1 traderInfo)
+func (_OrderValidator *OrderValidatorSession) GetTraderInfo(order Struct0, takerAddress common.Address) (Struct1, error) {
 	return _OrderValidator.Contract.GetTraderInfo(&_OrderValidator.CallOpts, order, takerAddress)
 }
 
 // GetTraderInfo is a free data retrieval call binding the contract method 0xf241ffb0.
 //
-// Solidity: function getTraderInfo(OrderWithoutExchangeAddress order, address takerAddress) constant returns(TraderInfo traderInfo)
-func (_OrderValidator *OrderValidatorCallerSession) GetTraderInfo(order OrderWithoutExchangeAddress, takerAddress common.Address) (TraderInfo, error) {
+// Solidity: function getTraderInfo(Struct0 order, address takerAddress) constant returns(Struct1 traderInfo)
+func (_OrderValidator *OrderValidatorCallerSession) GetTraderInfo(order Struct0, takerAddress common.Address) (Struct1, error) {
 	return _OrderValidator.Contract.GetTraderInfo(&_OrderValidator.CallOpts, order, takerAddress)
 }
 
 // GetTradersInfo is a free data retrieval call binding the contract method 0x690d3114.
 //
 // Solidity: function getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[] orders, address[] takerAddresses) constant returns((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)[])
-func (_OrderValidator *OrderValidatorCaller) GetTradersInfo(opts *bind.CallOpts, orders []OrderWithoutExchangeAddress, takerAddresses []common.Address) ([]TraderInfo, error) {
+func (_OrderValidator *OrderValidatorCaller) GetTradersInfo(opts *bind.CallOpts, orders []Struct0, takerAddresses []common.Address) ([]Struct1, error) {
 	var (
-		ret0 = new([]TraderInfo)
+		ret0 = new([]Struct1)
 	)
 	out := ret0
 	err := _OrderValidator.contract.Call(opts, out, "getTradersInfo", orders, takerAddresses)
@@ -414,13 +422,13 @@ func (_OrderValidator *OrderValidatorCaller) GetTradersInfo(opts *bind.CallOpts,
 // GetTradersInfo is a free data retrieval call binding the contract method 0x690d3114.
 //
 // Solidity: function getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[] orders, address[] takerAddresses) constant returns((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)[])
-func (_OrderValidator *OrderValidatorSession) GetTradersInfo(orders []OrderWithoutExchangeAddress, takerAddresses []common.Address) ([]TraderInfo, error) {
+func (_OrderValidator *OrderValidatorSession) GetTradersInfo(orders []Struct0, takerAddresses []common.Address) ([]Struct1, error) {
 	return _OrderValidator.Contract.GetTradersInfo(&_OrderValidator.CallOpts, orders, takerAddresses)
 }
 
 // GetTradersInfo is a free data retrieval call binding the contract method 0x690d3114.
 //
 // Solidity: function getTradersInfo((address,address,address,address,uint256,uint256,uint256,uint256,uint256,uint256,bytes,bytes)[] orders, address[] takerAddresses) constant returns((uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256)[])
-func (_OrderValidator *OrderValidatorCallerSession) GetTradersInfo(orders []OrderWithoutExchangeAddress, takerAddresses []common.Address) ([]TraderInfo, error) {
+func (_OrderValidator *OrderValidatorCallerSession) GetTradersInfo(orders []Struct0, takerAddresses []common.Address) ([]Struct1, error) {
 	return _OrderValidator.Contract.GetTradersInfo(&_OrderValidator.CallOpts, orders, takerAddresses)
 }

--- a/ethereum/wrappers/order_validator_aliases.go
+++ b/ethereum/wrappers/order_validator_aliases.go
@@ -4,10 +4,10 @@ package wrappers
 // contract ABI so we add type aliases here to correct the struct names.
 
 // OrderWithoutExchangeAddress is a 0x order representation expected by the smart contracts.
-type OrderWithoutExchangeAddress = Struct1
+type OrderWithoutExchangeAddress = Struct0
 
 // TraderInfo contains all the order-relevant trader balances & allowances.
-type TraderInfo = Struct2
+type TraderInfo = Struct1
 
 // OrderInfo contains the status and filled amount of an order.
-type OrderInfo = Struct3
+type OrderInfo = Struct2

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -25,6 +25,7 @@ const (
 	Expired
 	FullyFilled
 	Cancelled
+	SignatureInvalid
 )
 
 // Order represents an unsigned 0x order

--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -44,7 +44,7 @@ func TestECSignOrder(t *testing.T) {
 	fakeExchangeContractAddress := common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c48")
 
 	order := Order{
-		MakerAddress:          common.HexToAddress("0x5409ed021d9299bf6814279a6a1411a7e866a631"),
+		MakerAddress:          constants.GanacheAccount0,
 		TakerAddress:          constants.NullAddress,
 		SenderAddress:         constants.NullAddress,
 		FeeRecipientAddress:   constants.NullAddress,


### PR DESCRIPTION
This PR:
- Updates the Ganache snapshot we use to a version that includes a modified OrderValidator.sol contract with 0x signature validation added to `getOrderInfo()` and `getOrdersAndTradersInfo()` (which is the one we use to do batch order validation).
- Re-generates the OrderValidator contract wrapper to correspond to the updated contract.
- Refactors `BatchValidate` to call the new method, supplying the order signatures and checking the return value for invalid signatures.
- Adds a `BatchValidate` test to make sure it properly reports orders with invalid signatures.