### PR TITLE
Use GossipSub instead of FloodSub

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1198,7 +1198,6 @@
     "github.com/libp2p/go-libp2p-net",
     "github.com/libp2p/go-libp2p-peer",
     "github.com/libp2p/go-libp2p-peerstore",
-    "github.com/libp2p/go-libp2p-protocol",
     "github.com/libp2p/go-libp2p-pubsub",
     "github.com/multiformats/go-multiaddr",
     "github.com/ocdogan/rbt",

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -52,7 +52,7 @@ const (
 	advertiseTTL = 5 * time.Minute
 	// pubsubProtocolID is the protocol ID to use for pubsub.
 	// TODO(albrow): Is there a way to use a custom protocol ID with GossipSub?
-	// pubsubProtocolID = protocol.ID("/0x-mesh-floodsub/0.0.1")
+	// pubsubProtocolID = protocol.ID("/0x-mesh-gossipsub/0.0.1")
 	pubsubProtocolID = pubsub.GossipSubID
 )
 

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -186,8 +186,6 @@ func New(config Config) (*Node, error) {
 	routingDiscovery := discovery.NewRoutingDiscovery(kadDHT)
 
 	// Set up pubsub.
-	pubsub.GossipSubHistoryGossip = 10
-	pubsub.GossipSubHistoryLength = 20
 	ps, err := pubsub.NewGossipSub(nodeCtx, basicHost)
 	if err != nil {
 		cancel()

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -23,7 +23,6 @@ import (
 	p2pnet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
-	protocol "github.com/libp2p/go-libp2p-protocol"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
@@ -52,7 +51,9 @@ const (
 	// advertiseTTL is the TTL for our announcement to the discovery network.
 	advertiseTTL = 5 * time.Minute
 	// pubsubProtocolID is the protocol ID to use for pubsub.
-	pubsubProtocolID = protocol.ID("/0x-mesh-floodsub/0.0.1")
+	// TODO(albrow): Is there a way to use a custom protocol ID with GossipSub?
+	// pubsubProtocolID = protocol.ID("/0x-mesh-floodsub/0.0.1")
+	pubsubProtocolID = pubsub.GossipSubID
 )
 
 // bootstrapPeers is a list of peers to use for bootstrapping the DHT. Based on
@@ -185,8 +186,9 @@ func New(config Config) (*Node, error) {
 	routingDiscovery := discovery.NewRoutingDiscovery(kadDHT)
 
 	// Set up pubsub.
-	// TODO: Replace with WeijieSub. Using FloodSub for now.
-	ps, err := pubsub.NewFloodsubWithProtocols(nodeCtx, basicHost, []protocol.ID{pubsubProtocolID})
+	pubsub.GossipSubHistoryGossip = 10
+	pubsub.GossipSubHistoryLength = 20
+	ps, err := pubsub.NewGossipSub(nodeCtx, basicHost)
 	if err != nil {
 		cancel()
 		return nil, err


### PR DESCRIPTION
This PR changes our our main mechanism for communicating orders to peers from FloodSub to GossipSub. GossipSub is still not perfect for our use case, but it will dramatically reduce thrashing that can occur in FloodSub whenever new messages are sent to all peers. It should lead to more efficient bandwidth usage overall.

The change itself was really easy, but because GossipSub incurs higher latency, I had to make significant changes to our tests in order to get them working again.