### PR TITLE
DO NOT MERGE: Stress testing order watching logic

### DIFF
--- a/cmd/demo/add_order/main.go
+++ b/cmd/demo/add_order/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"math/big"
+	"os"
 	"time"
 
 	"github.com/0xProject/0x-mesh/constants"
@@ -43,6 +44,8 @@ var testOrder = &zeroex.Order{
 }
 
 func main() {
+	log.SetOutput(os.Stdout)
+
 	env := clientEnvVars{}
 	if err := envvar.Parse(&env); err != nil {
 		panic(err)

--- a/cmd/demo/add_order/main.go
+++ b/cmd/demo/add_order/main.go
@@ -70,6 +70,7 @@ func main() {
 	if err != nil {
 		log.WithError(err).Fatal("could not sign 0x order")
 	}
+	orderHash, _ := signedTestOrder.ComputeOrderHash()
 
 	signedTestOrders := []*zeroex.SignedOrder{signedTestOrder}
 	addOrdersResponse, err := client.AddOrders(signedTestOrders)

--- a/cmd/demo/add_order/main.go
+++ b/cmd/demo/add_order/main.go
@@ -73,7 +73,6 @@ func main() {
 	if err != nil {
 		log.WithError(err).Fatal("could not sign 0x order")
 	}
-	orderHash, _ := signedTestOrder.ComputeOrderHash()
 
 	signedTestOrders := []*zeroex.SignedOrder{signedTestOrder}
 	addOrdersResponse, err := client.AddOrders(signedTestOrders)

--- a/cmd/demo/sra_bridge/main.go
+++ b/cmd/demo/sra_bridge/main.go
@@ -1,0 +1,226 @@
+// +build !js
+
+// demo/sra_bridge is a short program that fetches orders from the RadarRelay SRA endpoint
+// and dumps them into a Mesh node which watching the order event stream.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/0xProject/0x-mesh/rpc"
+	"github.com/0xProject/0x-mesh/zeroex"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/plaid/go-envvar/envvar"
+	log "github.com/sirupsen/logrus"
+)
+
+type clientEnvVars struct {
+	// RPCAddress is the address of the 0x Mesh node to communicate with.
+	RPCAddress string `envvar:"RPC_ADDRESS"`
+}
+
+func main() {
+	env := clientEnvVars{}
+	if err := envvar.Parse(&env); err != nil {
+		panic(err)
+	}
+
+	client, err := rpc.NewClient(env.RPCAddress)
+	if err != nil {
+		log.WithError(err).Fatal("could not create client")
+	}
+
+	ctx := context.Background()
+	orderInfosChan := make(chan []*zeroex.OrderInfo, 8000)
+	clientSubscription, err := client.SubscribeToOrderStream(ctx, orderInfosChan)
+	if err != nil {
+		log.WithError(err).Fatal("Couldn't set up OrderStream subscription")
+	}
+
+	go func() {
+		for {
+			select {
+			case orderInfos := <-orderInfosChan:
+				for _, orderInfo := range orderInfos {
+					var orderStatus string
+					switch orderInfo.OrderStatus {
+					case zeroex.Invalid:
+						orderStatus = "Invalid"
+					case zeroex.Fillable:
+						orderStatus = "Fillable"
+					case zeroex.Expired:
+						orderStatus = "Expired"
+					case zeroex.FullyFilled:
+						orderStatus = "FullyFilled"
+					case zeroex.Cancelled:
+						orderStatus = "Cancelled"
+					case zeroex.SignatureInvalid:
+						orderStatus = "SignatureInvalid"
+					case zeroex.InvalidMakerAssetAmount:
+						orderStatus = "InvalidMakerAssetAmount"
+					case zeroex.InvalidTakerAssetAmount:
+						orderStatus = "InvalidTakerAssetAmount"
+					}
+					log.Printf("Order event: Hash: %s status: %s remaining: %d\n", orderInfo.OrderHash.Hex(), orderStatus, orderInfo.FillableTakerAssetAmount)
+				}
+			}
+		}
+
+		clientSubscription.Unsubscribe()
+	}()
+
+	orderHashToWasSeen := map[common.Hash]bool{}
+	ticker := time.NewTicker(20 * time.Second)
+	chunkSize := 200
+	for {
+		signedOrders := getRadarOrders()
+		unseenSignedOrder := []*zeroex.SignedOrder{}
+		for _, signedorder := range signedOrders {
+			orderHash, _ := signedorder.ComputeOrderHash()
+			if _, ok := orderHashToWasSeen[orderHash]; !ok {
+				orderHashToWasSeen[orderHash] = true
+				unseenSignedOrder = append(unseenSignedOrder, signedorder)
+			}
+		}
+		fmt.Println("Found", len(unseenSignedOrder), " new orders!")
+		chunks := [][]*zeroex.SignedOrder{}
+		for len(unseenSignedOrder) > chunkSize {
+			chunks = append(chunks, unseenSignedOrder[:chunkSize])
+			unseenSignedOrder = unseenSignedOrder[chunkSize:]
+		}
+		if len(unseenSignedOrder) > 0 {
+			chunks = append(chunks, unseenSignedOrder)
+		}
+
+		for _, chunk := range chunks {
+			orderHashToSuccinctOrderInfo, err := client.AddOrders(chunk)
+			if err != nil {
+				log.WithError(err).Fatal("error from AddOrder")
+			} else {
+				log.Printf("submitted %d orders", len(orderHashToSuccinctOrderInfo))
+				invalidOrderHashes := []common.Hash{}
+				for orderHash, succinctOrderInfo := range orderHashToSuccinctOrderInfo {
+					if succinctOrderInfo.FillableTakerAssetAmount == big.NewInt(0) {
+						invalidOrderHashes = append(invalidOrderHashes, orderHash)
+					}
+				}
+				log.Println(len(invalidOrderHashes), "invalid orders found:", invalidOrderHashes)
+			}
+		}
+
+		<-ticker.C
+	}
+}
+
+var radarRelaySRAEndpoint = "https://api.radarrelay.com/0x/v2"
+
+const perPage = 1000
+const networkID = 1
+
+type ordersResponse struct {
+	Total   int         `json:"total"`
+	Page    int         `json:"page"`
+	PerPage int         `json:"perPage"`
+	Records []orderData `json:"records"`
+}
+
+type orderData struct {
+	Order wireOrder `json:"order"`
+}
+
+type wireOrder struct {
+	MakerAddress          string `json:"makerAddress"`
+	MakerAssetData        string `json:"makerAssetData"`
+	MakerAssetAmount      string `json:"makerAssetAmount"`
+	MakerFee              string `json:"makerFee"`
+	TakerAddress          string `json:"takerAddress"`
+	TakerAssetData        string `json:"takerAssetData"`
+	TakerAssetAmount      string `json:"takerAssetAmount"`
+	TakerFee              string `json:"takerFee"`
+	SenderAddress         string `json:"senderAddress"`
+	ExchangeAddress       string `json:"exchangeAddress"`
+	FeeRecipientAddress   string `json:"feeRecipientAddress"`
+	ExpirationTimeSeconds string `json:"expirationTimeSeconds"`
+	Salt                  string `json:"salt"`
+	Signature             string `json:"signature"`
+}
+
+func (w *wireOrder) convertToSignedOrder() *zeroex.SignedOrder {
+	makerAssetAmount, ok := math.ParseBig256(w.MakerAssetAmount)
+	if !ok {
+		panic("Failed to parse makerAssetAmount")
+	}
+	takerAssetAmount, ok := math.ParseBig256(w.TakerAssetAmount)
+	if !ok {
+		panic("Failed to parse takerAssetAmount")
+	}
+	makerFee, ok := math.ParseBig256(w.MakerFee)
+	if !ok {
+		panic("Failed to parse makerFee")
+	}
+	takerFee, ok := math.ParseBig256(w.TakerFee)
+	if !ok {
+		panic("Failed to parse takerFee")
+	}
+	salt, ok := math.ParseBig256(w.Salt)
+	if !ok {
+		panic("Failed to parse salt")
+	}
+	expirationTimeSeconds, ok := math.ParseBig256(w.ExpirationTimeSeconds)
+	if !ok {
+		panic("Failed to parse expirationTimeSeconds")
+	}
+	return &zeroex.SignedOrder{
+		Order: &zeroex.Order{
+			MakerAddress:          common.HexToAddress(w.MakerAddress),
+			MakerAssetData:        common.Hex2Bytes(w.MakerAssetData[2:]),
+			MakerAssetAmount:      makerAssetAmount,
+			MakerFee:              makerFee,
+			TakerAddress:          common.HexToAddress(w.TakerAddress),
+			TakerAssetData:        common.Hex2Bytes(w.TakerAssetData[2:]),
+			TakerAssetAmount:      takerAssetAmount,
+			TakerFee:              takerFee,
+			SenderAddress:         common.HexToAddress(w.SenderAddress),
+			ExchangeAddress:       common.HexToAddress(w.ExchangeAddress),
+			FeeRecipientAddress:   common.HexToAddress(w.FeeRecipientAddress),
+			ExpirationTimeSeconds: expirationTimeSeconds,
+			Salt:                  salt,
+		},
+		Signature: common.Hex2Bytes(w.Signature[2:]),
+	}
+}
+
+func getRadarOrders() []*zeroex.SignedOrder {
+	requestURL := fmt.Sprintf("%s/%s?networkId=%d&perPage=%d", radarRelaySRAEndpoint, "orders", networkID, perPage)
+	resp, err := http.Get(requestURL)
+	if err != nil {
+		log.WithError(err).Fatal("Couldn't fetch orders from RadarRelay")
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		log.WithFields(map[string]interface{}{
+			"statusCode": resp.StatusCode,
+			"body":       string(body),
+		}).Fatal("Got non-200 status code back from RadarRelay")
+	}
+	var ordersResponse ordersResponse
+	err = json.Unmarshal(body, &ordersResponse)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to parse body into OrdersResponse struct")
+	}
+
+	signedOrders := []*zeroex.SignedOrder{}
+	for _, record := range ordersResponse.Records {
+		signedOrder := record.Order.convertToSignedOrder()
+		signedOrders = append(signedOrders, signedOrder)
+	}
+	return signedOrders
+}

--- a/cmd/demo/sra_bridge/main.go
+++ b/cmd/demo/sra_bridge/main.go
@@ -106,10 +106,10 @@ func main() {
 				log.WithError(err).Fatal("error from AddOrder")
 			} else {
 				log.Printf("submitted %d orders", len(orderHashToSuccinctOrderInfo))
-				invalidOrderHashes := []common.Hash{}
+				invalidOrderHashes := []string{}
 				for orderHash, succinctOrderInfo := range orderHashToSuccinctOrderInfo {
-					if succinctOrderInfo.FillableTakerAssetAmount == big.NewInt(0) {
-						invalidOrderHashes = append(invalidOrderHashes, orderHash)
+					if succinctOrderInfo.FillableTakerAssetAmount.Cmp(big.NewInt(0)) == 0 {
+						invalidOrderHashes = append(invalidOrderHashes, orderHash.Hex())
 					}
 				}
 				log.Println(len(invalidOrderHashes), "invalid orders found:", invalidOrderHashes)

--- a/cmd/demo/sra_bridge/main.go
+++ b/cmd/demo/sra_bridge/main.go
@@ -40,6 +40,7 @@ func main() {
 	ctx := context.Background()
 	orderInfosChan := make(chan []*zeroex.OrderInfo, 8000)
 	clientSubscription, err := client.SubscribeToOrderStream(ctx, orderInfosChan)
+	_ = clientSubscription
 	if err != nil {
 		log.WithError(err).Fatal("Couldn't set up OrderStream subscription")
 	}

--- a/cmd/demo/sra_bridge/main.go
+++ b/cmd/demo/sra_bridge/main.go
@@ -73,7 +73,7 @@ func main() {
 			}
 		}
 
-		clientSubscription.Unsubscribe()
+		// clientSubscription.Unsubscribe()
 	}()
 
 	orderHashToWasSeen := map[common.Hash]bool{}

--- a/cmd/demo/sra_bridge/main.go
+++ b/cmd/demo/sra_bridge/main.go
@@ -210,12 +210,14 @@ func getRadarOrders() []*zeroex.SignedOrder {
 		log.WithFields(map[string]interface{}{
 			"statusCode": resp.StatusCode,
 			"body":       string(body),
-		}).Fatal("Got non-200 status code back from RadarRelay")
+		}).Warn("Got non-200 status code back from RadarRelay")
+		return []*zeroex.SignedOrder{}
 	}
 	var ordersResponse ordersResponse
 	err = json.Unmarshal(body, &ordersResponse)
 	if err != nil {
-		log.WithError(err).Fatal("Failed to parse body into OrdersResponse struct")
+		log.WithError(err).Warn("Failed to parse body into OrdersResponse struct")
+		return []*zeroex.SignedOrder{}
 	}
 
 	signedOrders := []*zeroex.SignedOrder{}

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -145,7 +145,7 @@ func (app *App) ValidateAndStore(messages []*p2p.Message) ([]*p2p.Message, error
 			log.WithFields(map[string]interface{}{
 				"orderInfo": orderInfo,
 				"from":      msg.From.String(),
-			}).Warn("not storing invalid order received from peer")
+			}).Trace("not storing invalid order received from peer")
 		}
 	}
 	return validMessages, nil

--- a/rpc/client_server_test.go
+++ b/rpc/client_server_test.go
@@ -24,9 +24,9 @@ import (
 // dummyRPCHandler is used for testing purposes. It allows declaring handlers
 // for some requests or all of them, depending on testing needs.
 type dummyRPCHandler struct {
-	addOrdersHandler 			func(orders []*zeroex.SignedOrder) (*AddOrdersResponse, error)
-	addPeerHandler           	func(peerInfo peerstore.PeerInfo) error
-	subscribeToOrdersHandler 	func(ctx context.Context) (*rpc.Subscription, error)
+	addOrdersHandler         func(orders []*zeroex.SignedOrder) (*AddOrdersResponse, error)
+	addPeerHandler           func(peerInfo peerstore.PeerInfo) error
+	subscribeToOrdersHandler func(ctx context.Context) (*rpc.Subscription, error)
 }
 
 func (d *dummyRPCHandler) AddOrders(orders []*zeroex.SignedOrder) (*AddOrdersResponse, error) {

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -25,6 +25,8 @@ const (
 	FullyFilled
 	Cancelled
 	SignatureInvalid
+	InvalidMakerAssetData
+	InvalidTakerAssetData
 )
 
 // Order represents an unsigned 0x order

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -246,7 +246,7 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*SignedOrder) (m
 			continue
 		}
 
-		if signedOrder.MakerAssetAmount == big.NewInt(0) {
+		if signedOrder.MakerAssetAmount.Cmp(big.NewInt(0)) == 0 {
 			orderHashToInfo[orderHash] = &OrderInfo{
 				OrderHash:                orderHash,
 				SignedOrder:              signedOrder,
@@ -255,7 +255,7 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*SignedOrder) (m
 			}
 			continue
 		}
-		if signedOrder.TakerAssetAmount == big.NewInt(0) {
+		if signedOrder.TakerAssetAmount.Cmp(big.NewInt(0)) == 0 {
 			orderHashToInfo[orderHash] = &OrderInfo{
 				OrderHash:                orderHash,
 				SignedOrder:              signedOrder,

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -235,8 +235,6 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*SignedOrder) (m
 		if err != nil {
 			log.Panic("Computing the orderHash failed unexpectedly")
 		}
-		// TODO(fabio): Allow Mesh operator to specify an expirationBuffer (+/-)
-		// that they wish to tolerate. Use the same expirationBuffer as the ExpirationWatcher
 		now := big.NewInt(time.Now().UTC().Unix())
 		if signedOrder.ExpirationTimeSeconds.Cmp(now) == -1 {
 			orderHashToInfo[orderHash] = &OrderInfo{

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -58,7 +58,8 @@ type OrderHashToSuccinctOrderInfo map[common.Hash]*SuccinctOrderInfo
 
 // OrderValidator validates 0x orders
 type OrderValidator struct {
-	orderValidator *wrappers.OrderValidator
+	orderValidator   *wrappers.OrderValidator
+	assetDataDecoder *AssetDataDecoder
 }
 
 // NewOrderValidator instantiates a new order validator
@@ -69,8 +70,14 @@ func NewOrderValidator(ethClient *ethclient.Client, networkID int) (*OrderValida
 		return nil, err
 	}
 
+	assetDataDecoder, err := NewAssetDataDecoder()
+	if err != nil {
+		return nil, err
+	}
+
 	return &OrderValidator{
-		orderValidator: orderValidator,
+		orderValidator:   orderValidator,
+		assetDataDecoder: assetDataDecoder,
 	}, nil
 }
 
@@ -79,17 +86,21 @@ func NewOrderValidator(ethClient *ethclient.Client, networkID int) (*OrderValida
 // requests concurrently. If a request fails, re-attempt it up to four times before giving up.
 // If it some requests fail, this method still returns whatever order information it was able to
 // retrieve.
-func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.Hash]*OrderInfo {
+func (o *OrderValidator) BatchValidate(rawSignedOrders []*SignedOrder) map[common.Hash]*OrderInfo {
+	if len(rawSignedOrders) == 0 {
+		return map[common.Hash]*OrderInfo{}
+	}
+	orderHashToInfo, schemaCheckedSignedOrders := o.BatchOffchainValidation(rawSignedOrders)
 	takerAddresses := []common.Address{}
-	for _, signedOrder := range signedOrders {
+	for _, signedOrder := range schemaCheckedSignedOrders {
 		takerAddresses = append(takerAddresses, signedOrder.TakerAddress)
 	}
 	orders := []wrappers.OrderWithoutExchangeAddress{}
-	for _, signedOrder := range signedOrders {
+	for _, signedOrder := range schemaCheckedSignedOrders {
 		orders = append(orders, signedOrder.ConvertToOrderWithoutExchangeAddress())
 	}
 	signatures := [][]byte{}
-	for _, signedOrder := range signedOrders {
+	for _, signedOrder := range schemaCheckedSignedOrders {
 		signatures = append(signatures, signedOrder.Signature)
 	}
 
@@ -116,7 +127,6 @@ func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.H
 	semaphoreChan := make(chan struct{}, concurrencyLimit)
 	defer close(semaphoreChan)
 
-	orderHashToInfo := map[common.Hash]*OrderInfo{}
 	wg := &sync.WaitGroup{}
 	for i, params := range chunks {
 		wg.Add(1)
@@ -172,7 +182,7 @@ func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.H
 					traderInfo := results.TradersInfo[j]
 					isValidSignature := results.IsValidSignature[j]
 					orderHash := common.Hash(orderInfo.OrderHash)
-					signedOrder := signedOrders[chunkSize*i+j]
+					signedOrder := schemaCheckedSignedOrders[chunkSize*i+j]
 					orderStatus := OrderStatus(orderInfo.OrderStatus)
 					if !isValidSignature {
 						orderStatus = SignatureInvalid
@@ -208,6 +218,157 @@ func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.H
 
 	wg.Wait()
 	return orderHashToInfo
+}
+
+// BatchOffchainValidation performs all off-chain validation checks on a batch of 0x orders.
+// These checks include:
+// - `MakerAssetAmount` and `TakerAssetAmount` cannot be 0
+// - `AssetData` fields contain properly encoded, and currently supported assetData (ERC20 & ERC721 for now)
+// - `Signature` contains a properly encoded 0x signature
+// - Validate that order isn't expired
+// Returns an orderHashToInfo mapping with all invalid orders added to it, and an array of the valid signedOrders
+func (o *OrderValidator) BatchOffchainValidation(signedOrders []*SignedOrder) (map[common.Hash]*OrderInfo, []*SignedOrder) {
+	orderHashToInfo := map[common.Hash]*OrderInfo{}
+	validSignedOrders := []*SignedOrder{}
+	for _, signedOrder := range signedOrders {
+		orderHash, err := signedOrder.ComputeOrderHash()
+		if err != nil {
+			log.Panic("Computing the orderHash failed unexpectedly")
+		}
+		// TODO(fabio): Allow Mesh operator to specify an expirationBuffer (+/-)
+		// that they wish to tolerate. Use the same expirationBuffer as the ExpirationWatcher
+		now := big.NewInt(time.Now().UTC().Unix())
+		if signedOrder.ExpirationTimeSeconds.Cmp(now) == -1 {
+			orderHashToInfo[orderHash] = &OrderInfo{
+				OrderHash:                orderHash,
+				SignedOrder:              signedOrder,
+				FillableTakerAssetAmount: big.NewInt(0),
+				OrderStatus:              Expired,
+			}
+			continue
+		}
+
+		if signedOrder.MakerAssetAmount == big.NewInt(0) {
+			orderHashToInfo[orderHash] = &OrderInfo{
+				OrderHash:                orderHash,
+				SignedOrder:              signedOrder,
+				FillableTakerAssetAmount: big.NewInt(0),
+				OrderStatus:              InvalidMakerAssetAmount,
+			}
+			continue
+		}
+		if signedOrder.TakerAssetAmount == big.NewInt(0) {
+			orderHashToInfo[orderHash] = &OrderInfo{
+				OrderHash:                orderHash,
+				SignedOrder:              signedOrder,
+				FillableTakerAssetAmount: big.NewInt(0),
+				OrderStatus:              InvalidTakerAssetAmount,
+			}
+			continue
+		}
+
+		isMakerAssetDataSupported := o.isSupportedAssetData(signedOrder.MakerAssetData)
+		if !isMakerAssetDataSupported {
+			orderHashToInfo[orderHash] = &OrderInfo{
+				OrderHash:                orderHash,
+				SignedOrder:              signedOrder,
+				FillableTakerAssetAmount: big.NewInt(0),
+				OrderStatus:              InvalidMakerAssetData,
+			}
+			continue
+		}
+		isTakerAssetDataSupported := o.isSupportedAssetData(signedOrder.TakerAssetData)
+		if !isTakerAssetDataSupported {
+			orderHashToInfo[orderHash] = &OrderInfo{
+				OrderHash:                orderHash,
+				SignedOrder:              signedOrder,
+				FillableTakerAssetAmount: big.NewInt(0),
+				OrderStatus:              InvalidTakerAssetData,
+			}
+			continue
+		}
+
+		isSupportedSignature := isSupportedSignature(signedOrder.Signature, orderHash)
+		if !isSupportedSignature {
+			orderHashToInfo[orderHash] = &OrderInfo{
+				OrderHash:                orderHash,
+				SignedOrder:              signedOrder,
+				FillableTakerAssetAmount: big.NewInt(0),
+				OrderStatus:              SignatureInvalid,
+			}
+			continue
+		}
+
+		validSignedOrders = append(validSignedOrders, signedOrder)
+	}
+
+	return orderHashToInfo, validSignedOrders
+}
+
+func (o *OrderValidator) isSupportedAssetData(assetData []byte) bool {
+	assetDataName, err := o.assetDataDecoder.GetName(assetData)
+	if err != nil {
+		return false
+	}
+	switch assetDataName {
+	case "ERC20Token":
+		var decodedAssetData ERC20AssetData
+		err := o.assetDataDecoder.Decode(assetData, &decodedAssetData)
+		if err != nil {
+			return false
+		}
+	case "ERC721Token":
+		var decodedAssetData ERC721AssetData
+		err := o.assetDataDecoder.Decode(assetData, &decodedAssetData)
+		if err != nil {
+			return false
+		}
+	case "MultiAsset":
+		// TODO(fabio): Once OrderValidator.sol supports validating orders involving multiAssetData,
+		// refactor this to add support.
+		return false
+	default:
+		return false
+	}
+	return true
+}
+
+func isSupportedSignature(signature []byte, orderHash common.Hash) bool {
+	signatureType := SignatureType(signature[len(signature)-1])
+
+	switch signatureType {
+	case IllegalSignature:
+	case InvalidSignature:
+		return false
+
+	case EIP712Signature:
+		if len(signature) != 66 {
+			return false
+		}
+		// TODO(fabio): Do further validation by splitting into r,s,v and do ECRecover
+
+	case EthSignSignature:
+		if len(signature) != 66 {
+			return false
+		}
+		// TODO(fabio): Do further validation by splitting into r,s,v, add prefix to hash
+		// and do ECRecover
+
+	case ValidatorSignature:
+		if len(signature) < 21 {
+			return false
+		}
+
+	case WalletSignature:
+	case PreSignedSignature:
+		return true
+
+	default:
+		return false
+
+	}
+
+	return true
 }
 
 func calculateRemainingFillableTakerAmount(signedOrder *SignedOrder, orderInfo wrappers.OrderInfo, traderInfo wrappers.TraderInfo) *big.Int {

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -150,6 +150,7 @@ func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.H
 						"err":            err.Error(),
 						"attempt":        b.Attempt(),
 						"orders":         params.Orders,
+						"signatures":     params.Signatures,
 						"takerAddresses": params.TakerAddresses,
 					}).Info("GetOrdersAndTradersInfo request failed")
 					d := b.Duration()
@@ -158,6 +159,7 @@ func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.H
 						log.WithFields(log.Fields{
 							"err":            err.Error(),
 							"orders":         params.Orders,
+							"signatures":     params.Signatures,
 							"takerAddresses": params.TakerAddresses,
 						}).Warning("Gave up on GetOrdersAndTradersInfo request after backoff limit reached")
 						return // Give up after 4 attempts

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -81,16 +81,16 @@ func NewOrderValidator(ethClient *ethclient.Client, networkID int) (*OrderValida
 // retrieve.
 func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.Hash]*OrderInfo {
 	takerAddresses := []common.Address{}
-	for i := 0; i < len(signedOrders); i++ {
-		takerAddresses = append(takerAddresses, signedOrders[i].TakerAddress)
+	for _, signedOrder := range signedOrders {
+		takerAddresses = append(takerAddresses, signedOrder.TakerAddress)
 	}
 	orders := []wrappers.OrderWithoutExchangeAddress{}
-	for i := 0; i < len(signedOrders); i++ {
-		orders = append(orders, signedOrders[i].ConvertToOrderWithoutExchangeAddress())
+	for _, signedOrder := range signedOrders {
+		orders = append(orders, signedOrder.ConvertToOrderWithoutExchangeAddress())
 	}
 	signatures := [][]byte{}
-	for i := 0; i < len(signedOrders); i++ {
-		signatures = append(signatures, signedOrders[i].Signature)
+	for _, signedOrder := range signedOrders {
+		signatures = append(signatures, signedOrder.Signature)
 	}
 
 	// Chunk into groups of chunkSize orders/takerAddresses for each call

--- a/zeroex/order_validator_test.go
+++ b/zeroex/order_validator_test.go
@@ -103,13 +103,10 @@ var testCases = []testCase{
 }
 
 func TestBatchValidateOffChainCases(t *testing.T) {
-	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
-	require.NoError(t, err)
-
 	for _, testCase := range testCases {
 		order := modifyOrder(t, testOrder, testCase.Field, testCase.Value)
 
-		signedOrder, err := SignOrder(&order, rpcClient)
+		signedOrder, err := SignTestOrder(&order)
 		require.NoError(t, err)
 
 		orderHash, err := order.ComputeOrderHash()
@@ -192,7 +189,7 @@ func TestCalculateRemainingFillableTakerAmount(t *testing.T) {
 	order.TakerAssetAmount = takerAssetAmount
 	order.MakerAssetAmount = makerAssetAmount
 	order.MakerFee = makerFee
-	signedOrder, err := SignOrder(&order, rpcClient)
+	signedOrder, err := SignTestOrder(&order)
 	require.NoError(t, err)
 
 	orderHash, err := order.ComputeOrderHash()

--- a/zeroex/order_validator_test.go
+++ b/zeroex/order_validator_test.go
@@ -7,6 +7,7 @@ package zeroex
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/ethereum/wrappers"
@@ -16,65 +17,150 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBatchValidateExpiredOrder(t *testing.T) {
-	contractNameToAddress := constants.NetworkIDToContractAddresses[constants.TestNetworkID]
+var unsupportedAssetData = common.Hex2Bytes("a2cb61b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064")
+var malformedAssetData = []byte("9HJhsAAAAAAAAAAAAAAAAInSSmtMyxtvqiYl")
+var malformedSignature = []byte("9HJhsAAAAAAAAAAAAAAAAInSSmtMyxtvqiYl")
+var multiAssetAssetData = common.Hex2Bytes("94cfcdd7000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000046000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000024f47261b00000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c48000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044025717920000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c480000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000204a7cb5fb70000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c480000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000003e90000000000000000000000000000000000000000000000000000000000002711000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000c800000000000000000000000000000000000000000000000000000000000007d10000000000000000000000000000000000000000000000000000000000004e210000000000000000000000000000000000000000000000000000000000000044025717920000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c4800000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
 
-	order := &Order{
-		MakerAddress:          constants.GanacheAccount0,
-		TakerAddress:          constants.NullAddress,
-		SenderAddress:         constants.NullAddress,
-		FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
-		MakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064"),
-		TakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3"),
-		Salt:                  big.NewInt(1548619145450),
-		MakerFee:              big.NewInt(0),
-		TakerFee:              big.NewInt(0),
-		MakerAssetAmount:      big.NewInt(3551808554499581700),
-		TakerAssetAmount:      big.NewInt(300000000000000),
-		ExpirationTimeSeconds: big.NewInt(1548619325),
-		ExchangeAddress:       contractNameToAddress.Exchange,
+var testOrder = Order{
+	MakerAddress:          constants.GanacheAccount0,
+	TakerAddress:          constants.NullAddress,
+	SenderAddress:         constants.NullAddress,
+	FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+	MakerAssetData:        common.Hex2Bytes("f47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c"),
+	TakerAssetData:        common.Hex2Bytes("f47261b00000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082"),
+	Salt:                  big.NewInt(1548619145450),
+	MakerFee:              big.NewInt(0),
+	TakerFee:              big.NewInt(0),
+	MakerAssetAmount:      big.NewInt(1000),
+	TakerAssetAmount:      big.NewInt(2000),
+	ExpirationTimeSeconds: big.NewInt(time.Now().Add(48 * time.Hour).Unix()),
+	ExchangeAddress:       constants.NetworkIDToContractAddresses[constants.TestNetworkID].Exchange,
+}
+
+type testCase struct {
+	Field               string
+	Value               interface{}
+	ExpectedOrderStatus OrderStatus
+}
+
+var testCases = []testCase{
+	testCase{
+		Field:               "MakerAssetAmount",
+		Value:               big.NewInt(0),
+		ExpectedOrderStatus: InvalidMakerAssetAmount,
+	},
+	testCase{
+		Field:               "MakerAssetAmount",
+		Value:               big.NewInt(1000000),
+		ExpectedOrderStatus: Fillable,
+	},
+	testCase{
+		Field:               "TakerAssetAmount",
+		Value:               big.NewInt(0),
+		ExpectedOrderStatus: InvalidTakerAssetAmount,
+	},
+	testCase{
+		Field:               "TakerAssetAmount",
+		Value:               big.NewInt(1000000),
+		ExpectedOrderStatus: Fillable,
+	},
+	testCase{
+		Field:               "MakerAssetData",
+		Value:               multiAssetAssetData,
+		ExpectedOrderStatus: InvalidMakerAssetData,
+	},
+	testCase{
+		Field:               "TakerAssetData",
+		Value:               multiAssetAssetData,
+		ExpectedOrderStatus: InvalidTakerAssetData,
+	},
+	testCase{
+		Field:               "MakerAssetData",
+		Value:               malformedAssetData,
+		ExpectedOrderStatus: InvalidMakerAssetData,
+	},
+	testCase{
+		Field:               "TakerAssetData",
+		Value:               malformedAssetData,
+		ExpectedOrderStatus: InvalidTakerAssetData,
+	},
+	testCase{
+		Field:               "MakerAssetData",
+		Value:               unsupportedAssetData,
+		ExpectedOrderStatus: InvalidMakerAssetData,
+	},
+	testCase{
+		Field:               "TakerAssetData",
+		Value:               unsupportedAssetData,
+		ExpectedOrderStatus: InvalidTakerAssetData,
+	},
+	testCase{
+		Field:               "ExpirationTimeSeconds",
+		Value:               big.NewInt(time.Now().Add(-5 * time.Minute).Unix()),
+		ExpectedOrderStatus: Expired,
+	},
+}
+
+func TestBatchValidateOffChainCases(t *testing.T) {
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+
+	for _, testCase := range testCases {
+		order := modifyOrder(t, testOrder, testCase.Field, testCase.Value)
+
+		signedOrder, err := SignOrder(&order, rpcClient)
+		require.NoError(t, err)
+
+		orderHash, err := order.ComputeOrderHash()
+		require.NoError(t, err)
+
+		ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
+		require.NoError(t, err)
+
+		signedOrders := []*SignedOrder{
+			signedOrder,
+		}
+
+		orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID)
+		require.NoError(t, err)
+
+		orderInfos := orderValidator.BatchValidate(signedOrders)
+		assert.Len(t, orderInfos, 1)
+		assert.Equal(t, testCase.ExpectedOrderStatus, orderInfos[orderHash].OrderStatus)
+		assert.Equal(t, signedOrder, orderInfos[orderHash].SignedOrder)
 	}
-	signedOrder, err := SignTestOrder(order)
-	require.NoError(t, err)
+}
 
-	orderHash, err := order.ComputeOrderHash()
-	require.NoError(t, err)
+func TestBatchValidateMalformedSignature(t *testing.T) {
+	signedOrder := &SignedOrder{
+		Order: &testOrder,
+	}
+	// Incorrectly formatted signature
+	signedOrder.Signature = malformedSignature
 
-	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
+	orderHash, err := signedOrder.ComputeOrderHash()
 	require.NoError(t, err)
 
 	signedOrders := []*SignedOrder{
 		signedOrder,
 	}
 
+	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+
 	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID)
 	require.NoError(t, err)
 
 	orderInfos := orderValidator.BatchValidate(signedOrders)
 	assert.Len(t, orderInfos, 1)
-	assert.Equal(t, Expired, orderInfos[orderHash].OrderStatus)
+	assert.Equal(t, SignatureInvalid, orderInfos[orderHash].OrderStatus)
 	assert.Equal(t, signedOrder, orderInfos[orderHash].SignedOrder)
 }
 
 func TestBatchValidateSignatureInvalid(t *testing.T) {
-	contractNameToAddress := constants.NetworkIDToContractAddresses[constants.TestNetworkID]
-
 	signedOrder := &SignedOrder{
-		Order: &Order{
-			MakerAddress:          constants.GanacheAccount0,
-			TakerAddress:          constants.NullAddress,
-			SenderAddress:         constants.NullAddress,
-			FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
-			MakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064"),
-			TakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3"),
-			Salt:                  big.NewInt(1548619145450),
-			MakerFee:              big.NewInt(0),
-			TakerFee:              big.NewInt(0),
-			MakerAssetAmount:      big.NewInt(3551808554499581700),
-			TakerAssetAmount:      big.NewInt(300000000000000),
-			ExpirationTimeSeconds: big.NewInt(2850940800),
-			ExchangeAddress:       contractNameToAddress.Exchange,
-		},
+		Order: &testOrder,
 	}
 	// Add a correctly formatted signature that does not correspond to this order
 	signedOrder.Signature = common.Hex2Bytes("1c3582f06356a1314dbf1c0e534c4d8e92e59b056ee607a7ff5a825f5f2cc5e6151c5cc7fdd420f5608e4d5bef108e42ad90c7a4b408caef32e24374cf387b0d7603")
@@ -99,27 +185,14 @@ func TestBatchValidateSignatureInvalid(t *testing.T) {
 }
 
 func TestCalculateRemainingFillableTakerAmount(t *testing.T) {
-	contractNameToAddress := constants.NetworkIDToContractAddresses[constants.TestNetworkID]
-
 	takerAssetAmount := big.NewInt(200000000000000000)
 	makerAssetAmount := big.NewInt(100000000000000000)
 	makerFee := big.NewInt(10000000000000000)
-	order := &Order{
-		MakerAddress:          constants.GanacheAccount0,
-		TakerAddress:          constants.NullAddress,
-		SenderAddress:         constants.NullAddress,
-		FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
-		MakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064"),
-		TakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3"),
-		Salt:                  big.NewInt(1548619145450),
-		MakerFee:              makerFee,
-		TakerFee:              big.NewInt(10000000000000000),
-		MakerAssetAmount:      makerAssetAmount,
-		TakerAssetAmount:      takerAssetAmount,
-		ExpirationTimeSeconds: big.NewInt(99548619325),
-		ExchangeAddress:       contractNameToAddress.Exchange,
-	}
-	signedOrder, err := SignTestOrder(order)
+	order := testOrder
+	order.TakerAssetAmount = takerAssetAmount
+	order.MakerAssetAmount = makerAssetAmount
+	order.MakerFee = makerFee
+	signedOrder, err := SignOrder(&order, rpcClient)
 	require.NoError(t, err)
 
 	orderHash, err := order.ComputeOrderHash()
@@ -232,4 +305,22 @@ func TestCalculateRemainingFillableTakerAmount(t *testing.T) {
 	}
 	remainingFillableTakerAssetAmount := calculateRemainingFillableTakerAmount(signedOrder, orderInfo, traderInfo)
 	assert.Equal(t, new(big.Int).Div(takerAssetAmount, big.NewInt(2)), remainingFillableTakerAssetAmount)
+}
+
+func modifyOrder(t *testing.T, order Order, field string, value interface{}) Order {
+	switch field {
+	case "MakerAssetData":
+		order.MakerAssetData = value.([]byte)
+	case "TakerAssetData":
+		order.TakerAssetData = value.([]byte)
+	case "MakerAssetAmount":
+		order.MakerAssetAmount = value.(*big.Int)
+	case "TakerAssetAmount":
+		order.TakerAssetAmount = value.(*big.Int)
+	case "ExpirationTimeSeconds":
+		order.ExpirationTimeSeconds = value.(*big.Int)
+	default:
+		t.Fatal("Unsupported order field: ", field)
+	}
+	return order
 }

--- a/zeroex/orderwatch/expirationwatch.go
+++ b/zeroex/orderwatch/expirationwatch.go
@@ -134,7 +134,7 @@ func (e *ExpirationWatcher) Receive() <-chan []ExpiredOrder {
 // to the caller
 func (e *ExpirationWatcher) prune() []ExpiredOrder {
 	pruned := []ExpiredOrder{}
-	currentTimestamp := time.Now().Unix()
+	currentTimestamp := time.Now().UTC().Unix()
 	for {
 		e.rbTreeMu.RLock()
 		key, value := e.rbTree.Min()

--- a/zeroex/orderwatch/watcher.go
+++ b/zeroex/orderwatch/watcher.go
@@ -463,7 +463,7 @@ func (w *Watcher) generateOrderEventsIfChanged(orders []*meshdb.Order) {
 			// order fails to succeed (re-try steps included)
 			continue
 		}
-		if order.FillableTakerAssetAmount != orderInfo.FillableTakerAssetAmount {
+		if order.FillableTakerAssetAmount.Cmp(orderInfo.FillableTakerAssetAmount) != 0 {
 			isOrderUnfillable := orderInfo.FillableTakerAssetAmount.Cmp(big.NewInt(0)) == 0
 			if isOrderUnfillable {
 				w.unwatchOrder(order, false)

--- a/zeroex/orderwatch/watcher.go
+++ b/zeroex/orderwatch/watcher.go
@@ -535,7 +535,7 @@ func (w *Watcher) handleDecodeErr(err error, eventType string) {
 			"eventType":       eventType,
 			"topics":          err.(UnsupportedEventError).Topics,
 			"contractAddress": err.(UnsupportedEventError).ContractAddress,
-		}).Warn("unsupported event found")
+		}).Trace("unsupported event found")
 
 	default:
 		logger.WithFields(logger.Fields{


### PR DESCRIPTION
This PR adds an `sra_bridge` demo client that dumps RadarRelay orders into Mesh on some interval.

Note: The refactor of `AddOrder` to `AddOrders` was moved to a separate PR, but until that get's merged, it's code is also in this branch.