### PR TITLE
Split order event subscription into separate demo script

### DIFF
--- a/cmd/demo/add_order/main.go
+++ b/cmd/demo/add_order/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"math/big"
 	"time"
 
@@ -53,13 +52,6 @@ func main() {
 		log.WithError(err).Fatal("could not create client")
 	}
 
-	ctx := context.Background()
-	orderInfosChan := make(chan []*zeroex.OrderInfo, 8000)
-	clientSubscription, err := client.SubscribeToOrders(ctx, orderInfosChan)
-	if err != nil {
-		log.WithError(err).Fatal("Couldn't set up OrderStream subscription")
-	}
-
 	ethClient, err := ethrpc.Dial(env.EthereumRPCURL)
 	if err != nil {
 		log.WithError(err).Fatal("could not create Ethereum rpc client")
@@ -78,9 +70,4 @@ func main() {
 	} else {
 		log.Printf("submitted %d orders. Added: %d, Invalid: %d, FailedToAdd: %d", len(signedTestOrders), len(addOrdersResponse.Added), len(addOrdersResponse.Invalid), len(addOrdersResponse.FailedToAdd))
 	}
-
-	orderInfos := <-orderInfosChan
-	log.Printf("Received order event: %+v\n", orderInfos[0])
-
-	clientSubscription.Unsubscribe()
 }

--- a/cmd/demo/subscribe_to_orders/main.go
+++ b/cmd/demo/subscribe_to_orders/main.go
@@ -1,0 +1,47 @@
+// +build !js
+
+// demo/add_order is a short program that adds an order to 0x Mesh via RPC
+package main
+
+import (
+	"context"
+
+	"github.com/0xProject/0x-mesh/rpc"
+	"github.com/0xProject/0x-mesh/zeroex"
+	"github.com/plaid/go-envvar/envvar"
+	log "github.com/sirupsen/logrus"
+)
+
+type clientEnvVars struct {
+	// RPCAddress is the address of the 0x Mesh node to communicate with.
+	RPCAddress string `envvar:"RPC_ADDRESS"`
+	// EthereumRPCURL is the URL of an Etheruem node which supports the JSON RPC
+	// API.
+	EthereumRPCURL string `envvar:"ETHEREUM_RPC_URL"`
+}
+
+func main() {
+	env := clientEnvVars{}
+	if err := envvar.Parse(&env); err != nil {
+		panic(err)
+	}
+
+	client, err := rpc.NewClient(env.RPCAddress)
+	if err != nil {
+		log.WithError(err).Fatal("could not create client")
+	}
+
+	ctx := context.Background()
+	orderInfosChan := make(chan []*zeroex.OrderInfo, 8000)
+	clientSubscription, err := client.SubscribeToOrders(ctx, orderInfosChan)
+	if err != nil {
+		log.WithError(err).Fatal("Couldn't set up OrderStream subscription")
+	}
+	defer clientSubscription.Unsubscribe()
+
+	for orderInfos := range orderInfosChan {
+		for _, orderInfo := range orderInfos {
+			log.Printf("Received order event: %+v\n", orderInfo)
+		}
+	}
+}

--- a/cmd/demo/subscribe_to_orders/main.go
+++ b/cmd/demo/subscribe_to_orders/main.go
@@ -15,9 +15,6 @@ import (
 type clientEnvVars struct {
 	// RPCAddress is the address of the 0x Mesh node to communicate with.
 	RPCAddress string `envvar:"RPC_ADDRESS"`
-	// EthereumRPCURL is the URL of an Etheruem node which supports the JSON RPC
-	// API.
-	EthereumRPCURL string `envvar:"ETHEREUM_RPC_URL"`
 }
 
 func main() {


### PR DESCRIPTION
It is useful to have a test script that continuously receives order events via subscription instead of just receiving one event. To accomplish this, I created a new script at __cmd/demo/subscribe_to_orders/main.go__. I also removed the subscription-related code from __cmd/demo/add_order/main.go__.