### PR TITLE
rpc: Refactor `AddOrder` to `AddOrders`

### DIFF
--- a/cmd/demo/add_order/main.go
+++ b/cmd/demo/add_order/main.go
@@ -61,10 +61,10 @@ func main() {
 		log.WithError(err).Fatal("could not sign 0x order")
 	}
 
-	hash, err := client.AddOrder(signedTestOrder)
+	orderHashToSuccinctOrderInfo, err := client.AddOrders([]*zeroex.SignedOrder{signedTestOrder})
 	if err != nil {
 		log.WithError(err).Fatal("error from AddOrder")
 	} else {
-		log.Printf("added valid order: %s", hash.Hex())
+		log.Printf("submitted %d orders", len(orderHashToSuccinctOrderInfo))
 	}
 }

--- a/cmd/demo/add_order/main.go
+++ b/cmd/demo/add_order/main.go
@@ -61,10 +61,11 @@ func main() {
 		log.WithError(err).Fatal("could not sign 0x order")
 	}
 
-	orderHashToSuccinctOrderInfo, err := client.AddOrders([]*zeroex.SignedOrder{signedTestOrder})
+	signedTestOrders := []*zeroex.SignedOrder{signedTestOrder}
+	addOrdersResponse, err := client.AddOrders(signedTestOrders)
 	if err != nil {
 		log.WithError(err).Fatal("error from AddOrder")
 	} else {
-		log.Printf("submitted %d orders", len(orderHashToSuccinctOrderInfo))
+		log.Printf("submitted %d orders. Added: %d, Invalid: %d, FailedToAdd: %d", len(signedTestOrders), len(addOrdersResponse.Added), len(addOrdersResponse.Invalid), len(addOrdersResponse.FailedToAdd))
 	}
 }

--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -42,23 +42,16 @@ func listenRPC(app *core.App, config standaloneConfig) error {
 	return rpcServer.Listen()
 }
 
-// AddOrder is called when an RPC client calls AddOrder.
-func (handler *rpcHandler) AddOrder(order *zeroex.SignedOrder) error {
-	log.Debug("received AddOrder request via RPC")
-	if err := handler.app.AddOrder(order); err != nil {
-		if err == core.ErrInvalidOrder {
-			// If the order is invalid, we want to communicate the error back to the
-			// RPC client.
-			log.WithField("order", order).Warn("received invalid order via RPC")
-			return err
-		} else {
-			// All other error types are considered internal errors. We don't need to
-			// leak details to the RPC client.
-			log.WithField("error", err.Error()).Error("internal error in AddOrder RPC call")
-			return errInternal
-		}
+// AddOrders is called when an RPC client calls AddOrders.
+func (handler *rpcHandler) AddOrders(orders []*zeroex.SignedOrder) (zeroex.OrderHashToSuccinctOrderInfo, error) {
+	log.Debug("received AddOrders request via RPC")
+	orderHashToSuccinctOrderInfo, err := handler.app.AddOrders(orders)
+	if err != nil {
+		// We don't want to leak internal error details to the RPC client.
+		log.WithField("error", err.Error()).Error("internal error in AddOrders RPC call")
+		return nil, errInternal
 	}
-	return nil
+	return orderHashToSuccinctOrderInfo, nil
 }
 
 // AddPeer is called when an RPC client calls AddPeer,

--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -43,15 +43,15 @@ func listenRPC(app *core.App, config standaloneConfig) error {
 }
 
 // AddOrders is called when an RPC client calls AddOrders.
-func (handler *rpcHandler) AddOrders(orders []*zeroex.SignedOrder) (zeroex.OrderHashToSuccinctOrderInfo, error) {
+func (handler *rpcHandler) AddOrders(orders []*zeroex.SignedOrder) (*rpc.AddOrdersResponse, error) {
 	log.Debug("received AddOrders request via RPC")
-	orderHashToSuccinctOrderInfo, err := handler.app.AddOrders(orders)
+	addOrdersResponse, err := handler.app.AddOrders(orders)
 	if err != nil {
 		// We don't want to leak internal error details to the RPC client.
 		log.WithField("error", err.Error()).Error("internal error in AddOrders RPC call")
 		return nil, errInternal
 	}
-	return orderHashToSuccinctOrderInfo, nil
+	return addOrdersResponse, nil
 }
 
 // AddPeer is called when an RPC client calls AddPeer,

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -1,8 +1,9 @@
 package rpc
 
 import (
+	"encoding/json"
+
 	"github.com/0xProject/0x-mesh/zeroex"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	peer "github.com/libp2p/go-libp2p-peer"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
@@ -26,14 +27,19 @@ func NewClient(addr string) (*Client, error) {
 	}, nil
 }
 
-// AddOrder adds the order to the 0x Mesh node and broadcasts it throughout the
+// AddOrders adds orders to the 0x Mesh node and broadcasts them throughout the
 // 0x Mesh network.
-func (c *Client) AddOrder(order *zeroex.SignedOrder) (common.Hash, error) {
-	var orderHashHex string
-	if err := c.rpcClient.Call(&orderHashHex, "mesh_addOrder", order); err != nil {
-		return common.Hash{}, err
+func (c *Client) AddOrders(orders []*zeroex.SignedOrder) (zeroex.OrderHashToSuccinctOrderInfo, error) {
+	var orderHashToSuccinctOrderInfoJSON string
+	if err := c.rpcClient.Call(&orderHashToSuccinctOrderInfoJSON, "mesh_addOrders", orders); err != nil {
+		return nil, err
 	}
-	return common.HexToHash(orderHashHex), nil
+	var orderHashToSuccinctOrderInfo zeroex.OrderHashToSuccinctOrderInfo
+	err := json.Unmarshal([]byte(orderHashToSuccinctOrderInfoJSON), &orderHashToSuccinctOrderInfo)
+	if err != nil {
+		return nil, err
+	}
+	return orderHashToSuccinctOrderInfo, nil
 }
 
 // AddPeer adds the peer to the node's list of peers. The node will attempt to

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -29,17 +29,17 @@ func NewClient(addr string) (*Client, error) {
 
 // AddOrders adds orders to the 0x Mesh node and broadcasts them throughout the
 // 0x Mesh network.
-func (c *Client) AddOrders(orders []*zeroex.SignedOrder) (zeroex.OrderHashToSuccinctOrderInfo, error) {
-	var orderHashToSuccinctOrderInfoJSON string
-	if err := c.rpcClient.Call(&orderHashToSuccinctOrderInfoJSON, "mesh_addOrders", orders); err != nil {
+func (c *Client) AddOrders(orders []*zeroex.SignedOrder) (*AddOrdersResponse, error) {
+	var addOrdersResponseJSON string
+	if err := c.rpcClient.Call(&addOrdersResponseJSON, "mesh_addOrders", orders); err != nil {
 		return nil, err
 	}
-	var orderHashToSuccinctOrderInfo zeroex.OrderHashToSuccinctOrderInfo
-	err := json.Unmarshal([]byte(orderHashToSuccinctOrderInfoJSON), &orderHashToSuccinctOrderInfo)
+	var addOrdersResponse AddOrdersResponse
+	err := json.Unmarshal([]byte(addOrdersResponseJSON), &addOrdersResponse)
 	if err != nil {
 		return nil, err
 	}
-	return orderHashToSuccinctOrderInfo, nil
+	return &addOrdersResponse, nil
 }
 
 // AddPeer adds the peer to the node's list of peers. The node will attempt to

--- a/rpc/client_server_test.go
+++ b/rpc/client_server_test.go
@@ -91,7 +91,7 @@ func TestAddOrdersSuccess(t *testing.T) {
 	signedTestOrders := []*zeroex.SignedOrder{signedTestOrder}
 
 	expectedOrderStatus := zeroex.Fillable
-	expectedFillableTakerAssetAmount := signedOrder.TakerAssetAmount
+	expectedFillableTakerAssetAmount := signedTestOrder.TakerAssetAmount
 
 	// Set up the dummy handler with an addOrdersHandler
 	wg := &sync.WaitGroup{}
@@ -105,8 +105,8 @@ func TestAddOrdersSuccess(t *testing.T) {
 				require.NoError(t, err)
 				addOrdersResponse.Added = append(addOrdersResponse.Added, &zeroex.SuccinctOrderInfo{
 					OrderHash:                orderHash,
-					OrderStatus:              expectedOrderStatus,
-					FillableTakerAssetAmount: expectedFillableTakerAssetAmount,
+					OrderStatus:              zeroex.Fillable,
+					FillableTakerAssetAmount: signedOrder.TakerAssetAmount,
 				})
 			}
 			wg.Done()

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -17,19 +17,19 @@ type rpcService struct {
 // RPCHandler is used to respond to incoming requests from the client.
 type RPCHandler interface {
 	// AddOrders is called when the client sends an AddOrders request.
-	AddOrders(orders []*zeroex.SignedOrder) (zeroex.OrderHashToSuccinctOrderInfo, error)
+	AddOrders(orders []*zeroex.SignedOrder) (*AddOrdersResponse, error)
 	// AddPeer is called when the client sends an AddPeer request.
 	AddPeer(peerInfo peerstore.PeerInfo) error
 }
 
 // AddOrders calls rpcHandler.AddOrders and returns the SuccinctOrderInfo for each order.
 func (s *rpcService) AddOrders(orders []*zeroex.SignedOrder) (string, error) {
-	orderHashToSuccinctOrderInfo, err := s.rpcHandler.AddOrders(orders)
+	addOrdersResponse, err := s.rpcHandler.AddOrders(orders)
 	if err != nil {
 		return "", err
 	}
-	orderHashToSuccinctOrderInfoBytes, err := json.Marshal(orderHashToSuccinctOrderInfo)
-	return string(orderHashToSuccinctOrderInfoBytes), nil
+	addOrdersResponseBytes, err := json.Marshal(addOrdersResponse)
+	return string(addOrdersResponseBytes), nil
 }
 
 // AddOrder builds PeerInfo out of the given peer ID and multiaddresses and

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -1,7 +1,6 @@
 package rpc
 
 import (
-	"context"
 	"encoding/json"
 
 	"github.com/0xProject/0x-mesh/zeroex"

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -1,6 +1,9 @@
 package rpc
 
 import (
+	"context"
+	"encoding/json"
+
 	"github.com/0xProject/0x-mesh/zeroex"
 	peer "github.com/libp2p/go-libp2p-peer"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
@@ -14,23 +17,20 @@ type rpcService struct {
 
 // RPCHandler is used to respond to incoming requests from the client.
 type RPCHandler interface {
-	// AddOrder is called when the client sends an AddOrder request.
-	AddOrder(order *zeroex.SignedOrder) error
+	// AddOrders is called when the client sends an AddOrders request.
+	AddOrders(orders []*zeroex.SignedOrder) (zeroex.OrderHashToSuccinctOrderInfo, error)
 	// AddPeer is called when the client sends an AddPeer request.
 	AddPeer(peerInfo peerstore.PeerInfo) error
 }
 
-// AddOrder calls rpcHandler.AddOrder and returns the computed order hash.
-// TODO(albrow): Add the ability to send multiple orders at once.
-func (s *rpcService) AddOrder(order *zeroex.SignedOrder) (orderHashHex string, err error) {
-	orderHash, err := order.ComputeOrderHash()
+// AddOrders calls rpcHandler.AddOrders and returns the SuccinctOrderInfo for each order.
+func (s *rpcService) AddOrders(orders []*zeroex.SignedOrder) (string, error) {
+	orderHashToSuccinctOrderInfo, err := s.rpcHandler.AddOrders(orders)
 	if err != nil {
 		return "", err
 	}
-	if err := s.rpcHandler.AddOrder(order); err != nil {
-		return "", err
-	}
-	return orderHash.Hex(), nil
+	orderHashToSuccinctOrderInfoBytes, err := json.Marshal(orderHashToSuccinctOrderInfo)
+	return string(orderHashToSuccinctOrderInfoBytes), nil
 }
 
 // AddOrder builds PeerInfo out of the given peer ID and multiaddresses and

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -1,0 +1,13 @@
+package rpc
+
+import (
+	"github.com/0xProject/0x-mesh/zeroex"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// AddOrdersResponse is the response returned to the `AddOrders` request
+type AddOrdersResponse struct {
+	Added       []*zeroex.SuccinctOrderInfo
+	Invalid     []*zeroex.SuccinctOrderInfo
+	FailedToAdd []common.Hash
+}

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -45,6 +45,17 @@ type OrderInfo struct {
 	OrderStatus              OrderStatus
 }
 
+// SuccinctOrderInfo represents the necessary information about an order without including
+// the order itself
+type SuccinctOrderInfo struct {
+	OrderHash                common.Hash
+	FillableTakerAssetAmount *big.Int
+	OrderStatus              OrderStatus
+}
+
+// OrderHashToSuccinctOrderInfo maps orderHashes to their corresponding succinctOrderInfo
+type OrderHashToSuccinctOrderInfo map[common.Hash]*SuccinctOrderInfo
+
 // OrderValidator validates 0x orders
 type OrderValidator struct {
 	orderValidator *wrappers.OrderValidator


### PR DESCRIPTION
Completes: https://github.com/0xProject/0x-mesh/issues/88

Since the caller now submits multiple orders in a single call, this method's return value is of type:

```
type AddOrdersResponse struct {
	Added       []*zeroex.SuccinctOrderInfo
	Invalid     []*zeroex.SuccinctOrderInfo
	FailedToAdd []common.Hash
}
```

Why? 

- `Added`: Some orders pass the order validation test and are added to Mesh.
- `Invalid`: Some order are not added to Mesh because they fail the order validation test. By letting the client know, they can also drop those orders from their data store.
- `Failed`: Some orders are not added to Mesh if the network request to validate them fails unexpectedly. By letting the client know, they can then try and add those orders again in a new request.
