### PR TITLE
Add multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+  # mesh-builder produces a statically linked binary
+FROM golang:1.12.1-alpine3.9 as mesh-builder
+
+
+RUN apk update && apk add ca-certificates nodejs-current npm make git dep
+RUN npm install -g yarn
+
+WORKDIR /go/src/github.com/0xProject/0x-mesh
+
+ADD . ./
+
+
+RUN make deps
+
+RUN CGO_ENABLED=0 go build ./cmd/mesh
+
+# Final Image
+FROM alpine:3.9
+
+RUN apk update && apk add ca-certificates --no-cache
+
+WORKDIR /usr/mesh
+
+COPY --from=mesh-builder /go/src/github.com/0xProject/0x-mesh/mesh /usr/mesh/mesh
+
+ENV RPC_PORT=60557
+EXPOSE 60557
+
+RUN chmod +x ./mesh
+
+ENTRYPOINT ./mesh


### PR DESCRIPTION
# About

This PR adds a multi-stage `Dockerfile` that builds mesh without CGO.

The end alpine image contains only the statically linked binary -> no dependency on `musl` / `glibc`.

Supersedes https://github.com/0xProject/0x-mesh/pull/128 - removed the change to Makefile, and this PR is against master.