### PR TITLE
Add support for a new Query.Count method

### DIFF
--- a/db/query_test.go
+++ b/db/query_test.go
@@ -276,8 +276,11 @@ func testQueryWithFilter(t *testing.T, col *Collection, filter *Filter, expected
 
 	for i, tc := range testCases {
 		var actual []*testModel
-		require.NoError(t, tc.query.Run(&actual))
+		require.NoError(t, tc.query.Run(&actual), "test case %d", i)
 		assert.Equal(t, tc.expected, actual, "test case %d", i)
+		actualCount, err := tc.query.Count()
+		require.NoError(t, err, "test case %d", i)
+		assert.Equal(t, len(tc.expected), actualCount, "test case %d", i)
 	}
 }
 


### PR DESCRIPTION
This feature is going to be necessary in order to tackle #73.