### PR TITLE
Remove verbose flag when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ test-all: test-go test-wasm
 
 .PHONY: test-go
 test-go:
-	go test ./... -v -race
+	go test ./... -race
 
 
 .PHONY: test-wasm
 test-wasm:
-	export ZEROEX_MESH_ROOT_DIR=$$(pwd); GOOS=js GOARCH=wasm go test -exec="$$ZEROEX_MESH_ROOT_DIR/test-wasm/go_js_wasm_exec" ./... -v
+	export ZEROEX_MESH_ROOT_DIR=$$(pwd); GOOS=js GOARCH=wasm go test -exec="$$ZEROEX_MESH_ROOT_DIR/test-wasm/go_js_wasm_exec" ./...
 
 
 .PHONY: lint


### PR DESCRIPTION
IMO the tests are getting too noisy and it is sometimes difficult to understand what went wrong when a test fails. When I was originally experimenting with adding the Wasm tests, it was helpful to use the `-v` flag to make sure all the tests were running as intended. At this point, I don't think it's necessary.