### PR TITLE
rpc: Address `broken pipe` log spam

### DIFF
--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -97,7 +97,8 @@ func SetupOrderStream(ctx context.Context, app *core.App) (*ethRpc.Subscription,
 				if err != nil {
 					log.WithField("error", err.Error()).Error("error while calling notifier.Notify")
 				}
-			case <-rpcSub.Err():
+			case err := <-rpcSub.Err():
+				log.WithField("err", err).Error("rpcSub returned an error")
 				orderWatcherSub.Unsubscribe()
 				return
 			case <-notifier.Closed():


### PR DESCRIPTION
Fixes: #109 

This PR:
- Adds logging of the err returned on rpcSub.Err() 
- Special-cases logging the expected `broken pipe` errors after a client disconnects as `trace` instead of the usual `error` severity. The `TODO` comment also documents this known race condition.