### PR TITLE
orderwatch: Avoid attempting to remove orders from ExpirationWatcher multiple times

### DIFF
--- a/zeroex/orderwatch/watcher.go
+++ b/zeroex/orderwatch/watcher.go
@@ -467,7 +467,7 @@ func (w *Watcher) generateOrderEventsIfChanged(orders []*meshdb.Order) {
 		if order.FillableTakerAssetAmount.Cmp(orderInfo.FillableTakerAssetAmount) != 0 {
 			isOrderUnfillable := orderInfo.FillableTakerAssetAmount.Cmp(big.NewInt(0)) == 0
 			if isOrderUnfillable {
-				didExpire := true
+				didExpire := false
 				w.unwatchOrder(order, didExpire)
 			} else {
 				w.rewatchOrder(order, orderInfo)

--- a/zeroex/orderwatch/watcher.go
+++ b/zeroex/orderwatch/watcher.go
@@ -506,9 +506,8 @@ func (w *Watcher) unwatchOrder(order *meshdb.Order, didExpire bool) {
 		}).Error("Failed to update order")
 	}
 
-	// If the order is being unwatched because it has expired, it will have been removed
-	// from the ExpirationWatcher immediately so that it can continue checking the remaining
-	// orders immediately
+	// If we unwatched the order but it didn't expire, we need to remove it from the expiration watcher. If
+	// it did expire, it will have already been removed so we don't need to remove it again.
 	if !didExpire {
 		w.expirationWatcher.Remove(order.SignedOrder.ExpirationTimeSeconds.Int64(), order.Hash)
 	}


### PR DESCRIPTION
When an expired order is discovered by the ExpirationWatcher it is immediately removed from it in order to continue validating other orders. The `unwatchOrder()` method in OrderWatcher was blindly telling the ExpirationWatcher to remove all orders, even those that should be unwatched because they have expired. This PR fixes the issue by discerning between `unwatch` requests because of expiry or other.