### PR TITLE
zeroex: Convert all struct keys to lower-case when output as JSON

### DIFF
--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -71,12 +71,12 @@ const (
 // OrderEvent is the order event emitted by Mesh nodes on the "orders" topic
 // when calling JSON-RPC method `mesh_subscribe`
 type OrderEvent struct {
-	OrderHash                common.Hash
-	SignedOrder              *SignedOrder
-	Kind                     OrderEventKind
-	FillableTakerAssetAmount *big.Int
+	OrderHash                common.Hash    `json:"orderHash"`
+	SignedOrder              *SignedOrder   `json:"signedOrder"`
+	Kind                     OrderEventKind `json:"kind"`
+	FillableTakerAssetAmount *big.Int       `json:"fillableTakerAssetAmount"`
 	// The hash of the Ethereum transaction that caused the order status to change
-	TxHash common.Hash
+	TxHash common.Hash `json:"txHash"`
 }
 
 // OrderEventKind enumerates all the possible order event types

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -47,17 +47,17 @@ type OrderInfo struct {
 // disruptions, etc...), we categorize them into `Kind`s and uniquely identify the reasons for
 // machines with a `Code`
 type RejectedOrderInfo struct {
-	OrderHash   common.Hash
-	SignedOrder *SignedOrder
-	Kind        RejectedOrderKind
-	Status      RejectedOrderStatus
+	OrderHash   common.Hash         `json:"orderHash"`
+	SignedOrder *SignedOrder        `json:"signedOrder"`
+	Kind        RejectedOrderKind   `json:"kind"`
+	Status      RejectedOrderStatus `json:"status"`
 }
 
 // AcceptedOrderInfo represents an fillable order and how much it could be filled for
 type AcceptedOrderInfo struct {
-	OrderHash                common.Hash
-	SignedOrder              *SignedOrder
-	FillableTakerAssetAmount *big.Int
+	OrderHash                common.Hash  `json:"orderHash"`
+	SignedOrder              *SignedOrder `json:"signedOrder"`
+	FillableTakerAssetAmount *big.Int     `json:"fillableTakerAssetAmount"`
 }
 
 // RejectedOrderStatus enumerates all the unique reasons for an orders rejection
@@ -142,8 +142,8 @@ const (
 // satisfy these conditions OR if we were unable to complete the validation process
 // for whatever reason
 type ValidationResults struct {
-	Accepted []*AcceptedOrderInfo
-	Rejected []*RejectedOrderInfo
+	Accepted []*AcceptedOrderInfo `json:"accepted"`
+	Rejected []*RejectedOrderInfo `json:"rejected"`
 }
 
 // OrderValidator validates 0x orders


### PR DESCRIPTION
These keys are sent over JSON-RPC to clients and their keys should be lower-case when sent.