### PR TITLE
zeroex: Perform all possible off-chain 0x validation before on-chain validation

### DIFF
--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -25,6 +25,8 @@ const (
 	FullyFilled
 	Cancelled
 	SignatureInvalid
+	InvalidMakerAssetData
+	InvalidTakerAssetData
 )
 
 // Order represents an unsigned 0x order

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -233,8 +233,6 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*SignedOrder) (m
 		if err != nil {
 			log.Panic("Computing the orderHash failed unexpectedly")
 		}
-		// TODO(fabio): Allow Mesh operator to specify an expirationBuffer (+/-)
-		// that they wish to tolerate. Use the same expirationBuffer as the ExpirationWatcher
 		now := big.NewInt(time.Now().UTC().Unix())
 		if signedOrder.ExpirationTimeSeconds.Cmp(now) == -1 {
 			orderHashToInfo[orderHash] = &OrderInfo{

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -233,7 +233,7 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*SignedOrder) (m
 		if err != nil {
 			log.Panic("Computing the orderHash failed unexpectedly")
 		}
-		now := big.NewInt(time.Now().UTC().Unix())
+		now := big.NewInt(time.Now().Unix())
 		if signedOrder.ExpirationTimeSeconds.Cmp(now) == -1 {
 			orderHashToInfo[orderHash] = &OrderInfo{
 				OrderHash:                orderHash,

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -244,7 +244,7 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*SignedOrder) (m
 			continue
 		}
 
-		if signedOrder.MakerAssetAmount == big.NewInt(0) {
+		if signedOrder.MakerAssetAmount.Cmp(big.NewInt(0)) == 0 {
 			orderHashToInfo[orderHash] = &OrderInfo{
 				OrderHash:                orderHash,
 				SignedOrder:              signedOrder,
@@ -253,7 +253,7 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*SignedOrder) (m
 			}
 			continue
 		}
-		if signedOrder.TakerAssetAmount == big.NewInt(0) {
+		if signedOrder.TakerAssetAmount.Cmp(big.NewInt(0)) == 0 {
 			orderHashToInfo[orderHash] = &OrderInfo{
 				OrderHash:                orderHash,
 				SignedOrder:              signedOrder,

--- a/zeroex/order_validator_test.go
+++ b/zeroex/order_validator_test.go
@@ -7,6 +7,7 @@ package zeroex
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/ethereum/wrappers"
@@ -16,65 +17,147 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBatchValidateExpiredOrder(t *testing.T) {
-	contractNameToAddress := constants.NetworkIDToContractAddresses[constants.TestNetworkID]
+var unsupportedAssetData = common.Hex2Bytes("a2cb61b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064")
+var malformedAssetData = []byte("9HJhsAAAAAAAAAAAAAAAAInSSmtMyxtvqiYl")
+var malformedSignature = []byte("9HJhsAAAAAAAAAAAAAAAAInSSmtMyxtvqiYl")
+var multiAssetAssetData = common.Hex2Bytes("94cfcdd7000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000046000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000024f47261b00000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c48000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044025717920000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c480000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000204a7cb5fb70000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c480000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000003e90000000000000000000000000000000000000000000000000000000000002711000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000c800000000000000000000000000000000000000000000000000000000000007d10000000000000000000000000000000000000000000000000000000000004e210000000000000000000000000000000000000000000000000000000000000044025717920000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c4800000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
 
-	order := &Order{
-		MakerAddress:          constants.GanacheAccount0,
-		TakerAddress:          constants.NullAddress,
-		SenderAddress:         constants.NullAddress,
-		FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
-		MakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064"),
-		TakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3"),
-		Salt:                  big.NewInt(1548619145450),
-		MakerFee:              big.NewInt(0),
-		TakerFee:              big.NewInt(0),
-		MakerAssetAmount:      big.NewInt(3551808554499581700),
-		TakerAssetAmount:      big.NewInt(300000000000000),
-		ExpirationTimeSeconds: big.NewInt(1548619325),
-		ExchangeAddress:       contractNameToAddress.Exchange,
+var testOrder = Order{
+	MakerAddress:          constants.GanacheAccount0,
+	TakerAddress:          constants.NullAddress,
+	SenderAddress:         constants.NullAddress,
+	FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+	MakerAssetData:        common.Hex2Bytes("f47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c"),
+	TakerAssetData:        common.Hex2Bytes("f47261b00000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082"),
+	Salt:                  big.NewInt(1548619145450),
+	MakerFee:              big.NewInt(0),
+	TakerFee:              big.NewInt(0),
+	MakerAssetAmount:      big.NewInt(1000),
+	TakerAssetAmount:      big.NewInt(2000),
+	ExpirationTimeSeconds: big.NewInt(time.Now().Add(48 * time.Hour).Unix()),
+	ExchangeAddress:       constants.NetworkIDToContractAddresses[constants.TestNetworkID].Exchange,
+}
+
+type testCase struct {
+	Field               string
+	Value               interface{}
+	ExpectedOrderStatus OrderStatus
+}
+
+var testCases = []testCase{
+	testCase{
+		Field:               "MakerAssetAmount",
+		Value:               big.NewInt(0),
+		ExpectedOrderStatus: InvalidMakerAssetAmount,
+	},
+	testCase{
+		Field:               "MakerAssetAmount",
+		Value:               big.NewInt(1000000),
+		ExpectedOrderStatus: Fillable,
+	},
+	testCase{
+		Field:               "TakerAssetAmount",
+		Value:               big.NewInt(0),
+		ExpectedOrderStatus: InvalidTakerAssetAmount,
+	},
+	testCase{
+		Field:               "TakerAssetAmount",
+		Value:               big.NewInt(1000000),
+		ExpectedOrderStatus: Fillable,
+	},
+	testCase{
+		Field:               "MakerAssetData",
+		Value:               multiAssetAssetData,
+		ExpectedOrderStatus: InvalidMakerAssetData,
+	},
+	testCase{
+		Field:               "TakerAssetData",
+		Value:               multiAssetAssetData,
+		ExpectedOrderStatus: InvalidTakerAssetData,
+	},
+	testCase{
+		Field:               "MakerAssetData",
+		Value:               malformedAssetData,
+		ExpectedOrderStatus: InvalidMakerAssetData,
+	},
+	testCase{
+		Field:               "TakerAssetData",
+		Value:               malformedAssetData,
+		ExpectedOrderStatus: InvalidTakerAssetData,
+	},
+	testCase{
+		Field:               "MakerAssetData",
+		Value:               unsupportedAssetData,
+		ExpectedOrderStatus: InvalidMakerAssetData,
+	},
+	testCase{
+		Field:               "TakerAssetData",
+		Value:               unsupportedAssetData,
+		ExpectedOrderStatus: InvalidTakerAssetData,
+	},
+	testCase{
+		Field:               "ExpirationTimeSeconds",
+		Value:               big.NewInt(time.Now().Add(-5 * time.Minute).Unix()),
+		ExpectedOrderStatus: Expired,
+	},
+}
+
+func TestBatchValidateOffChainCases(t *testing.T) {
+	for _, testCase := range testCases {
+		order := modifyOrder(t, testOrder, testCase.Field, testCase.Value)
+
+		signedOrder, err := SignTestOrder(&order)
+		require.NoError(t, err)
+
+		orderHash, err := order.ComputeOrderHash()
+		require.NoError(t, err)
+
+		ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
+		require.NoError(t, err)
+
+		signedOrders := []*SignedOrder{
+			signedOrder,
+		}
+
+		orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID)
+		require.NoError(t, err)
+
+		orderInfos := orderValidator.BatchValidate(signedOrders)
+		assert.Len(t, orderInfos, 1)
+		assert.Equal(t, testCase.ExpectedOrderStatus, orderInfos[orderHash].OrderStatus)
+		assert.Equal(t, signedOrder, orderInfos[orderHash].SignedOrder)
 	}
-	signedOrder, err := SignTestOrder(order)
-	require.NoError(t, err)
+}
 
-	orderHash, err := order.ComputeOrderHash()
-	require.NoError(t, err)
+func TestBatchValidateMalformedSignature(t *testing.T) {
+	signedOrder := &SignedOrder{
+		Order: &testOrder,
+	}
+	// Incorrectly formatted signature
+	signedOrder.Signature = malformedSignature
 
-	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
+	orderHash, err := signedOrder.ComputeOrderHash()
 	require.NoError(t, err)
 
 	signedOrders := []*SignedOrder{
 		signedOrder,
 	}
 
+	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+
 	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID)
 	require.NoError(t, err)
 
 	orderInfos := orderValidator.BatchValidate(signedOrders)
 	assert.Len(t, orderInfos, 1)
-	assert.Equal(t, Expired, orderInfos[orderHash].OrderStatus)
+	assert.Equal(t, SignatureInvalid, orderInfos[orderHash].OrderStatus)
 	assert.Equal(t, signedOrder, orderInfos[orderHash].SignedOrder)
 }
 
 func TestBatchValidateSignatureInvalid(t *testing.T) {
-	contractNameToAddress := constants.NetworkIDToContractAddresses[constants.TestNetworkID]
-
 	signedOrder := &SignedOrder{
-		Order: &Order{
-			MakerAddress:          constants.GanacheAccount0,
-			TakerAddress:          constants.NullAddress,
-			SenderAddress:         constants.NullAddress,
-			FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
-			MakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064"),
-			TakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3"),
-			Salt:                  big.NewInt(1548619145450),
-			MakerFee:              big.NewInt(0),
-			TakerFee:              big.NewInt(0),
-			MakerAssetAmount:      big.NewInt(3551808554499581700),
-			TakerAssetAmount:      big.NewInt(300000000000000),
-			ExpirationTimeSeconds: big.NewInt(2850940800),
-			ExchangeAddress:       contractNameToAddress.Exchange,
-		},
+		Order: &testOrder,
 	}
 	// Add a correctly formatted signature that does not correspond to this order
 	signedOrder.Signature = common.Hex2Bytes("1c3582f06356a1314dbf1c0e534c4d8e92e59b056ee607a7ff5a825f5f2cc5e6151c5cc7fdd420f5608e4d5bef108e42ad90c7a4b408caef32e24374cf387b0d7603")
@@ -99,27 +182,14 @@ func TestBatchValidateSignatureInvalid(t *testing.T) {
 }
 
 func TestCalculateRemainingFillableTakerAmount(t *testing.T) {
-	contractNameToAddress := constants.NetworkIDToContractAddresses[constants.TestNetworkID]
-
 	takerAssetAmount := big.NewInt(200000000000000000)
 	makerAssetAmount := big.NewInt(100000000000000000)
 	makerFee := big.NewInt(10000000000000000)
-	order := &Order{
-		MakerAddress:          constants.GanacheAccount0,
-		TakerAddress:          constants.NullAddress,
-		SenderAddress:         constants.NullAddress,
-		FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
-		MakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064"),
-		TakerAssetData:        common.Hex2Bytes("f47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3"),
-		Salt:                  big.NewInt(1548619145450),
-		MakerFee:              makerFee,
-		TakerFee:              big.NewInt(10000000000000000),
-		MakerAssetAmount:      makerAssetAmount,
-		TakerAssetAmount:      takerAssetAmount,
-		ExpirationTimeSeconds: big.NewInt(99548619325),
-		ExchangeAddress:       contractNameToAddress.Exchange,
-	}
-	signedOrder, err := SignTestOrder(order)
+	order := testOrder
+	order.TakerAssetAmount = takerAssetAmount
+	order.MakerAssetAmount = makerAssetAmount
+	order.MakerFee = makerFee
+	signedOrder, err := SignTestOrder(&order)
 	require.NoError(t, err)
 
 	orderHash, err := order.ComputeOrderHash()
@@ -232,4 +302,22 @@ func TestCalculateRemainingFillableTakerAmount(t *testing.T) {
 	}
 	remainingFillableTakerAssetAmount := calculateRemainingFillableTakerAmount(signedOrder, orderInfo, traderInfo)
 	assert.Equal(t, new(big.Int).Div(takerAssetAmount, big.NewInt(2)), remainingFillableTakerAssetAmount)
+}
+
+func modifyOrder(t *testing.T, order Order, field string, value interface{}) Order {
+	switch field {
+	case "MakerAssetData":
+		order.MakerAssetData = value.([]byte)
+	case "TakerAssetData":
+		order.TakerAssetData = value.([]byte)
+	case "MakerAssetAmount":
+		order.MakerAssetAmount = value.(*big.Int)
+	case "TakerAssetAmount":
+		order.TakerAssetAmount = value.(*big.Int)
+	case "ExpirationTimeSeconds":
+		order.ExpirationTimeSeconds = value.(*big.Int)
+	default:
+		t.Fatal("Unsupported order field: ", field)
+	}
+	return order
 }

--- a/zeroex/order_validator_test.go
+++ b/zeroex/order_validator_test.go
@@ -22,88 +22,90 @@ var malformedAssetData = []byte("9HJhsAAAAAAAAAAAAAAAAInSSmtMyxtvqiYl")
 var malformedSignature = []byte("9HJhsAAAAAAAAAAAAAAAAInSSmtMyxtvqiYl")
 var multiAssetAssetData = common.Hex2Bytes("94cfcdd7000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000046000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000024f47261b00000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c48000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000044025717920000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c480000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000204a7cb5fb70000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c480000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001800000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000003e90000000000000000000000000000000000000000000000000000000000002711000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000c800000000000000000000000000000000000000000000000000000000000007d10000000000000000000000000000000000000000000000000000000000004e210000000000000000000000000000000000000000000000000000000000000044025717920000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c4800000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
 
-var testOrder = Order{
-	MakerAddress:          constants.GanacheAccount0,
-	TakerAddress:          constants.NullAddress,
-	SenderAddress:         constants.NullAddress,
-	FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
-	MakerAssetData:        common.Hex2Bytes("f47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c"),
-	TakerAssetData:        common.Hex2Bytes("f47261b00000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082"),
-	Salt:                  big.NewInt(1548619145450),
-	MakerFee:              big.NewInt(0),
-	TakerFee:              big.NewInt(0),
-	MakerAssetAmount:      big.NewInt(1000),
-	TakerAssetAmount:      big.NewInt(2000),
-	ExpirationTimeSeconds: big.NewInt(time.Now().Add(48 * time.Hour).Unix()),
-	ExchangeAddress:       constants.NetworkIDToContractAddresses[constants.TestNetworkID].Exchange,
+var testSignedOrder = SignedOrder{
+	Order: &Order {
+		MakerAddress:          constants.GanacheAccount0,
+		TakerAddress:          constants.NullAddress,
+		SenderAddress:         constants.NullAddress,
+		FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+		MakerAssetData:        common.Hex2Bytes("f47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c"),
+		TakerAssetData:        common.Hex2Bytes("f47261b00000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082"),
+		Salt:                  big.NewInt(1548619145450),
+		MakerFee:              big.NewInt(0),
+		TakerFee:              big.NewInt(0),
+		MakerAssetAmount:      big.NewInt(1000),
+		TakerAssetAmount:      big.NewInt(2000),
+		ExpirationTimeSeconds: big.NewInt(time.Now().Add(48 * time.Hour).Unix()),
+		ExchangeAddress:       constants.NetworkIDToContractAddresses[constants.TestNetworkID].Exchange,
+	},
 }
 
 type testCase struct {
-	Order               Order
+	SignedOrder               SignedOrder
 	ExpectedOrderStatus OrderStatus
 }
 
-var testCases = []testCase{
-	testCase{
-		Order:               orderWithCustomMakerAssetAmount(testOrder, big.NewInt(0)),
-		ExpectedOrderStatus: InvalidMakerAssetAmount,
-	},
-	testCase{
-		Order:               orderWithCustomMakerAssetAmount(testOrder, big.NewInt(1000000)),
-		ExpectedOrderStatus: Fillable,
-	},
-	testCase{
-		Order:               orderWithCustomTakerAssetAmount(testOrder, big.NewInt(0)),
-		ExpectedOrderStatus: InvalidTakerAssetAmount,
-	},
-	testCase{
-		Order:               orderWithCustomTakerAssetAmount(testOrder, big.NewInt(1000000)),
-		ExpectedOrderStatus: Fillable,
-	},
-	testCase{
-		Order:               orderWithCustomMakerAssetData(testOrder, multiAssetAssetData),
-		ExpectedOrderStatus: InvalidMakerAssetData,
-	},
-	testCase{
-		Order:               orderWithCustomTakerAssetData(testOrder, multiAssetAssetData),
-		ExpectedOrderStatus: InvalidTakerAssetData,
-	},
-	testCase{
-		Order:               orderWithCustomMakerAssetData(testOrder, malformedAssetData),
-		ExpectedOrderStatus: InvalidMakerAssetData,
-	},
-	testCase{
-		Order:               orderWithCustomTakerAssetData(testOrder, malformedAssetData),
-		ExpectedOrderStatus: InvalidTakerAssetData,
-	},
-	testCase{
-		Order:               orderWithCustomMakerAssetData(testOrder, unsupportedAssetData),
-		ExpectedOrderStatus: InvalidMakerAssetData,
-	},
-	testCase{
-		Order:               orderWithCustomTakerAssetData(testOrder, unsupportedAssetData),
-		ExpectedOrderStatus: InvalidTakerAssetData,
-	},
-	testCase{
-		Order:               orderWithCustomExpirationTimeSeconds(testOrder, big.NewInt(time.Now().Add(-5 * time.Minute).Unix())),
-		ExpectedOrderStatus: Expired,
-	},
-}
-
 func TestBatchValidateOffChainCases(t *testing.T) {
+	var testCases = []testCase{
+		testCase{
+			SignedOrder:               signedOrderWithCustomMakerAssetAmount(t, testSignedOrder, big.NewInt(0)),
+			ExpectedOrderStatus: InvalidMakerAssetAmount,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomMakerAssetAmount(t, testSignedOrder, big.NewInt(1000000)),
+			ExpectedOrderStatus: Fillable,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomTakerAssetAmount(t, testSignedOrder, big.NewInt(0)),
+			ExpectedOrderStatus: InvalidTakerAssetAmount,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomTakerAssetAmount(t, testSignedOrder, big.NewInt(1000000)),
+			ExpectedOrderStatus: Fillable,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomMakerAssetData(t, testSignedOrder, multiAssetAssetData),
+			ExpectedOrderStatus: InvalidMakerAssetData,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomTakerAssetData(t, testSignedOrder, multiAssetAssetData),
+			ExpectedOrderStatus: InvalidTakerAssetData,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomMakerAssetData(t, testSignedOrder, malformedAssetData),
+			ExpectedOrderStatus: InvalidMakerAssetData,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomTakerAssetData(t, testSignedOrder, malformedAssetData),
+			ExpectedOrderStatus: InvalidTakerAssetData,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomMakerAssetData(t, testSignedOrder, unsupportedAssetData),
+			ExpectedOrderStatus: InvalidMakerAssetData,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomTakerAssetData(t, testSignedOrder, unsupportedAssetData),
+			ExpectedOrderStatus: InvalidTakerAssetData,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomExpirationTimeSeconds(t, testSignedOrder, big.NewInt(time.Now().Add(-5 * time.Minute).Unix())),
+			ExpectedOrderStatus: Expired,
+		},
+		testCase{
+			SignedOrder:               signedOrderWithCustomSignature(t, testSignedOrder, malformedSignature),
+			ExpectedOrderStatus: SignatureInvalid,
+		},
+	}
+
 	for _, testCase := range testCases {
 
-		signedOrder, err := SignTestOrder(&testCase.Order)
-		require.NoError(t, err)
-
-		orderHash, err := signedOrder.ComputeOrderHash()
-		require.NoError(t, err)
+		orderHash, err := testCase.SignedOrder.ComputeOrderHash()
 
 		ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
 		require.NoError(t, err)
 
 		signedOrders := []*SignedOrder{
-			signedOrder,
+			&testCase.SignedOrder,
 		}
 
 		orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID)
@@ -112,40 +114,12 @@ func TestBatchValidateOffChainCases(t *testing.T) {
 		orderInfos := orderValidator.BatchValidate(signedOrders)
 		assert.Len(t, orderInfos, 1)
 		assert.Equal(t, testCase.ExpectedOrderStatus, orderInfos[orderHash].OrderStatus)
-		assert.Equal(t, signedOrder, orderInfos[orderHash].SignedOrder)
+		assert.Equal(t, &testCase.SignedOrder, orderInfos[orderHash].SignedOrder)
 	}
-}
-
-func TestBatchValidateMalformedSignature(t *testing.T) {
-	signedOrder := &SignedOrder{
-		Order: &testOrder,
-	}
-	// Incorrectly formatted signature
-	signedOrder.Signature = malformedSignature
-
-	orderHash, err := signedOrder.ComputeOrderHash()
-	require.NoError(t, err)
-
-	signedOrders := []*SignedOrder{
-		signedOrder,
-	}
-
-	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
-	require.NoError(t, err)
-
-	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID)
-	require.NoError(t, err)
-
-	orderInfos := orderValidator.BatchValidate(signedOrders)
-	assert.Len(t, orderInfos, 1)
-	assert.Equal(t, SignatureInvalid, orderInfos[orderHash].OrderStatus)
-	assert.Equal(t, signedOrder, orderInfos[orderHash].SignedOrder)
 }
 
 func TestBatchValidateSignatureInvalid(t *testing.T) {
-	signedOrder := &SignedOrder{
-		Order: &testOrder,
-	}
+	signedOrder := &testSignedOrder
 	// Add a correctly formatted signature that does not correspond to this order
 	signedOrder.Signature = common.Hex2Bytes("1c3582f06356a1314dbf1c0e534c4d8e92e59b056ee607a7ff5a825f5f2cc5e6151c5cc7fdd420f5608e4d5bef108e42ad90c7a4b408caef32e24374cf387b0d7603")
 
@@ -172,7 +146,7 @@ func TestCalculateRemainingFillableTakerAmount(t *testing.T) {
 	takerAssetAmount := big.NewInt(200000000000000000)
 	makerAssetAmount := big.NewInt(100000000000000000)
 	makerFee := big.NewInt(10000000000000000)
-	order := testOrder
+	order := copyOrder(*testSignedOrder.Order)
 	order.TakerAssetAmount = takerAssetAmount
 	order.MakerAssetAmount = makerAssetAmount
 	order.MakerFee = makerFee
@@ -291,23 +265,52 @@ func TestCalculateRemainingFillableTakerAmount(t *testing.T) {
 	assert.Equal(t, new(big.Int).Div(takerAssetAmount, big.NewInt(2)), remainingFillableTakerAssetAmount)
 }
 
-func orderWithCustomMakerAssetAmount(order Order, makerAssetAmount *big.Int) Order {
-	order.MakerAssetAmount = makerAssetAmount
-	return order
+func signedOrderWithCustomMakerAssetAmount(t *testing.T, signedOrder SignedOrder, makerAssetAmount *big.Int) SignedOrder {
+	signedOrderCopy := copySignedOrder(signedOrder)
+	signedOrderCopy.MakerAssetAmount = makerAssetAmount
+	signedOrderWithSignature, err := SignTestOrder(signedOrderCopy.Order)
+	require.NoError(t, err)
+	return *signedOrderWithSignature
 }
-func orderWithCustomTakerAssetAmount(order Order, takerAssetAmount *big.Int) Order {
-	order.TakerAssetAmount = takerAssetAmount
-	return order
+func signedOrderWithCustomTakerAssetAmount(t *testing.T, signedOrder SignedOrder, takerAssetAmount *big.Int) SignedOrder {
+	signedOrderCopy := copySignedOrder(signedOrder)
+	signedOrderCopy.TakerAssetAmount = takerAssetAmount
+	signedOrderWithSignature, err := SignTestOrder(signedOrderCopy.Order)
+	require.NoError(t, err)
+	return *signedOrderWithSignature
 }
-func orderWithCustomMakerAssetData(order Order, makerAssetData []byte) Order {
-	order.MakerAssetData = makerAssetData
-	return order
+func signedOrderWithCustomMakerAssetData(t *testing.T, signedOrder SignedOrder, makerAssetData []byte) SignedOrder {
+	signedOrderCopy := copySignedOrder(signedOrder)
+	signedOrderCopy.MakerAssetData = makerAssetData
+	signedOrderWithSignature, err := SignTestOrder(signedOrderCopy.Order)
+	require.NoError(t, err)
+	return *signedOrderWithSignature
 }
-func orderWithCustomTakerAssetData(order Order, takerAssetData []byte) Order {
-	order.TakerAssetData = takerAssetData
-	return order
+func signedOrderWithCustomTakerAssetData(t *testing.T, signedOrder SignedOrder, takerAssetData []byte) SignedOrder {
+	signedOrderCopy := copySignedOrder(signedOrder)
+	signedOrderCopy.TakerAssetData = takerAssetData
+	signedOrderWithSignature, err := SignTestOrder(signedOrderCopy.Order)
+	require.NoError(t, err)
+	return *signedOrderWithSignature
 }
-func orderWithCustomExpirationTimeSeconds(order Order, expirationTimeSeconds *big.Int) Order {
-	order.ExpirationTimeSeconds = expirationTimeSeconds
+func signedOrderWithCustomExpirationTimeSeconds(t *testing.T, signedOrder SignedOrder, expirationTimeSeconds *big.Int) SignedOrder {
+	signedOrderCopy := copySignedOrder(signedOrder)
+	signedOrderCopy.ExpirationTimeSeconds = expirationTimeSeconds
+	signedOrderWithSignature, err := SignTestOrder(signedOrderCopy.Order)
+	require.NoError(t, err)
+	return *signedOrderWithSignature
+}
+func signedOrderWithCustomSignature(t *testing.T, signedOrder SignedOrder, signature []byte) SignedOrder {
+	signedOrderCopy := copySignedOrder(signedOrder)
+	signedOrderCopy.Signature = signature
+	return signedOrderCopy
+}
+func copySignedOrder(signedOrder SignedOrder) SignedOrder {
+	s := signedOrder
+	order := copyOrder(*signedOrder.Order)
+	s.Order = &order
+	return s
+}
+func copyOrder(order Order) Order {
 	return order
 }

--- a/zeroex/orderwatch/expirationwatch.go
+++ b/zeroex/orderwatch/expirationwatch.go
@@ -134,7 +134,7 @@ func (e *ExpirationWatcher) Receive() <-chan []ExpiredOrder {
 // to the caller
 func (e *ExpirationWatcher) prune() []ExpiredOrder {
 	pruned := []ExpiredOrder{}
-	currentTimestamp := time.Now().UTC().Unix()
+	currentTimestamp := time.Now().Unix()
 	for {
 		e.rbTreeMu.RLock()
 		key, value := e.rbTree.Min()

--- a/zeroex/orderwatch/expirationwatch.go
+++ b/zeroex/orderwatch/expirationwatch.go
@@ -134,7 +134,7 @@ func (e *ExpirationWatcher) Receive() <-chan []ExpiredOrder {
 // to the caller
 func (e *ExpirationWatcher) prune() []ExpiredOrder {
 	pruned := []ExpiredOrder{}
-	currentTimestamp := time.Now().Unix()
+	currentTimestamp := time.Now().UTC().Unix()
 	for {
 		e.rbTreeMu.RLock()
 		key, value := e.rbTree.Min()


### PR DESCRIPTION
This PR completes: https://github.com/0xProject/0x-mesh/issues/85 and https://github.com/0xProject/0x-mesh/issues/57https://github.com/0xProject/0x-mesh/issues/57

- Previously we were relying entirely on on-chain 0x order validation. Not only was this inefficient, the very call to the contract would fail if the supplied orders with incorrectly formatted. This PR thus adds the following off-chain validation checks:
  - Make sure maker & taker assetData are decodable and supported
  - Make sure signature is properly formatted and supported
  - Make sure order isn't expired
  - Make sure maker & taker assetAmounts are not 0
If any of these checks fail, `BatchFill()` won't include these orders in the contract call. An `OrderInfo` object for these invalid orders is still returned from `BatchFill()` however.