### PR TITLE
Fix Mesh compilation without CGO & WASM compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
       - run:
           name: Run Go tests
           command: make test-go
-    # TODO(albrow): Re-enable Wasm tests after we fix issues with go-ethereum.  
-    #   - run:
-    #       name: Run WebAssembly tests
-    #       command: make test-wasm
+      - run:
+          name: Run WebAssembly tests
+          command: make test-wasm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,3 +40,6 @@ jobs:
       - run:
           name: Run WebAssembly tests
           command: make test-wasm
+      - run:
+          name: Test installing Mesh with CGO
+          command: CGO_ENABLED=0 go install ./...

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -69,8 +69,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master_with_fix"
-  digest = "1:dd2e15ee36c195dcdc018c745ac3fd59a679331d1e8ca06ac72b28ede41ae788"
+  branch = "updated_wasm_signer_core"
+  digest = "1:57c7a97fda5024407fb7e5edb3ba578b2fead14e408e6be518bc096945fb8ab0"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -126,7 +126,7 @@
     "trie",
   ]
   pruneopts = "T"
-  revision = "018cc4c323bcac27ce585adf815fb4620a1cc153"
+  revision = "715ecba95505d2d558cea273a7c2a162370e0eb1"
   source = "github.com/0xProject/go-ethereum"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -69,8 +69,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "updated_wasm_signer_core"
-  digest = "1:57c7a97fda5024407fb7e5edb3ba578b2fead14e408e6be518bc096945fb8ab0"
+  branch = "wasm_signer_core_1"
+  digest = "1:0cbe3816c19b5e8def421e948377963a877b444e2fdd62126791998c2e27749a"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -126,15 +126,15 @@
     "trie",
   ]
   pruneopts = "T"
-  revision = "715ecba95505d2d558cea273a7c2a162370e0eb1"
+  revision = "f0a71cf559354873939c1a5ea980288bac9a40f4"
   source = "github.com/0xProject/go-ethereum"
 
 [[projects]]
-  digest = "1:c52ac440c00e8b404a713a2de487b7b5e0e93a89a758832d9fc15b2817d6d5d6"
+  digest = "1:488fd8ad8e2a40f5a4dc76dd1fc8e90f850bc481d2991f34b4b9720f48fd2f48"
   name = "github.com/gballet/go-libpcsclite"
   packages = ["."]
   pruneopts = "UT"
-  revision = "312b5175032f98274685a4dd81935a92ad2412a5"
+  revision = "2fd9b619dd3c5d74acbd975f997a6441984d74a7"
 
 [[projects]]
   digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -69,8 +69,8 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "wasm_signer_core"
-  digest = "1:ab24cc688093e2a228d54637ba05f154e6512c3724cb10e4dcd26266ff8ca5ac"
+  branch = "master_with_fix"
+  digest = "1:dd2e15ee36c195dcdc018c745ac3fd59a679331d1e8ca06ac72b28ede41ae788"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -126,7 +126,7 @@
     "trie",
   ]
   pruneopts = "T"
-  revision = "6d8ecdbbf27f2999296e481c289b645dac918e1a"
+  revision = "018cc4c323bcac27ce585adf815fb4620a1cc153"
   source = "github.com/0xProject/go-ethereum"
 
 [[projects]]
@@ -756,6 +756,14 @@
   version = "v0.0.8"
 
 [[projects]]
+  digest = "1:0356f3312c9bd1cbeda81505b7fd437501d8e778ab66998ef69f00d7f9b3a0d7"
+  name = "github.com/mattn/go-runewidth"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3ee7d812e62a0804a7d0a324e0249ca2db3476d3"
+  version = "v0.0.4"
+
+[[projects]]
   branch = "master"
   digest = "1:130cefe87d7eeefc824978dcb78e35672d4c49a11f25c153fbf0cfd952756fa3"
   name = "github.com/minio/blake2b-simd"
@@ -844,6 +852,14 @@
   revision = "de6e2b48be337942e6298423f95725aba2152cea"
 
 [[projects]]
+  digest = "1:abcdbf03ca6ca13d3697e2186edc1f33863bbdac2b3a44dfa39015e8903f7409"
+  name = "github.com/olekukonko/tablewriter"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e6d60cf7ba1f42d86d54cdf5508611c4aafb3970"
+  version = "v0.0.1"
+
+[[projects]]
   digest = "1:11e62d6050198055e6cd87ed57e5d8c669e84f839c16e16f192374d913d1a70d"
   name = "github.com/opentracing/opentracing-go"
   packages = [
@@ -886,6 +902,14 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:1b8344715571e257101066e65d0bc8172715ecf09c8bd09b56763ec6389395e4"
+  name = "github.com/prometheus/tsdb"
+  packages = ["fileutil"]
+  pruneopts = "UT"
+  revision = "d48a5e2d5c34116dfcbc7b935c66157847b2d8b5"
+  version = "v0.8.0"
 
 [[projects]]
   digest = "1:31d83d1b1c288073c91abadee3caec87de2a1fb5dbe589039264a802e67a26b8"
@@ -945,6 +969,22 @@
   packages = ["derivationpath"]
   pruneopts = "UT"
   revision = "d95853db0f480b9d6379009500acf44b21dc0be6"
+
+[[projects]]
+  digest = "1:266e2f508feb9a9a765bfeb74d116a88514248b2f8428788dcce574bd026b9c0"
+  name = "github.com/steakknife/bloomfilter"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "99ee86d9200fcc2ffde62f508329bd6627c0a307"
+  version = "1.0.4"
+
+[[projects]]
+  digest = "1:5ca4bdccd72e66aaba5b52f9c4a21f1021102f0919432fe138ad5d48abf06833"
+  name = "github.com/steakknife/hamming"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "003c143a81c25ea5e263d692919c611c7122ae6b"
+  version = "0.2.5"
 
 [[projects]]
   digest = "1:5da8ce674952566deae4dbc23d07c85caafc6cfa815b0b3e03e41979cedb8750"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  branch = "wasm_signer_core"
+  branch = "master_with_fix"
   source = "github.com/0xProject/go-ethereum"
   
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  branch = "updated_wasm_signer_core"
+  branch = "wasm_signer_core_1"
   source = "github.com/0xProject/go-ethereum"
   
 [[constraint]]
@@ -97,6 +97,6 @@
 
 [[override]]
   name = "github.com/gballet/go-libpcsclite"
-  revision = "312b5175032f98274685a4dd81935a92ad2412a5"
+  revision = "2fd9b619dd3c5d74acbd975f997a6441984d74a7"
   [metadata]
     note = "go-ethereum depends on this package and they made a breaking API change"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  branch = "master_with_fix"
+  branch = "updated_wasm_signer_core"
   source = "github.com/0xProject/go-ethereum"
   
 [[constraint]]


### PR DESCRIPTION
Fixes: #112

This PR supercedes #127 now that we've found an approach that doesn't require the removal of local signer.

The fix involved updating our `go-ethereum` dependency to include the commit that fixed their `CGO_ENABLED=0` flag. The new changes brought in also changed the code in `signer/core` so I had to make new changes in that package to re-enable WASM compilation (https://github.com/0xProject/go-ethereum/pull/5).

Mesh can now be compiled without cgo by running:

```
CGO_ENABLED=0 go build  -tags kqueue ./cmd/mesh
```

Note: the kqueue tags as per: https://github.com/rjeczalik/notify/issues/108