### PR TITLE
Implement Query.Offset method

### DIFF
--- a/db/query_test.go
+++ b/db/query_test.go
@@ -279,6 +279,14 @@ func testQueryWithFilter(t *testing.T, col *Collection, filter *Filter, expected
 			query:    col.NewQuery(filter).Reverse().Max(safeMax),
 			expected: reverseExpected[:safeMax],
 		},
+		{
+			query:    col.NewQuery(filter).Offset(1),
+			expected: expected[1:],
+		},
+		{
+			query:    col.NewQuery(filter).Offset(1).Max(safeMax - 1),
+			expected: expected[1:safeMax],
+		},
 	}
 
 	for i, tc := range testCases {

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -287,6 +287,14 @@ func testQueryWithFilter(t *testing.T, col *Collection, filter *Filter, expected
 			query:    col.NewQuery(filter).Offset(1).Max(safeMax - 1),
 			expected: expected[1:safeMax],
 		},
+		{
+			query:    col.NewQuery(filter).Offset(1).Reverse(),
+			expected: reverseExpected[1:],
+		},
+		{
+			query:    col.NewQuery(filter).Offset(1).Max(safeMax - 1).Reverse(),
+			expected: reverseExpected[1:safeMax],
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
`Query.Offset` is an analog to the [`OFFSET` keyword in SQL](https://www.postgresql.org/docs/current/queries-limit.html). (Just as `Query.Max` is the analog to `LIMIT` in SQL).

This feature is important for addressing https://github.com/0xProject/0x-mesh/issues/84 and will likely be useful for future optimizations as well.