### PR TITLE
Fix bug where snapshot was not correctly isolated

### DIFF
--- a/db/collection.go
+++ b/db/collection.go
@@ -26,7 +26,8 @@ type readOnlyCollection struct {
 	name      string
 	modelType reflect.Type
 	indexes   []*Index
-	indexMut  sync.RWMutex
+	// indexMut protects the indexes slice.
+	indexMut sync.RWMutex
 }
 
 // writeableCollection is an extension of readonlyCollection which adds support

--- a/db/index.go
+++ b/db/index.go
@@ -38,6 +38,8 @@ func (c *Collection) AddIndex(name string, getter func(Model) []byte) *Index {
 // will *not* be indexed. Note that in order to function correctly, indexes must
 // be based on data that is actually saved to the database (e.g. exported struct fields).
 func (c *Collection) AddMultiIndex(name string, getter func(Model) [][]byte) *Index {
+	c.indexMut.Lock()
+	defer c.indexMut.Unlock()
 	index := &Index{
 		col:    c,
 		name:   name,

--- a/db/query.go
+++ b/db/query.go
@@ -157,7 +157,7 @@ func (q *Query) getModelsWithIteratorForward(iter iterator.Iterator, models inte
 		if i < q.offset {
 			continue
 		}
-		if err := getAndAppendModelIfUnique(q.filter.index, pkSet, iter.Key(), modelsVal); err != nil {
+		if err := q.getAndAppendModelIfUnique(q.filter.index, pkSet, iter.Key(), modelsVal); err != nil {
 			return err
 		}
 		if q.max != 0 && modelsVal.Len() >= q.max {
@@ -178,7 +178,7 @@ func (q *Query) getModelsWithIteratorReverse(iter iterator.Iterator, models inte
 		if i < q.offset {
 			continue
 		}
-		if err := getAndAppendModelIfUnique(q.filter.index, pkSet, iter.Key(), modelsVal); err != nil {
+		if err := q.getAndAppendModelIfUnique(q.filter.index, pkSet, iter.Key(), modelsVal); err != nil {
 			return err
 		}
 		if q.max != 0 && modelsVal.Len() >= q.max {
@@ -188,7 +188,7 @@ func (q *Query) getModelsWithIteratorReverse(iter iterator.Iterator, models inte
 	return iter.Error()
 }
 
-func getAndAppendModelIfUnique(index *Index, pkSet stringset.Set, key []byte, modelsVal reflect.Value) error {
+func (q *Query) getAndAppendModelIfUnique(index *Index, pkSet stringset.Set, key []byte, modelsVal reflect.Value) error {
 	// We assume that each key in the iterator consists of an index prefix, the
 	// value for a particular model, and the model ID. We can extract a primary
 	// key from this key and use it to get the encoded data for the model
@@ -198,11 +198,11 @@ func getAndAppendModelIfUnique(index *Index, pkSet stringset.Set, key []byte, mo
 		return nil
 	}
 	pkSet.Add(string(pk))
-	data, err := index.col.reader.Get(pk, nil)
+	data, err := q.col.reader.Get(pk, nil)
 	if err != nil {
 		return err
 	}
-	model := reflect.New(index.col.modelType)
+	model := reflect.New(q.col.modelType)
 	if err := json.Unmarshal(data, model.Interface()); err != nil {
 		return err
 	}

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -21,7 +21,7 @@ func (c *Collection) GetSnapshot() (*Snapshot, error) {
 	c.indexMut.RLock()
 	indexes := make([]*Index, len(c.indexes))
 	copy(indexes, c.indexes)
-	defer c.indexMut.RUnlock()
+	c.indexMut.RUnlock()
 	return &Snapshot{
 		readOnlyCollection: &readOnlyCollection{
 			reader:    snapshot,

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -18,9 +18,18 @@ func (c *Collection) GetSnapshot() (*Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
+	c.indexMut.RLock()
+	indexes := make([]*Index, len(c.indexes))
+	copy(indexes, c.indexes)
+	defer c.indexMut.RUnlock()
 	return &Snapshot{
-		readOnlyCollection: c.readOnlyCollection,
-		snapshot:           snapshot,
+		readOnlyCollection: &readOnlyCollection{
+			reader:    snapshot,
+			name:      c.name,
+			modelType: c.modelType,
+			indexes:   indexes,
+		},
+		snapshot: snapshot,
 	}, nil
 }
 


### PR DESCRIPTION
I discovered a bug in the snapshot feature introduced in #132. The tests were not sufficient to catch the bug, so this PR also improves the snapshot tests.

WIP because there is still an issue where `Delete` is not correctly isolated. When you call `Delete` after a snapshot is taken, the model also appears to be deleted in the snapshot.