### PR TITLE
db: Add support for snapshots

### DIFF
--- a/db/collection.go
+++ b/db/collection.go
@@ -17,6 +17,8 @@ type Collection struct {
 	writerTransactor dbWriterTransactor
 }
 
+// readOnlyCollection is responsible for all the read-only methods and actions
+// associated with a collection. It cannot insert or delete any models.
 type readOnlyCollection struct {
 	reader    dbReader
 	name      string

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -7,21 +7,25 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
+// dbReader is an interface that encapsulates read-only functionality.
 type dbReader interface {
 	Get(key []byte, ro *opt.ReadOptions) (value []byte, err error)
 	Has(key []byte, ro *opt.ReadOptions) (ret bool, err error)
 	NewIterator(slice *util.Range, ro *opt.ReadOptions) iterator.Iterator
 }
 
+// dbWriter is an interface that encapsulates write/update functionality.
 type dbWriter interface {
 	Delete(key []byte, wo *opt.WriteOptions) error
 	Put(key, value []byte, wo *opt.WriteOptions) error
 }
 
+// dbTransactor is an interface for opening transactions.
 type dbTransactor interface {
 	OpenTransaction() (*leveldb.Transaction, error)
 }
 
+// dbWriterTransactor combines dbWriter and dbTransactor.
 type dbWriterTransactor interface {
 	dbWriter
 	dbTransactor

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -1,0 +1,28 @@
+package db
+
+import (
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+type dbReader interface {
+	Get(key []byte, ro *opt.ReadOptions) (value []byte, err error)
+	Has(key []byte, ro *opt.ReadOptions) (ret bool, err error)
+	NewIterator(slice *util.Range, ro *opt.ReadOptions) iterator.Iterator
+}
+
+type dbWriter interface {
+	Delete(key []byte, wo *opt.WriteOptions) error
+	Put(key, value []byte, wo *opt.WriteOptions) error
+}
+
+type dbTransactor interface {
+	OpenTransaction() (*leveldb.Transaction, error)
+}
+
+type dbWriterTransactor interface {
+	dbWriter
+	dbTransactor
+}

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -1,0 +1,32 @@
+package db
+
+import (
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+type Snapshot struct {
+	readOnlyCollection
+	snapshot *leveldb.Snapshot
+}
+
+// GetSnapshot returns a latest snapshot of the underlying DB. A snapshot is a
+// frozen snapshot of a DB state at a particular point in time. The content of
+// snapshot are guaranteed to be consistent. The snapshot must be released after
+// use, by calling Release method.
+func (db *DB) GetSnapshot(col *Collection) (*Snapshot, error) {
+	snapshot, err := db.ldb.GetSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	return &Snapshot{
+		readOnlyCollection: col.readOnlyCollection,
+		snapshot:           snapshot,
+	}, nil
+}
+
+// Release releases the snapshot. This will not release any ongoing queries,
+// which will still finish unless the database is closed. Other methods should
+// not be called after the snapshot has been released.
+func (s *Snapshot) Release() {
+	s.snapshot.Release()
+}

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -4,13 +4,13 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
+// Snapshot is a frozen snapshot of a DB state at a particular point in time.
 type Snapshot struct {
 	readOnlyCollection
 	snapshot *leveldb.Snapshot
 }
 
-// GetSnapshot returns a latest snapshot of the underlying DB. A snapshot is a
-// frozen snapshot of a DB state at a particular point in time. The content of
+// GetSnapshot returns a latest snapshot of the underlying DB. The content of
 // snapshot are guaranteed to be consistent. The snapshot must be released after
 // use, by calling Release method.
 func (db *DB) GetSnapshot(col *Collection) (*Snapshot, error) {

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -6,20 +6,20 @@ import (
 
 // Snapshot is a frozen snapshot of a DB state at a particular point in time.
 type Snapshot struct {
-	readOnlyCollection
+	*readOnlyCollection
 	snapshot *leveldb.Snapshot
 }
 
 // GetSnapshot returns a latest snapshot of the underlying DB. The content of
 // snapshot are guaranteed to be consistent. The snapshot must be released after
 // use, by calling Release method.
-func (db *DB) GetSnapshot(col *Collection) (*Snapshot, error) {
-	snapshot, err := db.ldb.GetSnapshot()
+func (c *Collection) GetSnapshot() (*Snapshot, error) {
+	snapshot, err := c.ldb.GetSnapshot()
 	if err != nil {
 		return nil, err
 	}
 	return &Snapshot{
-		readOnlyCollection: col.readOnlyCollection,
+		readOnlyCollection: c.readOnlyCollection,
 		snapshot:           snapshot,
 	}, nil
 }

--- a/db/snapshot_test.go
+++ b/db/snapshot_test.go
@@ -29,7 +29,7 @@ func TestSnapshot(t *testing.T) {
 	}
 
 	// Take a snapshot.
-	snapshot, err := db.GetSnapshot(col)
+	snapshot, err := col.GetSnapshot()
 	require.NoError(t, err)
 	defer snapshot.Release()
 

--- a/db/snapshot_test.go
+++ b/db/snapshot_test.go
@@ -1,0 +1,53 @@
+package db
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshot(t *testing.T) {
+	db := newTestDB(t)
+	col := db.NewCollection("people", &testModel{})
+
+	ageIndex := col.AddIndex("age", func(m Model) []byte {
+		return []byte(fmt.Sprint(m.(*testModel).Age))
+	})
+
+	// expected is a set of testModels with Age = 42
+	expected := []*testModel{}
+	for i := 0; i < 5; i++ {
+		model := &testModel{
+			Name: "ExpectedPerson_" + strconv.Itoa(i),
+			Age:  42,
+		}
+		require.NoError(t, col.Insert(model))
+		expected = append(expected, model)
+	}
+
+	// Take a snapshot.
+	snapshot, err := db.GetSnapshot(col)
+	require.NoError(t, err)
+	defer snapshot.Release()
+
+	// Any models we add after taking the snapshot should not be included in the
+	// query.
+	for i := 0; i < 5; i++ {
+		model := &testModel{
+			Name: "OtherPerson_" + strconv.Itoa(i),
+			Age:  i,
+		}
+		require.NoError(t, col.Insert(model))
+	}
+
+	// Make sure that only models we inserted before taking the snapshot are
+	// included in the query results.
+	filter := ageIndex.ValueFilter([]byte("42"))
+	query := snapshot.NewQuery(filter)
+	var actual []*testModel
+	require.NoError(t, query.Run(&actual))
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
This is a prerequisite for https://github.com/0xProject/0x-mesh/issues/86. Without the ability to take a snapshot, we can't guarantee a consistent view of the current set of orders for RPC clients.

For the implementation, I first recognized that there are some common methods between [`leveldb.Snapshot`](https://godoc.org/github.com/syndtr/goleveldb/leveldb#Snapshot) and [`leveldb.DB`](https://godoc.org/github.com/syndtr/goleveldb/leveldb#DB). Specifically, the `Get`, `Has`, and `NewIterator` methods. These are the methods that we rely on throughout the codebase (e.g. for creating and running queries). I encapsulated the common functionality in an interface called `dbReader`, and we now use `dbReader` instead of `*db.DB` wherever possible. This abstraction allows us to use the same underlying code for running queries, regardless of whether or not we are running them against a snapshot.

I also went ahead and abstracted the methods related to writing/updating the database. These will be useful when we add support for transactions in #22.