### PR TITLE
Add support for persistent identities via a private key file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 vendor/
 node_modules/
 TODO.md
-0x_mesh_db/
+0x_mesh/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1247,6 +1247,7 @@
     "github.com/stretchr/testify/require",
     "github.com/syndtr/goleveldb/leveldb",
     "github.com/syndtr/goleveldb/leveldb/iterator",
+    "github.com/syndtr/goleveldb/leveldb/opt",
     "github.com/syndtr/goleveldb/leveldb/util",
     "golang.org/x/crypto/sha3",
   ]

--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,12 @@ lint:
 .PHONY: mesh
 mesh:
 	go install ./cmd/mesh
+
+
+.PHONY: mesh-keygen
+mesh-keygen:
+	go install ./cmd/mesh-keygen
+
+
+.PHONY: all
+all: mesh mesh-keygen

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![GoDoc](https://godoc.org/github.com/0xProject/0x-mesh?status.svg)](https://godoc.org/github.com/0xProject/0x-mesh)
 [![Circle CI](https://img.shields.io/circleci/project/0xProject/0x-mesh/master.svg)](https://circleci.com/gh/0xProject/0x-mesh/tree/master)
 
-
 # 0x-mesh
 
 A peer-to-peer network for sharing orders
@@ -44,6 +43,21 @@ If you have `GOPATH/bin` in your `PATH`, you can now run 0x Mesh directly with:
 
 ```
 mesh
+```
+
+### Generating private keys
+
+Mesh ships with a utility called `mesh-keygen` for generating private keys,
+which are used for signing messages sent to peers. Build the tool with:
+
+```
+make mesh-keygen
+```
+
+If you have `GOPATH/bin` in your `PATH`, you can now run it directly with:
+
+```
+mesh-keygen
 ```
 
 ### Running tests

--- a/cmd/mesh-keygen/main.go
+++ b/cmd/mesh-keygen/main.go
@@ -1,0 +1,46 @@
+// +build !js
+
+// mesh-keygen is a short program that can be used to generate private keys.
+package main
+
+import (
+	"crypto/rand"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	p2pcrypto "github.com/libp2p/go-libp2p-crypto"
+	"github.com/plaid/go-envvar/envvar"
+)
+
+type envVars struct {
+	// PrivateKeyPath is the path where the private key will be written.
+	PrivateKeyPath string `envvar:"PRIVATE_KEY_PATH" default:"./0x_mesh/key/privkey"`
+}
+
+func main() {
+	env := envVars{}
+	if err := envvar.Parse(&env); err != nil {
+		panic(err)
+	}
+	if _, err := os.Stat(env.PrivateKeyPath); !os.IsNotExist(err) {
+		log.Fatalf("Key file: %s already exists. If you really want to overwrite it, delete the file and try again.", env.PrivateKeyPath)
+	}
+	dir := filepath.Dir(env.PrivateKeyPath)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		log.Fatal(err)
+	}
+	privKey, _, err := p2pcrypto.GenerateSecp256k1Key(rand.Reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+	keyBytes, err := p2pcrypto.MarshalPrivateKey(privKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+	encodedKey := p2pcrypto.ConfigEncodeKey(keyBytes)
+	if err := ioutil.WriteFile(env.PrivateKeyPath, []byte(encodedKey), os.ModePerm); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/core/core.go
+++ b/core/core.go
@@ -34,7 +34,7 @@ type Config struct {
 	// Verbosity is the logging verbosity: 0=panic, 1=fatal, 2=error, 3=warn, 4=info, 5=debug 6=trace
 	Verbosity int `envvar:"VERBOSITY" default:"2"`
 	// DatabaseDir is the directory to use for persisting the database.
-	DatabaseDir string `envvar:"DATABASE_DIR" default:"./0x_mesh_db"`
+	DatabaseDir string `envvar:"DATABASE_DIR" default:"./0x_mesh/db"`
 	// P2PListenPort is the port on which to listen for new peer connections. By
 	// default, 0x Mesh will let the OS select a randomly available port.
 	P2PListenPort int `envvar:"P2P_LISTEN_PORT" default:"0"`
@@ -47,6 +47,10 @@ type Config struct {
 	// UseBootstrapList is whether to use the predetermined list of peers to
 	// bootstrap the DHT and peer discovery.
 	UseBootstrapList bool `envvar:"USE_BOOTSTRAP_LIST" default:"false"`
+	// PrivateKeyPath is the path to a to a Secp256k1 private key which will be
+	// used for signing messages and generating a peer ID. If empty, a randomly
+	// generated key will be used.
+	PrivateKeyPath string `envvar:"PRIVATE_KEY_PATH" default:"./0x_mesh/key/privkey"`
 }
 
 type App struct {
@@ -127,7 +131,7 @@ func New(config Config) (*App, error) {
 		Topic:            pubsubTopic,
 		ListenPort:       config.P2PListenPort,
 		Insecure:         false,
-		RandSeed:         0,
+		PrivateKeyPath:   config.PrivateKeyPath,
 		MessageHandler:   app,
 		RendezvousString: "/0x-mesh/0.0.1",
 		UseBootstrapList: config.UseBootstrapList,

--- a/core/core.go
+++ b/core/core.go
@@ -47,7 +47,7 @@ type Config struct {
 	// UseBootstrapList is whether to use the predetermined list of peers to
 	// bootstrap the DHT and peer discovery.
 	UseBootstrapList bool `envvar:"USE_BOOTSTRAP_LIST" default:"false"`
-	// PrivateKeyPath is the path to a to a Secp256k1 private key which will be
+	// PrivateKeyPath is the path to a Secp256k1 private key which will be
 	// used for signing messages and generating a peer ID. If empty, a randomly
 	// generated key will be used.
 	PrivateKeyPath string `envvar:"PRIVATE_KEY_PATH" default:"./0x_mesh/key/privkey"`

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"sort"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -78,8 +77,8 @@ func newTestNode(t *testing.T) *Node {
 	t.Helper()
 	config := Config{
 		Topic:            testTopic,
-		ListenPort:       0, // Let OS randomly choose an open port.
-		RandSeed:         atomic.AddInt64(&counter, 1),
+		ListenPort:       0,  // Let OS randomly choose an open port.
+		PrivateKeyPath:   "", // Randomly generate a new private key.
 		MessageHandler:   &dummyMessageHandler{},
 		RendezvousString: testRendezvousString,
 	}


### PR DESCRIPTION
Fixes #130.

I also added a new command-line tool called `mesh-keygen` for generating key files in the appropriate format.