### PR TITLE
[WIP] Initial dockerfile

### DIFF
--- a/cmd/mesh/Dockerfile
+++ b/cmd/mesh/Dockerfile
@@ -1,0 +1,16 @@
+FROM frolvlad/alpine-glibc
+
+WORKDIR /usr/mesh
+
+COPY mesh-linux-amd64 .
+COPY forever.sh .
+
+ENV RPC_PORT=60557           
+EXPOSE 60557
+
+RUN chmod +x ./mesh-linux-amd64
+RUN chmod +x ./forever.sh
+
+RUN apk add ca-certificates
+
+ENTRYPOINT ./forever.sh

--- a/cmd/mesh/forever.sh
+++ b/cmd/mesh/forever.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+RC=1
+while [ $RC -ne 0 ]; do
+  /usr/mesh/mesh-linux-amd64
+  RC=$?
+done


### PR DESCRIPTION
Fixes: #77 

This PR creates a Dockerfile for running a pre-built Mesh binary within a Docker container. 

TODO:
- [ ] Figure out what's requiring cgo, and one removed, use a vanilla `alpine` image instead of `frolvlad/alpine-glibc`