### PR TITLE
zeroex: Make `GetOrdersAndTradersInfo()` network request failure logs less noisy

### DIFF
--- a/db/escape.go
+++ b/db/escape.go
@@ -40,7 +40,7 @@ func unescape(value []byte) []byte {
 				// This is only possible if the value was not escaped properly. Should
 				// never happen.
 				log.WithFields(log.Fields{
-					"err":   err.Error(),
+					"error": err.Error(),
 					"value": hex.Dump(value),
 				}).Panic("unexpected error in unescape")
 			}

--- a/ethereum/eth_watcher.go
+++ b/ethereum/eth_watcher.go
@@ -74,7 +74,7 @@ func (e *ETHWatcher) Start() error {
 
 			if err := e.updateBalances(); err != nil {
 				log.WithFields(log.Fields{
-					"err": err.Error(),
+					"error": err.Error(),
 				}).Error("unexpected error from ETHWatcher.updateBalances()")
 			}
 

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -147,7 +147,7 @@ func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.H
 				results, err := o.orderValidator.GetOrdersAndTradersInfo(opts, params.Orders, params.Signatures, params.TakerAddresses)
 				if err != nil {
 					log.WithFields(log.Fields{
-						"err":       err.Error(),
+						"error":     err.Error(),
 						"attempt":   b.Attempt(),
 						"numOrders": len(params.Orders),
 					}).Info("GetOrdersAndTradersInfo request failed")
@@ -155,7 +155,7 @@ func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.H
 					if d == maxDuration {
 						<-semaphoreChan
 						log.WithFields(log.Fields{
-							"err":       err.Error(),
+							"error":     err.Error(),
 							"numOrders": len(params.Orders),
 						}).Warning("Gave up on GetOrdersAndTradersInfo request after backoff limit reached")
 						return // Give up after 4 attempts

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -147,18 +147,16 @@ func (o *OrderValidator) BatchValidate(signedOrders []*SignedOrder) map[common.H
 				results, err := o.orderValidator.GetOrdersAndTradersInfo(opts, params.Orders, params.Signatures, params.TakerAddresses)
 				if err != nil {
 					log.WithFields(log.Fields{
-						"err":            err.Error(),
-						"attempt":        b.Attempt(),
-						"orders":         params.Orders,
-						"takerAddresses": params.TakerAddresses,
+						"err":       err.Error(),
+						"attempt":   b.Attempt(),
+						"numOrders": len(params.Orders),
 					}).Info("GetOrdersAndTradersInfo request failed")
 					d := b.Duration()
 					if d == maxDuration {
 						<-semaphoreChan
 						log.WithFields(log.Fields{
-							"err":            err.Error(),
-							"orders":         params.Orders,
-							"takerAddresses": params.TakerAddresses,
+							"err":       err.Error(),
+							"numOrders": len(params.Orders),
 						}).Warning("Gave up on GetOrdersAndTradersInfo request after backoff limit reached")
 						return // Give up after 4 attempts
 					}

--- a/zeroex/orderwatch/watcher.go
+++ b/zeroex/orderwatch/watcher.go
@@ -292,7 +292,7 @@ func (w *Watcher) setupEventWatcher() {
 								continue
 							default:
 								logger.WithFields(logger.Fields{
-									"err": err.Error(),
+									"error": err.Error(),
 								}).Panic("unexpected event decoder error encountered")
 							}
 						}
@@ -400,7 +400,7 @@ func (w *Watcher) setupEventWatcher() {
 							orders, err := w.meshDB.FindOrdersByMakerAddressAndMaxSalt(exchangeCancelUpToEvent.MakerAddress, exchangeCancelUpToEvent.OrderEpoch)
 							if err != nil {
 								logger.WithFields(logger.Fields{
-									"err": err.Error(),
+									"error": err.Error(),
 								}).Panic("unexpected query error encountered")
 							}
 							w.generateOrderEventsIfChanged(orders)
@@ -438,7 +438,7 @@ func (w *Watcher) findOrdersAndGenerateOrderEvents(makerAddress, tokenAddress co
 	orders, err := w.meshDB.FindOrdersByMakerAddressTokenAddressAndTokenID(makerAddress, tokenAddress, tokenID)
 	if err != nil {
 		logger.WithFields(logger.Fields{
-			"err": err.Error(),
+			"error": err.Error(),
 		}).Panic("unexpected query error encountered")
 	}
 	w.generateOrderEventsIfChanged(orders)
@@ -539,7 +539,7 @@ func (w *Watcher) handleDecodeErr(err error, eventType string) {
 
 	default:
 		logger.WithFields(logger.Fields{
-			"err": err.Error(),
+			"error": err.Error(),
 		}).Panic("unexpected event decoder error encountered")
 	}
 }


### PR DESCRIPTION
This PR edits the logs emitted on `GetOrdersAndTradersInfo()` request failures since it was too noisy and of limited use. Most of the time the failure has nothing to do with the orders submitted and more to do with other network disruptions.