### PR TITLE
Fix bug in db.Index.ValueFilter

### DIFF
--- a/db/query.go
+++ b/db/query.go
@@ -53,7 +53,7 @@ func (q *Query) Reverse() *Query {
 // ValueFilter returns a Filter which will match all models with an index value
 // equal to the given value.
 func (index *Index) ValueFilter(val []byte) *Filter {
-	prefix := []byte(fmt.Sprintf("%s:%s", index.prefix(), escape(val)))
+	prefix := []byte(fmt.Sprintf("%s:%s:", index.prefix(), escape(val)))
 	return &Filter{
 		index: index,
 		slice: util.BytesPrefix(prefix),

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -38,6 +38,13 @@ func TestQueryWithValue(t *testing.T) {
 		require.NoError(t, col.Insert(model))
 	}
 
+	// Save one more model with an Age that is a prefix of the target age.
+	model := &testModel{
+		Name: "PersonWithPrefixAge",
+		Age:  420,
+	}
+	require.NoError(t, col.Insert(model))
+
 	filter := ageIndex.ValueFilter([]byte("42"))
 	testQueryWithFilter(t, col, filter, expected)
 }


### PR DESCRIPTION
The bug was causing queries constructed with ValueFilter to also return any model where the target value was a prefix of the index value. So e.g., a query using `ValueFilter("foo")` would return models with a value of "foobar".