### PR TITLE
Implement a max message size for orders

### DIFF
--- a/core/encoding.go
+++ b/core/encoding.go
@@ -4,15 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/0xProject/0x-mesh/p2p"
 	"github.com/0xProject/0x-mesh/zeroex"
 )
-
-// maxSizeInBytes is the maximum number of bytes allowed for encoded orders. It
-// is more than 10x the size of a typical ERC20 order.
-const maxSizeInBytes = 8192
-
-var errMaxSize = fmt.Errorf("message exceeds maximum size of %d bytes", maxSizeInBytes)
 
 type orderMessage struct {
 	MessageType string
@@ -35,38 +28,4 @@ func decodeOrder(data []byte) (*zeroex.SignedOrder, error) {
 		return nil, fmt.Errorf("unexpected message type: %q", orderMessage.MessageType)
 	}
 	return orderMessage.Order, nil
-}
-
-func validateMessageSize(message *p2p.Message) error {
-	if len(message.Data) > maxSizeInBytes {
-		return errMaxSize
-	}
-	return nil
-}
-
-func validateOrderSize(order *zeroex.SignedOrder) error {
-	encoded, err := encodeOrder(order)
-	if err != nil {
-		return err
-	}
-	if len(encoded) > maxSizeInBytes {
-		return errMaxSize
-	}
-	return nil
-}
-
-func filterOrdersBySize(orders []*zeroex.SignedOrder) (valid []*zeroex.SignedOrder, invalid []*zeroex.SignedOrder, err error) {
-	valid = []*zeroex.SignedOrder{}
-	invalid = []*zeroex.SignedOrder{}
-	for _, order := range orders {
-		err = validateOrderSize(order)
-		if err == nil {
-			valid = append(valid, order)
-		} else if err == errMaxSize {
-			invalid = append(invalid, order)
-		} else {
-			return nil, nil, err
-		}
-	}
-	return valid, invalid, nil
 }

--- a/core/encoding.go
+++ b/core/encoding.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/0xProject/0x-mesh/p2p"
@@ -12,6 +13,29 @@ import (
 const maxSizeInBytes = 8192
 
 var errMaxSize = fmt.Errorf("message exceeds maximum size of %d bytes", maxSizeInBytes)
+
+type orderMessage struct {
+	MessageType string
+	Order       *zeroex.SignedOrder
+}
+
+func encodeOrder(order *zeroex.SignedOrder) ([]byte, error) {
+	return json.Marshal(orderMessage{
+		MessageType: "order",
+		Order:       order,
+	})
+}
+
+func decodeOrder(data []byte) (*zeroex.SignedOrder, error) {
+	var orderMessage orderMessage
+	if err := json.Unmarshal(data, &orderMessage); err != nil {
+		return nil, err
+	}
+	if orderMessage.MessageType != "order" {
+		return nil, fmt.Errorf("unexpected message type: %q", orderMessage.MessageType)
+	}
+	return orderMessage.Order, nil
+}
 
 func validateMessageSize(message *p2p.Message) error {
 	if len(message.Data) > maxSizeInBytes {

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -77,6 +77,8 @@ func (app *App) ValidateAndStore(messages []*p2p.Message) ([]*p2p.Message, error
 				"maxSizeInBytes":    maxSizeInBytes,
 				"actualSizeInBytes": len(msg.Data),
 			}).Trace("received message that exceeds maximum size")
+			// TODO(albrow): Update peer scores via the Connection Manager. This
+			// incur a negative score.
 			continue
 		}
 		order, err := decodeOrder(msg.Data)

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -82,7 +82,12 @@ func (app *App) ValidateAndStore(messages []*p2p.Message) ([]*p2p.Message, error
 		}
 		order, err := decodeOrder(msg.Data)
 		if err != nil {
-			return nil, err
+			log.WithFields(map[string]interface{}{
+				"error": err,
+				"from":  msg.From,
+			}).Trace("could not decode received message")
+			app.handlePeerScoreEvent(msg.From, psInvalidMessage)
+			continue
 		}
 		orderHash, err := order.ComputeOrderHash()
 		if err != nil {

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -95,6 +95,15 @@ func (app *App) ValidateAndStore(messages []*p2p.Message) ([]*p2p.Message, error
 	orders := []*zeroex.SignedOrder{}
 	orderHashToMessage := map[common.Hash]*p2p.Message{}
 	for _, msg := range messages {
+		if err := validateMessageSize(msg); err != nil {
+			log.WithFields(map[string]interface{}{
+				"error":             err,
+				"from":              msg.From,
+				"maxSizeInBytes":    maxSizeInBytes,
+				"actualSizeInBytes": len(msg.Data),
+			}).Trace("received message that exceeds maximum size")
+			continue
+		}
 		order, err := decodeOrder(msg.Data)
 		if err != nil {
 			return nil, err

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -3,8 +3,6 @@
 package core
 
 import (
-	"encoding/json"
-	"fmt"
 	"math/rand"
 
 	"github.com/0xProject/0x-mesh/meshdb"
@@ -13,29 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	log "github.com/sirupsen/logrus"
 )
-
-type orderMessage struct {
-	MessageType string
-	Order       *zeroex.SignedOrder
-}
-
-func encodeOrder(order *zeroex.SignedOrder) ([]byte, error) {
-	return json.Marshal(orderMessage{
-		MessageType: "order",
-		Order:       order,
-	})
-}
-
-func decodeOrder(data []byte) (*zeroex.SignedOrder, error) {
-	var orderMessage orderMessage
-	if err := json.Unmarshal(data, &orderMessage); err != nil {
-		return nil, err
-	}
-	if orderMessage.MessageType != "order" {
-		return nil, fmt.Errorf("unexpected message type: %q", orderMessage.MessageType)
-	}
-	return orderMessage.Order, nil
-}
 
 // Ensure that App implements p2p.MessageHandler.
 var _ p2p.MessageHandler = &App{}

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -142,7 +142,7 @@ func (app *App) HandleMessages(messages []*p2p.Message) error {
 			"from":              msg.From.String(),
 		}).Warn("not storing rejected order received from peer")
 		switch rejectedOrderInfo.Status {
-		case ROInternalError, ROOrderAlreadyStored:
+		case ROInternalError, ROOrderAlreadyStored, zeroex.RORequestFailed:
 			// Don't incur a negative score for these status types (it might not be
 			// their fault).
 		default:

--- a/core/peer_score.go
+++ b/core/peer_score.go
@@ -1,0 +1,27 @@
+// +build !js
+
+package core
+
+import (
+	peer "github.com/libp2p/go-libp2p-peer"
+	log "github.com/sirupsen/logrus"
+)
+
+type peerScoreEvent uint
+
+const (
+	psInvalidMessage peerScoreEvent = iota
+	psValidMessage
+	psOrderStored
+)
+
+func (app *App) handlePeerScoreEvent(id peer.ID, event peerScoreEvent) {
+	switch event {
+	case psInvalidMessage:
+		app.node.UpdatePeerScore(id, -5)
+	case psValidMessage, psOrderStored:
+		// For now we don't update the score for these events. Might change later.
+	default:
+		log.WithField("event", event).Error("unknown peerScoreEvent")
+	}
+}

--- a/core/peer_score.go
+++ b/core/peer_score.go
@@ -16,11 +16,18 @@ const (
 )
 
 func (app *App) handlePeerScoreEvent(id peer.ID, event peerScoreEvent) {
+	// Note: for some events, we use `SetPeerScore` instead of `AddPeerScore` in
+	// order to limit the maximum positive score associated with that event.
+	// Without this, peers could be incentivized to artificially increase their
+	// score in a way that doesn't benefit the network. (For example, they could
+	// spam the network with valid messages).
 	switch event {
 	case psInvalidMessage:
-		app.node.UpdatePeerScore(id, -5)
-	case psValidMessage, psOrderStored:
-		// For now we don't update the score for these events. Might change later.
+		app.node.AddPeerScore(id, "invalid-message", -5)
+	case psValidMessage:
+		app.node.SetPeerScore(id, "valid-message", 5)
+	case psOrderStored:
+		app.node.SetPeerScore(id, "order-stored", 10)
 	default:
 		log.WithField("event", event).Error("unknown peerScoreEvent")
 	}

--- a/core/validation.go
+++ b/core/validation.go
@@ -1,0 +1,130 @@
+// +build !js
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/0xProject/0x-mesh/db"
+	"github.com/0xProject/0x-mesh/meshdb"
+	"github.com/0xProject/0x-mesh/p2p"
+	"github.com/0xProject/0x-mesh/zeroex"
+	"github.com/ethereum/go-ethereum/common"
+	log "github.com/sirupsen/logrus"
+)
+
+// maxOrderSizeInBytes is the maximum number of bytes allowed for encoded orders. It
+// is more than 10x the size of a typical ERC20 order.
+const maxOrderSizeInBytes = 8192
+
+var errMaxSize = fmt.Errorf("message exceeds maximum size of %d bytes", maxOrderSizeInBytes)
+
+// RejectedOrderStatus values
+var (
+	ROInternalError = zeroex.RejectedOrderStatus{
+		Code:    "InternalError",
+		Message: "an unexpected internal error has occurred",
+	}
+	ROMaxOrderSizeExceeded = zeroex.RejectedOrderStatus{
+		Code:    "MaxOrderSizeExceeded",
+		Message: fmt.Sprintf("order exceeds the maximum encoded size of %d bytes", maxOrderSizeInBytes),
+	}
+	ROOrderAlreadyStored = zeroex.RejectedOrderStatus{
+		Code:    "OrderAlreadyStored",
+		Message: "order is already stored",
+	}
+)
+
+// RejectedOrderKind values
+const (
+	MeshValidation = zeroex.RejectedOrderKind("MESH_VALIDATION")
+)
+
+// validateOrders applies general 0x validation and Mesh-specific validation to
+// the given orders.
+func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*zeroex.ValidationResults, error) {
+	results := &zeroex.ValidationResults{}
+	validMeshOrders := []*zeroex.SignedOrder{}
+	for _, order := range orders {
+		orderHash, err := order.ComputeOrderHash()
+		if err != nil {
+			log.WithField("error", err).Error("could not compute order hash")
+			results.Rejected = append(results.Rejected, &zeroex.RejectedOrderInfo{
+				OrderHash:   orderHash,
+				SignedOrder: order,
+				Kind:        zeroex.MeshError,
+				Status:      ROInternalError,
+			})
+			continue
+		}
+		if err := validateOrderSize(order); err != nil {
+			if err == errMaxSize {
+				results.Rejected = append(results.Rejected, &zeroex.RejectedOrderInfo{
+					OrderHash:   orderHash,
+					SignedOrder: order,
+					Kind:        MeshValidation,
+					Status:      ROMaxOrderSizeExceeded,
+				})
+				continue
+			} else {
+				log.WithField("error", err).Error("could not validate order size")
+				results.Rejected = append(results.Rejected, &zeroex.RejectedOrderInfo{
+					OrderHash:   orderHash,
+					SignedOrder: order,
+					Kind:        zeroex.MeshError,
+					Status:      ROInternalError,
+				})
+				continue
+			}
+		}
+		alreadyStored, err := app.orderAlreadyStored(orderHash)
+		if err != nil {
+			log.WithField("error", err).Error("could not check if order was already stored")
+			return nil, err
+		}
+		if alreadyStored {
+			results.Rejected = append(results.Rejected, &zeroex.RejectedOrderInfo{
+				OrderHash:   orderHash,
+				SignedOrder: order,
+				Kind:        MeshValidation,
+				Status:      ROOrderAlreadyStored,
+			})
+			continue
+		}
+		validMeshOrders = append(validMeshOrders, order)
+	}
+	zeroexResults := app.orderValidator.BatchValidate(validMeshOrders)
+	zeroexResults.Rejected = append(zeroexResults.Rejected, results.Rejected...)
+	return zeroexResults, nil
+}
+
+func validateMessageSize(message *p2p.Message) error {
+	if len(message.Data) > maxOrderSizeInBytes {
+		return errMaxSize
+	}
+	return nil
+}
+
+func validateOrderSize(order *zeroex.SignedOrder) error {
+	encoded, err := encodeOrder(order)
+	if err != nil {
+		return err
+	}
+	if len(encoded) > maxOrderSizeInBytes {
+		return errMaxSize
+	}
+	return nil
+}
+
+// TODO(albrow): Use the more efficient Exists method instead of FindByID.
+func (app *App) orderAlreadyStored(orderHash common.Hash) (bool, error) {
+	var order meshdb.Order
+	err := app.db.Orders.FindByID(orderHash.Bytes(), &order)
+	if err == nil {
+		return true, nil
+	}
+	if _, ok := err.(db.NotFoundError); ok {
+		return false, nil
+	}
+	return false, err
+}

--- a/core/validation.go
+++ b/core/validation.go
@@ -14,7 +14,7 @@ import (
 )
 
 // maxOrderSizeInBytes is the maximum number of bytes allowed for encoded orders. It
-// is more than 10x the size of a typical ERC20 order.
+// is more than 10x the size of a typical ERC20 order to account for multiAsset orders.
 const maxOrderSizeInBytes = 8192
 
 var errMaxSize = fmt.Errorf("message exceeds maximum size of %d bytes", maxOrderSizeInBytes)

--- a/core/validators.go
+++ b/core/validators.go
@@ -1,0 +1,48 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/0xProject/0x-mesh/p2p"
+	"github.com/0xProject/0x-mesh/zeroex"
+)
+
+// maxSizeInBytes is the maximum number of bytes allowed for encoded orders. It
+// is more than 10x the size of a typical ERC20 order.
+const maxSizeInBytes = 8192
+
+var errMaxSize = fmt.Errorf("message exceeds maximum size of %d bytes", maxSizeInBytes)
+
+func validateMessageSize(message *p2p.Message) error {
+	if len(message.Data) > maxSizeInBytes {
+		return errMaxSize
+	}
+	return nil
+}
+
+func validateOrderSize(order *zeroex.SignedOrder) error {
+	encoded, err := encodeOrder(order)
+	if err != nil {
+		return err
+	}
+	if len(encoded) > maxSizeInBytes {
+		return errMaxSize
+	}
+	return nil
+}
+
+func filterOrdersBySize(orders []*zeroex.SignedOrder) (valid []*zeroex.SignedOrder, invalid []*zeroex.SignedOrder, err error) {
+	valid = []*zeroex.SignedOrder{}
+	invalid = []*zeroex.SignedOrder{}
+	for _, order := range orders {
+		err = validateOrderSize(order)
+		if err == nil {
+			valid = append(valid, order)
+		} else if err == errMaxSize {
+			invalid = append(invalid, order)
+		} else {
+			return nil, nil, err
+		}
+	}
+	return valid, invalid, nil
+}

--- a/p2p/message.go
+++ b/p2p/message.go
@@ -14,11 +14,10 @@ type Message struct {
 // MessageHandler is an interface responsible for validating and storing
 // messages as well as selecting messages which are ready to be shared.
 type MessageHandler interface {
-	// ValidateAndStore validates the given messages and then stores and returns
-	// any that are valid. It should only return an error if there was a problem
-	// validating the messages. It should not return an error for invalid or
-	// duplicate messages.
-	ValidateAndStore([]*Message) ([]*Message, error)
+	// HandleMessages is called whenever new messages are received. It should only
+	// return an error if there was a problem handling the messages. It should not
+	// return an error for invalid or duplicate messages.
+	HandleMessages([]*Message) error
 	// GetMessagesToShare returns up to max messages to be shared with peers.
 	GetMessagesToShare(max int) ([][]byte, error)
 }

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -344,8 +344,7 @@ func (n *Node) runOnce() error {
 	if err != nil {
 		return err
 	}
-	_, err = n.messageHandler.ValidateAndStore(incoming)
-	if err != nil {
+	if err := n.messageHandler.HandleMessages(incoming); err != nil {
 		return fmt.Errorf("could not validate or store messages: %s", err.Error())
 	}
 
@@ -410,6 +409,9 @@ func (n *Node) receiveBatch() ([]*Message, error) {
 				return messages, nil
 			}
 			return nil, err
+		}
+		if msg.From == n.host.ID() {
+			continue
 		}
 		messages = append(messages, msg)
 	}

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -54,6 +54,9 @@ const (
 	// TODO(albrow): Is there a way to use a custom protocol ID with GossipSub?
 	// pubsubProtocolID = protocol.ID("/0x-mesh-gossipsub/0.0.1")
 	pubsubProtocolID = pubsub.GossipSubID
+	// customScoreTag is a tag used by the connection manager whenever UpdatePeerRank
+	// is called.
+	customScoreTag = "custom-score"
 )
 
 // bootstrapPeers is a list of peers to use for bootstrapping the DHT. Based on
@@ -280,6 +283,12 @@ func (n *Node) connectToBootstrapList() error {
 	time.Sleep(2 * time.Second)
 
 	return nil
+}
+
+// UpdatePeerSCore can be used to update the score for a given peer. Peers that
+// end up with a low score will eventually be disconnected.
+func (n *Node) UpdatePeerScore(id peer.ID, diff int) {
+	n.connManager.UpsertTag(id, customScoreTag, func(current int) int { return current + diff })
 }
 
 // Connect ensures there is a connection between this host and the peer with

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -30,8 +30,8 @@ const (
 // messages valid and doesn't actually store or share any messages.
 type dummyMessageHandler struct{}
 
-func (*dummyMessageHandler) ValidateAndStore(messages []*Message) ([]*Message, error) {
-	return messages, nil
+func (*dummyMessageHandler) HandleMessages(messages []*Message) error {
+	return nil
 }
 
 func (*dummyMessageHandler) GetMessagesToShare(max int) ([][]byte, error) {
@@ -197,21 +197,21 @@ func newInMemoryMessageHandler(validator func(*Message) (bool, error)) *inMemory
 	}
 }
 
-func (mh *inMemoryMessageHandler) ValidateAndStore(messages []*Message) ([]*Message, error) {
+func (mh *inMemoryMessageHandler) HandleMessages(messages []*Message) error {
 	validMessages := []*Message{}
 	for _, msg := range messages {
 		valid, err := mh.validator(msg)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if valid {
 			validMessages = append(validMessages, msg)
 		}
 	}
 	if err := mh.store(validMessages); err != nil {
-		return nil, err
+		return err
 	}
-	return validMessages, nil
+	return nil
 }
 
 func (mh *inMemoryMessageHandler) store(messages []*Message) error {


### PR DESCRIPTION
We've always wanted to perform ETH balance checks to limit the capacity for malicious actors to flood the network. The original plan was to calculate `(ETH balance of maker) / (total bytes of storage allocated to maker)`. However, we've discovered that it is almost impossible to determine the number of bytes of storage used by a given maker due to the fact that LevelDB uses opaque compression techniques. Even if we could do it, it would likely be computationally expensive and likely require iterating over a large number of keys.

As a compromise, we've chosen to use a less precise calculation: `(ETH balance of maker) / (total number of orders stored for that maker)`. Since orders can be theoretically unlimited in size, we've also decided to also add a max size for order messages. This PR implements that limit.

Still WIP while we figure out some interface design questions. I also want to update peer scores in the Connection Manager in this PR before we merge.