### PR TITLE
Implement database transactions

### DIFF
--- a/db/batch.go
+++ b/db/batch.go
@@ -1,0 +1,44 @@
+package db
+
+import (
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+type readerWithBatchWriter struct {
+	reader dbReader
+	batch  *leveldb.Batch
+}
+
+func newReaderWithBatchWriter(reader dbReader) *readerWithBatchWriter {
+	return &readerWithBatchWriter{
+		reader: reader,
+		batch:  &leveldb.Batch{},
+	}
+}
+
+var _ dbReadWriter = &readerWithBatchWriter{}
+
+func (readWriter *readerWithBatchWriter) Get(key []byte, ro *opt.ReadOptions) ([]byte, error) {
+	return readWriter.reader.Get(key, ro)
+}
+
+func (readWriter *readerWithBatchWriter) NewIterator(slice *util.Range, ro *opt.ReadOptions) iterator.Iterator {
+	return readWriter.reader.NewIterator(slice, ro)
+}
+
+func (readWriter *readerWithBatchWriter) Has(key []byte, ro *opt.ReadOptions) (bool, error) {
+	return readWriter.reader.Has(key, ro)
+}
+
+func (readWriter *readerWithBatchWriter) Delete(key []byte, wo *opt.WriteOptions) error {
+	readWriter.batch.Delete(key)
+	return nil
+}
+
+func (readWriter *readerWithBatchWriter) Put(key, value []byte, wo *opt.WriteOptions) error {
+	readWriter.batch.Put(key, value)
+	return nil
+}

--- a/db/col_info.go
+++ b/db/col_info.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+)
+
+type colInfo struct {
+	name      string
+	modelType reflect.Type
+	indexes   []*Index
+	// indexMut protects the indexes slice.
+	indexMut sync.RWMutex
+}
+
+func (c *colInfo) copy() *colInfo {
+	c.indexMut.RLock()
+	indexes := make([]*Index, len(c.indexes))
+	copy(indexes, c.indexes)
+	c.indexMut.RUnlock()
+	return &colInfo{
+		name:      c.name,
+		modelType: c.modelType,
+		indexes:   indexes,
+	}
+}
+
+func (c *colInfo) prefix() []byte {
+	return []byte(fmt.Sprintf("model:%s", c.name))
+}
+
+func (c *colInfo) primaryKeyForModel(model Model) []byte {
+	return c.primaryKeyForID(model.ID())
+}
+
+func (c *colInfo) primaryKeyForID(id []byte) []byte {
+	return []byte(fmt.Sprintf("%s:%s", c.prefix(), escape(id)))
+}
+
+func (c *colInfo) primaryKeyForIDWithoutEscape(id []byte) []byte {
+	return []byte(fmt.Sprintf("%s:%s", c.prefix(), id))
+}
+
+func (c *colInfo) checkModelType(model Model) error {
+	actualType := reflect.TypeOf(model)
+	if c.modelType != actualType {
+		if actualType.Kind() == reflect.Ptr {
+			if c.modelType == actualType.Elem() {
+				// Pointers to the expected type are allowed here.
+				return nil
+			}
+		}
+		return fmt.Errorf("for %q collection: incorrect type for model (expected %s but got %s)", c.name, c.modelType, actualType)
+	}
+	return nil
+}
+
+func (c *colInfo) checkModelsType(models interface{}) error {
+	expectedType := reflect.PtrTo(reflect.SliceOf(c.modelType))
+	actualType := reflect.TypeOf(models)
+	if expectedType != actualType {
+		return fmt.Errorf("for %q collection: incorrect type for models (expected %s but got %s)", c.name, expectedType, actualType)
+	}
+	return nil
+}

--- a/db/collection.go
+++ b/db/collection.go
@@ -55,7 +55,11 @@ func (c *Collection) Insert(model Model) error {
 	if err := insertWithTransaction(c.info, txn, model); err != nil {
 		_ = txn.Discard()
 	}
-	return txn.Commit()
+	if err := txn.Commit(); err != nil {
+		_ = txn.Discard()
+		return err
+	}
+	return nil
 }
 
 // Update updates an existing model in the database. It returns an error if the
@@ -65,7 +69,11 @@ func (c *Collection) Update(model Model) error {
 	if err := updateWithTransaction(c.info, txn, model); err != nil {
 		_ = txn.Discard()
 	}
-	return txn.Commit()
+	if err := txn.Commit(); err != nil {
+		_ = txn.Discard()
+		return err
+	}
+	return nil
 }
 
 // Delete deletes the model with the given ID from the database. It returns an
@@ -75,7 +83,11 @@ func (c *Collection) Delete(id []byte) error {
 	if err := deleteWithTransaction(c.info, txn, id); err != nil {
 		_ = txn.Discard()
 	}
-	return txn.Commit()
+	if err := txn.Commit(); err != nil {
+		_ = txn.Discard()
+		return err
+	}
+	return nil
 }
 
 // New Query creates and returns a new query with the given filter. By default,

--- a/db/collection.go
+++ b/db/collection.go
@@ -1,40 +1,15 @@
 package db
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
 	"reflect"
-	"sync"
 
 	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 // Collection represents a set of a specific type of model.
 type Collection struct {
-	*readOnlyCollection
-	*writeableCollection
-	ldb *leveldb.DB
-}
-
-// readOnlyCollection is responsible for all the read-only methods and actions
-// associated with a collection. It cannot insert or delete any models.
-type readOnlyCollection struct {
-	reader    dbReader
-	name      string
-	modelType reflect.Type
-	indexes   []*Index
-	// indexMut protects the indexes slice.
-	indexMut sync.RWMutex
-}
-
-// writeableCollection is an extension of readonlyCollection which adds support
-// for inserting, updating, and deleting models in the database.
-type writeableCollection struct {
-	*readOnlyCollection
-	writerTransactor dbWriterTransactor
+	info *colInfo
+	ldb  *leveldb.DB
 }
 
 // NewCollection creates and returns a new collection with the given name and
@@ -42,286 +17,60 @@ type writeableCollection struct {
 // collection should typically be created once at the start of your application
 // and re-used.
 func (db *DB) NewCollection(name string, typ Model) *Collection {
-	readOnly := &readOnlyCollection{
-		reader:    db.ldb,
-		name:      name,
-		modelType: reflect.TypeOf(typ),
-	}
 	return &Collection{
-		readOnlyCollection: readOnly,
-		writeableCollection: &writeableCollection{
-			readOnlyCollection: readOnly,
-			writerTransactor:   db.ldb,
+		info: &colInfo{
+			name:      name,
+			modelType: reflect.TypeOf(typ),
 		},
 		ldb: db.ldb,
 	}
 }
 
 // Name returns the name of the collection.
-func (c *readOnlyCollection) Name() string {
-	return c.name
-}
-
-func (c *readOnlyCollection) prefix() []byte {
-	return []byte(fmt.Sprintf("model:%s", c.name))
-}
-
-func (c *readOnlyCollection) primaryKeyForModel(model Model) []byte {
-	return c.primaryKeyForID(model.ID())
-}
-
-func (c *readOnlyCollection) primaryKeyForID(id []byte) []byte {
-	return []byte(fmt.Sprintf("%s:%s", c.prefix(), escape(id)))
-}
-
-func (c *readOnlyCollection) primaryKeyForIDWithoutEscape(id []byte) []byte {
-	return []byte(fmt.Sprintf("%s:%s", c.prefix(), id))
-}
-
-func (c *readOnlyCollection) checkModelType(model Model) error {
-	actualType := reflect.TypeOf(model)
-	if c.modelType != actualType {
-		if actualType.Kind() == reflect.Ptr {
-			if c.modelType == actualType.Elem() {
-				// Pointers to the expected type are allowed here.
-				return nil
-			}
-		}
-		return fmt.Errorf("for %q collection: incorrect type for model (expected %s but got %s)", c.Name(), c.modelType, actualType)
-	}
-	return nil
-}
-
-func (c *readOnlyCollection) checkModelsType(models interface{}) error {
-	expectedType := reflect.PtrTo(reflect.SliceOf(c.modelType))
-	actualType := reflect.TypeOf(models)
-	if expectedType != actualType {
-		return fmt.Errorf("for %q collection: incorrect type for models (expected %s but got %s)", c.Name(), expectedType, actualType)
-	}
-	return nil
+func (c *Collection) Name() string {
+	return c.info.name
 }
 
 // FindByID finds the model with the given ID and scans the results into the
 // given model. As in the Unmarshal and Decode methods in the encoding/json
 // package, model must be settable via reflect. Typically, this means you should
 // pass in a pointer.
-func (c *readOnlyCollection) FindByID(id []byte, model Model) error {
-	if err := c.checkModelType(model); err != nil {
-		return err
-	}
-	pk := c.primaryKeyForID(id)
-	data, err := c.reader.Get(pk, nil)
-	if err != nil {
-		if err == leveldb.ErrNotFound {
-			return NotFoundError{ID: id}
-		}
-		return err
-	}
-	return json.Unmarshal(data, model)
+func (c *Collection) FindByID(id []byte, model Model) error {
+	return findByID(c.info, c.ldb, id, model)
 }
 
 // FindAll finds all models for the collection and scans the results into the
 // given models. models should be a pointer to an empty slice of a concrete
 // model type (e.g. *[]myModelType).
-func (c *readOnlyCollection) FindAll(models interface{}) error {
-	prefixRange := util.BytesPrefix(c.prefix())
-	iter := c.reader.NewIterator(prefixRange, nil)
-	return c.findWithIterator(iter, models)
-}
-
-func (c *readOnlyCollection) findWithIterator(iter iterator.Iterator, models interface{}) error {
-	defer iter.Release()
-	if err := c.checkModelsType(models); err != nil {
-		return err
-	}
-	modelsVal := reflect.ValueOf(models).Elem()
-	for iter.Next() {
-		// We assume that each value in the iterator is the encoded data for some
-		// model.
-		data := iter.Value()
-		model := reflect.New(c.modelType)
-		if err := json.Unmarshal(data, model.Interface()); err != nil {
-			return err
-		}
-		modelsVal.Set(reflect.Append(modelsVal, model.Elem()))
-	}
-	if err := iter.Error(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// findExistingModelByPrimaryKey gets the latest data for the given primary key.
-// Useful in cases where the given model may be out of date with what is
-// currently stored in the database. It *doesn't* discard the transaction if
-// there is an error.
-func (c *readOnlyCollection) findExistingModelByPrimaryKey(txn *leveldb.Transaction, primaryKey []byte) (Model, error) {
-	data, err := txn.Get(primaryKey, nil)
-	if err != nil {
-		return nil, err
-	}
-	// Use reflect to create a new reference for the model type.
-	modelRef := reflect.New(c.modelType).Interface()
-	if err := json.Unmarshal(data, modelRef); err != nil {
-		return nil, err
-	}
-	model := reflect.ValueOf(modelRef).Elem().Interface().(Model)
-	return model, nil
+func (c *Collection) FindAll(models interface{}) error {
+	return findAll(c.info, c.ldb, models)
 }
 
 // Insert inserts the given model into the database. It returns an error if a
 // model with the same id already exists.
-func (c *writeableCollection) Insert(model Model) error {
-	if len(model.ID()) == 0 {
-		return errors.New("can't insert model with empty ID")
-	}
-	if err := c.checkModelType(model); err != nil {
-		return err
-	}
-	data, err := json.Marshal(model)
-	if err != nil {
-		return err
-	}
-	txn, err := c.writerTransactor.OpenTransaction()
-	if err != nil {
-		return err
-	}
-	pk := c.primaryKeyForModel(model)
-	if exists, err := txn.Has(pk, nil); err != nil {
-		txn.Discard()
-		return err
-	} else if exists {
-		txn.Discard()
-		return AlreadyExistsError{ID: model.ID()}
-	}
-	if err := txn.Put(pk, data, nil); err != nil {
-		txn.Discard()
-		return err
-	}
-	if err := c.saveIndexesForModel(txn, model); err != nil {
-		txn.Discard()
-		return err
-	}
-
-	return txn.Commit()
+func (c *Collection) Insert(model Model) error {
+	return insert(c.info, c.ldb, model)
 }
 
 // Update updates an existing model in the database. It returns an error if the
 // given model doesn't already exist.
-func (c *writeableCollection) Update(model Model) error {
-	if len(model.ID()) == 0 {
-		return errors.New("can't update model with empty ID")
-	}
-	if err := c.checkModelType(model); err != nil {
-		return err
-	}
-	newData, err := json.Marshal(model)
-	if err != nil {
-		return err
-	}
-	txn, err := c.writerTransactor.OpenTransaction()
-	if err != nil {
-		return err
-	}
-	pk := c.primaryKeyForModel(model)
-
-	// Check if the model already exists and return an error if not.
-	if exists, err := txn.Has(pk, nil); err != nil {
-		txn.Discard()
-		return err
-	} else if !exists {
-		txn.Discard()
-		return NotFoundError{ID: model.ID()}
-	}
-
-	// Get the existing data for the model and delete any (now outdated) indexes.
-	existingModel, err := c.findExistingModelByPrimaryKey(txn, pk)
-	if err != nil {
-		txn.Discard()
-		return err
-	}
-	if err := c.deleteIndexesForModel(txn, existingModel); err != nil {
-		txn.Discard()
-		return err
-	}
-
-	// Save the new data and add the new indexes.
-	if err := txn.Put(pk, newData, nil); err != nil {
-		txn.Discard()
-		return err
-	}
-	if err := c.saveIndexesForModel(txn, model); err != nil {
-		txn.Discard()
-		return err
-	}
-
-	return txn.Commit()
+func (c *Collection) Update(model Model) error {
+	return update(c.info, c.ldb, model)
 }
 
 // Delete deletes the model with the given ID from the database. It returns an
 // error if the model doesn't exist in the database.
-func (c *writeableCollection) Delete(id []byte) error {
-	if len(id) == 0 {
-		return errors.New("can't delete model with empty ID")
-	}
-	txn, err := c.writerTransactor.OpenTransaction()
-	if err != nil {
-		return err
-	}
-
-	// We need to get the latest data because the given model might be out of sync
-	// with the actual data in the database.
-	pk := c.primaryKeyForID(id)
-	latest, err := c.findExistingModelByPrimaryKey(txn, pk)
-	if err != nil {
-		txn.Discard()
-		if err == leveldb.ErrNotFound {
-			return NotFoundError{ID: id}
-		}
-		return err
-	}
-
-	// Delete the primary key.
-	if err := txn.Delete(pk, nil); err != nil {
-		txn.Discard()
-		return err
-	}
-
-	// Delete any index entries.
-	if err := c.deleteIndexesForModel(txn, latest); err != nil {
-		txn.Discard()
-		return err
-	}
-
-	return txn.Commit()
+func (c *Collection) Delete(id []byte) error {
+	return delete(c.info, c.ldb, id)
 }
 
-// deleteIndexesForModel deletes any indexes computed from the given model. It
-// *doesn't* discard the transaction if there is an error.
-func (c *writeableCollection) deleteIndexesForModel(txn *leveldb.Transaction, model Model) error {
-	c.indexMut.RLock()
-	defer c.indexMut.RUnlock()
-	for _, index := range c.indexes {
-		keys := index.keysForModel(model)
-		for _, key := range keys {
-			if err := txn.Delete(key, nil); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-func (c *writeableCollection) saveIndexesForModel(txn *leveldb.Transaction, model Model) error {
-	c.indexMut.RLock()
-	defer c.indexMut.RUnlock()
-	for _, index := range c.indexes {
-		keys := index.keysForModel(model)
-		for _, key := range keys {
-			if err := txn.Put(key, nil, nil); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
+// New Query creates and returns a new query with the given filter. By default,
+// a query will return all models that match the filter in ascending byte order
+// according to their index values. The query offers methods that can be used to
+// change this (e.g. Reverse and Max). The query is lazily executed, i.e. it
+// does not actually touch the database until they are run. In general, queries
+// have a runtime of O(N) where N is the number of models that are returned by
+// the query, but using some features may significantly change this.
+func (c *Collection) NewQuery(filter *Filter) *Query {
+	return newQuery(c.info, c.ldb, filter)
 }

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestInsert(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 	expected := &testModel{
@@ -23,6 +24,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestFindByID(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 	expected := &testModel{
@@ -36,6 +38,7 @@ func TestFindByID(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 	original := &testModel{
@@ -54,6 +57,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestFindAll(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 	expected := []*testModel{}
@@ -71,6 +75,7 @@ func TestFindAll(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 	col.AddIndex("age", func(m Model) []byte {
@@ -95,6 +100,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDeleteAfterUpdate(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 	col.AddIndex("age", func(m Model) []byte {

--- a/db/db.go
+++ b/db/db.go
@@ -32,6 +32,7 @@ type DB struct {
 }
 
 // Open creates a new database using the given file path for permanent storage.
+// It is not safe to have multiple DBs using the same file path.
 func Open(path string) (*DB, error) {
 	ldb, err := leveldb.OpenFile(path, nil)
 	if err != nil {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -24,6 +24,7 @@ func newTestDB(t *testing.T) *DB {
 }
 
 func TestOpen(t *testing.T) {
+	t.Parallel()
 	db, err := Open("/tmp/leveldb_testing")
 	require.NoError(t, err)
 	require.NoError(t, db.Close())

--- a/db/escape_test.go
+++ b/db/escape_test.go
@@ -26,6 +26,7 @@ var trickyByteValues = [][]byte{
 }
 
 func TestEscapeUnescape(t *testing.T) {
+	t.Parallel()
 	for _, expected := range trickyByteValues {
 		actual := unescape(escape(expected))
 		assert.Equal(t, expected, actual)
@@ -33,6 +34,7 @@ func TestEscapeUnescape(t *testing.T) {
 }
 
 func TestFindWithValueWithEscape(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 	ageIndex := col.AddIndex("age", func(m Model) []byte {

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestInsertWithIndex(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 	col.AddIndex("age", func(m Model) []byte {
@@ -25,6 +26,7 @@ func TestInsertWithIndex(t *testing.T) {
 }
 
 func TestUpdateWithIndex(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 	col.AddIndex("age", func(m Model) []byte {

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -2,16 +2,13 @@ package db
 
 import (
 	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 // dbReader is an interface that encapsulates read-only functionality.
 type dbReader interface {
-	Get(key []byte, ro *opt.ReadOptions) (value []byte, err error)
+	leveldb.Reader
 	Has(key []byte, ro *opt.ReadOptions) (ret bool, err error)
-	NewIterator(slice *util.Range, ro *opt.ReadOptions) iterator.Iterator
 }
 
 // dbWriter is an interface that encapsulates write/update functionality.

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -8,7 +8,7 @@ import (
 // dbReader is an interface that encapsulates read-only functionality.
 type dbReader interface {
 	leveldb.Reader
-	Has(key []byte, ro *opt.ReadOptions) (ret bool, err error)
+	Has(key []byte, ro *opt.ReadOptions) (bool, error)
 }
 
 // dbWriter is an interface that encapsulates write/update functionality.
@@ -17,7 +17,16 @@ type dbWriter interface {
 	Put(key, value []byte, wo *opt.WriteOptions) error
 }
 
-// dbTransactor is an interface for opening transactions.
-type dbTransactor interface {
-	OpenTransaction() (*leveldb.Transaction, error)
+type dbBatchWriter interface {
+	Write(batch *leveldb.Batch, ro *opt.WriteOptions) error
+}
+
+type dbReadWriter interface {
+	dbReader
+	dbWriter
+}
+
+type dbReadBatchWriter interface {
+	dbReadWriter
+	dbBatchWriter
 }

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -21,9 +21,3 @@ type dbWriter interface {
 type dbTransactor interface {
 	OpenTransaction() (*leveldb.Transaction, error)
 }
-
-// dbWriterTransactor combines dbWriter and dbTransactor.
-type dbWriterTransactor interface {
-	dbWriter
-	dbTransactor
-}

--- a/db/operations.go
+++ b/db/operations.go
@@ -1,0 +1,232 @@
+package db
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+func findByID(info *colInfo, reader dbReader, id []byte, model Model) error {
+	if err := info.checkModelType(model); err != nil {
+		return err
+	}
+	pk := info.primaryKeyForID(id)
+	data, err := reader.Get(pk, nil)
+	if err != nil {
+		if err == leveldb.ErrNotFound {
+			return NotFoundError{ID: id}
+		}
+		return err
+	}
+	return json.Unmarshal(data, model)
+}
+
+func findAll(info *colInfo, reader dbReader, models interface{}) error {
+	prefixRange := util.BytesPrefix(info.prefix())
+	iter := reader.NewIterator(prefixRange, nil)
+	return findWithIterator(info, iter, models)
+}
+
+func findWithIterator(info *colInfo, iter iterator.Iterator, models interface{}) error {
+	defer iter.Release()
+	if err := info.checkModelsType(models); err != nil {
+		return err
+	}
+	modelsVal := reflect.ValueOf(models).Elem()
+	for iter.Next() {
+		// We assume that each value in the iterator is the encoded data for some
+		// model.
+		data := iter.Value()
+		model := reflect.New(info.modelType)
+		if err := json.Unmarshal(data, model.Interface()); err != nil {
+			return err
+		}
+		modelsVal.Set(reflect.Append(modelsVal, model.Elem()))
+	}
+	if err := iter.Error(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// findExistingModelByPrimaryKey gets the latest data for the given primary key.
+// Useful in cases where the given model may be out of date with what is
+// currently stored in the database. It *doesn't* discard the transaction if
+// there is an error.
+func findExistingModelByPrimaryKey(info *colInfo, txn *leveldb.Transaction, primaryKey []byte) (Model, error) {
+	data, err := txn.Get(primaryKey, nil)
+	if err != nil {
+		return nil, err
+	}
+	// Use reflect to create a new reference for the model type.
+	modelRef := reflect.New(info.modelType).Interface()
+	if err := json.Unmarshal(data, modelRef); err != nil {
+		return nil, err
+	}
+	model := reflect.ValueOf(modelRef).Elem().Interface().(Model)
+	return model, nil
+}
+
+func insert(info *colInfo, transactor dbTransactor, model Model) error {
+	txn, err := transactor.OpenTransaction()
+	if err != nil {
+		return err
+	}
+	if err := insertWithTransaction(info, txn, model); err != nil {
+		txn.Discard()
+	}
+	return txn.Commit()
+}
+
+func insertWithTransaction(info *colInfo, txn *leveldb.Transaction, model Model) error {
+	if len(model.ID()) == 0 {
+		return errors.New("can't insert model with empty ID")
+	}
+	if err := info.checkModelType(model); err != nil {
+		return err
+	}
+	data, err := json.Marshal(model)
+	if err != nil {
+		return err
+	}
+	pk := info.primaryKeyForModel(model)
+	if exists, err := txn.Has(pk, nil); err != nil {
+		return err
+	} else if exists {
+		return AlreadyExistsError{ID: model.ID()}
+	}
+	if err := txn.Put(pk, data, nil); err != nil {
+		return err
+	}
+	if err := saveIndexesWithTransaction(info, txn, model); err != nil {
+		return err
+	}
+	return nil
+}
+
+func update(info *colInfo, transactor dbTransactor, model Model) error {
+	txn, err := transactor.OpenTransaction()
+	if err != nil {
+		return err
+	}
+	if err := updateWithTransaction(info, txn, model); err != nil {
+		txn.Discard()
+		return err
+	}
+	return txn.Commit()
+}
+
+func updateWithTransaction(info *colInfo, txn *leveldb.Transaction, model Model) error {
+	if len(model.ID()) == 0 {
+		return errors.New("can't update model with empty ID")
+	}
+	if err := info.checkModelType(model); err != nil {
+		return err
+	}
+
+	// Check if the model already exists and return an error if not.
+	pk := info.primaryKeyForModel(model)
+	if exists, err := txn.Has(pk, nil); err != nil {
+		return err
+	} else if !exists {
+		return NotFoundError{ID: model.ID()}
+	}
+
+	// Get the existing data for the model and delete any (now outdated) indexes.
+	existingModel, err := findExistingModelByPrimaryKey(info, txn, pk)
+	if err != nil {
+		return err
+	}
+	if err := deleteIndexesWithTransaction(info, txn, existingModel); err != nil {
+		return err
+	}
+
+	// Save the new data and add the new indexes.
+	newData, err := json.Marshal(model)
+	if err != nil {
+		return err
+	}
+	if err := txn.Put(pk, newData, nil); err != nil {
+		return err
+	}
+	if err := saveIndexesWithTransaction(info, txn, model); err != nil {
+		return err
+	}
+	return nil
+}
+
+func delete(info *colInfo, transactor dbTransactor, id []byte) error {
+	txn, err := transactor.OpenTransaction()
+	if err != nil {
+		return err
+	}
+	if err := deleteWithTransaction(info, txn, id); err != nil {
+		txn.Discard()
+		return err
+	}
+	return txn.Commit()
+}
+
+func deleteWithTransaction(info *colInfo, txn *leveldb.Transaction, id []byte) error {
+	if len(id) == 0 {
+		return errors.New("can't delete model with empty ID")
+	}
+
+	// We need to get the latest data because the given model might be out of sync
+	// with the actual data in the database.
+	pk := info.primaryKeyForID(id)
+	latest, err := findExistingModelByPrimaryKey(info, txn, pk)
+	if err != nil {
+		txn.Discard()
+		if err == leveldb.ErrNotFound {
+			return NotFoundError{ID: id}
+		}
+		return err
+	}
+
+	// Delete the primary key.
+	if err := txn.Delete(pk, nil); err != nil {
+		return err
+	}
+
+	// Delete any index entries.
+	if err := deleteIndexesWithTransaction(info, txn, latest); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func saveIndexesWithTransaction(info *colInfo, txn *leveldb.Transaction, model Model) error {
+	info.indexMut.RLock()
+	defer info.indexMut.RUnlock()
+	for _, index := range info.indexes {
+		keys := index.keysForModel(model)
+		for _, key := range keys {
+			if err := txn.Put(key, nil, nil); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// deleteIndexesForModel deletes any indexes computed from the given model. It
+// *doesn't* discard the transaction if there is an error.
+func deleteIndexesWithTransaction(info *colInfo, txn *leveldb.Transaction, model Model) error {
+	info.indexMut.RLock()
+	defer info.indexMut.RUnlock()
+	for _, index := range info.indexes {
+		keys := index.keysForModel(model)
+		for _, key := range keys {
+			if err := txn.Delete(key, nil); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -4,7 +4,8 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
-// Snapshot is a frozen snapshot of a DB state at a particular point in time.
+// Snapshot is a frozen, read-only snapshot of a DB state at a particular point
+// in time.
 type Snapshot struct {
 	colInfo  *colInfo
 	snapshot *leveldb.Snapshot

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -6,7 +6,7 @@ import (
 
 // Snapshot is a frozen snapshot of a DB state at a particular point in time.
 type Snapshot struct {
-	*readOnlyCollection
+	colInfo  *colInfo
 	snapshot *leveldb.Snapshot
 }
 
@@ -18,17 +18,8 @@ func (c *Collection) GetSnapshot() (*Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.indexMut.RLock()
-	indexes := make([]*Index, len(c.indexes))
-	copy(indexes, c.indexes)
-	c.indexMut.RUnlock()
 	return &Snapshot{
-		readOnlyCollection: &readOnlyCollection{
-			reader:    snapshot,
-			name:      c.name,
-			modelType: c.modelType,
-			indexes:   indexes,
-		},
+		colInfo:  c.info.copy(),
 		snapshot: snapshot,
 	}, nil
 }
@@ -38,4 +29,30 @@ func (c *Collection) GetSnapshot() (*Snapshot, error) {
 // not be called after the snapshot has been released.
 func (s *Snapshot) Release() {
 	s.snapshot.Release()
+}
+
+// FindByID finds the model with the given ID and scans the results into the
+// given model. As in the Unmarshal and Decode methods in the encoding/json
+// package, model must be settable via reflect. Typically, this means you should
+// pass in a pointer.
+func (s *Snapshot) FindByID(id []byte, model Model) error {
+	return findByID(s.colInfo, s.snapshot, id, model)
+}
+
+// FindAll finds all models for the collection and scans the results into the
+// given models. models should be a pointer to an empty slice of a concrete
+// model type (e.g. *[]myModelType).
+func (s *Snapshot) FindAll(models interface{}) error {
+	return findAll(s.colInfo, s.snapshot, models)
+}
+
+// New Query creates and returns a new query with the given filter. By default,
+// a query will return all models that match the filter in ascending byte order
+// according to their index values. The query offers methods that can be used to
+// change this (e.g. Reverse and Max). The query is lazily executed, i.e. it
+// does not actually touch the database until they are run. In general, queries
+// have a runtime of O(N) where N is the number of models that are returned by
+// the query, but using some features may significantly change this.
+func (s *Snapshot) NewQuery(filter *Filter) *Query {
+	return newQuery(s.colInfo, s.snapshot, filter)
 }

--- a/db/snapshot_test.go
+++ b/db/snapshot_test.go
@@ -51,7 +51,7 @@ func TestSnapshot(t *testing.T) {
 	col.AddIndex("name", func(m Model) []byte {
 		return []byte(m.(*testModel).Name)
 	})
-	assert.Equal(t, []*Index{ageIndex}, snapshot.indexes)
+	assert.Equal(t, []*Index{ageIndex}, snapshot.colInfo.indexes)
 
 	// Make sure that the query only return results that match the state at the
 	// time the snapshot was taken.

--- a/db/snapshot_test.go
+++ b/db/snapshot_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestSnapshot(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -1,0 +1,34 @@
+package db
+
+// type Transaction struct {
+// 	*writeableCollection
+// 	transaction *leveldb.Transaction
+// }
+
+// func (c *Collection) OpenTransaction() (*Transaction, error) {
+// 	snapshot, err := c.ldb.OpenTransaction()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	c.indexMut.RLock()
+// 	indexes := make([]*Index, len(c.indexes))
+// 	copy(indexes, c.indexes)
+// 	c.indexMut.RUnlock()
+// 	return &Transaction{
+// 		writeableCollection: &writeableCollection{
+// 			readOnlyCollection: &readOnlyCollection{
+// 				reader:    snapshot,
+// 				name:      c.name,
+// 				modelType: c.modelType,
+// 				indexes:   indexes,
+// 			},
+// 		},
+// 	}, nil
+// }
+
+// // Release releases the snapshot. This will not release any ongoing queries,
+// // which will still finish unless the database is closed. Other methods should
+// // not be called after the snapshot has been released.
+// func (s *Snapshot) Release() {
+// 	s.snapshot.Release()
+// }

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -1,34 +1,71 @@
 package db
 
-// type Transaction struct {
-// 	*writeableCollection
-// 	transaction *leveldb.Transaction
-// }
+import "github.com/syndtr/goleveldb/leveldb"
 
-// func (c *Collection) OpenTransaction() (*Transaction, error) {
-// 	snapshot, err := c.ldb.OpenTransaction()
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	c.indexMut.RLock()
-// 	indexes := make([]*Index, len(c.indexes))
-// 	copy(indexes, c.indexes)
-// 	c.indexMut.RUnlock()
-// 	return &Transaction{
-// 		writeableCollection: &writeableCollection{
-// 			readOnlyCollection: &readOnlyCollection{
-// 				reader:    snapshot,
-// 				name:      c.name,
-// 				modelType: c.modelType,
-// 				indexes:   indexes,
-// 			},
-// 		},
-// 	}, nil
-// }
+type Transaction struct {
+	colInfo *colInfo
+	txn     *leveldb.Transaction
+}
 
-// // Release releases the snapshot. This will not release any ongoing queries,
-// // which will still finish unless the database is closed. Other methods should
-// // not be called after the snapshot has been released.
-// func (s *Snapshot) Release() {
-// 	s.snapshot.Release()
-// }
+func (c *Collection) OpenTransaction() (*Transaction, error) {
+	txn, err := c.ldb.OpenTransaction()
+	if err != nil {
+		return nil, err
+	}
+	return &Transaction{
+		colInfo: c.info.copy(),
+		txn:     txn,
+	}, nil
+}
+
+func (txn *Transaction) Commit() error {
+	return txn.txn.Commit()
+}
+
+func (txn *Transaction) Discard() {
+	txn.txn.Discard()
+}
+
+// FindByID finds the model with the given ID and scans the results into the
+// given model. As in the Unmarshal and Decode methods in the encoding/json
+// package, model must be settable via reflect. Typically, this means you should
+// pass in a pointer.
+func (txn *Transaction) FindByID(id []byte, model Model) error {
+	return findByID(txn.colInfo, txn.txn, id, model)
+}
+
+// FindAll finds all models for the collection and scans the results into the
+// given models. models should be a pointer to an empty slice of a concrete
+// model type (e.g. *[]myModelType).
+func (txn *Transaction) FindAll(models interface{}) error {
+	return findAll(txn.colInfo, txn.txn, models)
+}
+
+// New Query creates and returns a new query with the given filter. By default,
+// a query will return all models that match the filter in ascending byte order
+// according to their index values. The query offers methods that can be used to
+// change this (e.g. Reverse and Max). The query is lazily executed, i.e. it
+// does not actually touch the database until they are run. In general, queries
+// have a runtime of O(N) where N is the number of models that are returned by
+// the query, but using some features may significantly change this.
+func (txn *Transaction) NewQuery(filter *Filter) *Query {
+	return newQuery(txn.colInfo, txn.txn, filter)
+}
+
+// Insert inserts the given model into the database. It returns an error if a
+// model with the same id already exists.
+func (txn *Transaction) Insert(model Model) error {
+	return insertWithTransaction(txn.colInfo, txn.txn, model)
+}
+
+// Update updates an existing model in the database. It returns an error if the
+// given model doesn't already exist.
+func (txn *Transaction) Update(model Model) error {
+	return updateWithTransaction(txn.colInfo, txn.txn, model)
+}
+
+// Delete deletes the model with the given ID from the database. It returns an
+// error if the model doesn't exist in the database.
+func (txn *Transaction) Delete(id []byte) error {
+	return deleteWithTransaction(txn.colInfo, txn.txn, id)
+}

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -1,32 +1,66 @@
 package db
 
-import "github.com/syndtr/goleveldb/leveldb"
+import (
+	"errors"
+	"sync"
+)
 
-// Transaction is an atomic database transaction.
+var (
+	ErrDiscarded = errors.New("transaction has already been discarded")
+	ErrCommitted = errors.New("transaction has already been committed")
+)
+
+// Transaction is an atomic database transaction which can be used to guarantee
+// consistency.
 type Transaction struct {
-	colInfo *colInfo
-	txn     *leveldb.Transaction
+	mut             sync.Mutex
+	colInfo         *colInfo
+	batchWriter     dbBatchWriter
+	readerWithBatch *readerWithBatchWriter
+	committed       bool
+	discarded       bool
 }
 
-// OpenTransaction opens an atomic DB transaction. Only one transaction can be
-// opened at a time. All write operations (e.g. Insert, Update, or Delete) will
-// be blocked until in-flight transaction is committed or discarded. The
-// returned transaction is safe for concurrent use.
+// OpenTransaction opens and returns a new transaction. While the transaction is
+// open, no other state changes (e.g. Insert, Update, or Delete) can be made to
+// the database (but concurrent reads are still allowed).
 //
-// Transaction is expensive and can overwhelm compaction, especially if
-// transaction size is small. Use with caution.
+// Transactions are atomic, meaning that either:
+//
+//     (1) The transaction will succeed and *all* queued operations will be
+//     applied, or
+//     (2) the transaction will be fail or be discarded, in which case *none* of
+//     the queued operations will be applied.
 //
 // The transaction must be closed once done, either by committing or discarding
-// the transaction. Closing the DB will discard any open transactions.
-func (c *Collection) OpenTransaction() (*Transaction, error) {
-	txn, err := c.ldb.OpenTransaction()
-	if err != nil {
-		return nil, err
-	}
+// the transaction. No changes will be made to the database state until the
+// transaction is committed.
+func (c *Collection) OpenTransaction() *Transaction {
+	c.info.writeMut.Lock()
 	return &Transaction{
-		colInfo: c.info.copy(),
-		txn:     txn,
-	}, nil
+		colInfo:         c.info.copy(),
+		batchWriter:     c.ldb,
+		readerWithBatch: newReaderWithBatchWriter(c.ldb),
+	}
+}
+
+// checkState acquires a lock on txn.mut and then calls unsafeCheckState.
+func (txn *Transaction) checkState() error {
+	txn.mut.Lock()
+	defer txn.mut.Unlock()
+	return txn.unsafeCheckState()
+}
+
+// unsafeCheckState checks the state of the transaction, assuming the caller has
+// already acquired a lock. It returns an error if the transaction has already
+// been committed or discarded.
+func (txn *Transaction) unsafeCheckState() error {
+	if txn.discarded {
+		return ErrDiscarded
+	} else if txn.committed {
+		return ErrCommitted
+	}
+	return nil
 }
 
 // Commit commits the transaction. If error is not nil, then the transaction is
@@ -34,56 +68,61 @@ func (c *Collection) OpenTransaction() (*Transaction, error) {
 //
 // Other methods should not be called after transaction has been committed.
 func (txn *Transaction) Commit() error {
-	return txn.txn.Commit()
+	txn.mut.Lock()
+	if err := txn.unsafeCheckState(); err != nil {
+		txn.mut.Unlock()
+		return err
+	}
+	txn.committed = true
+	txn.mut.Unlock()
+	defer txn.colInfo.writeMut.Unlock()
+	return txn.batchWriter.Write(txn.readerWithBatch.batch, nil)
 }
 
 // Discard discards the transaction.
 //
 // Other methods should not be called after transaction has been discarded.
-func (txn *Transaction) Discard() {
-	txn.txn.Discard()
+// However, it is safe to call Discard multiple times.
+func (txn *Transaction) Discard() error {
+	txn.mut.Lock()
+	if txn.committed {
+		return ErrCommitted
+	}
+	if txn.discarded {
+		return nil
+	}
+	defer txn.mut.Unlock()
+	txn.discarded = true
+	txn.colInfo.writeMut.Unlock()
+	return nil
 }
 
-// FindByID finds the model with the given ID and scans the results into the
-// given model. As in the Unmarshal and Decode methods in the encoding/json
-// package, model must be settable via reflect. Typically, this means you should
-// pass in a pointer.
-func (txn *Transaction) FindByID(id []byte, model Model) error {
-	return findByID(txn.colInfo, txn.txn, id, model)
-}
-
-// FindAll finds all models for the collection and scans the results into the
-// given models. models should be a pointer to an empty slice of a concrete
-// model type (e.g. *[]myModelType).
-func (txn *Transaction) FindAll(models interface{}) error {
-	return findAll(txn.colInfo, txn.txn, models)
-}
-
-// New Query creates and returns a new query with the given filter. By default,
-// a query will return all models that match the filter in ascending byte order
-// according to their index values. The query offers methods that can be used to
-// change this (e.g. Reverse and Max). The query is lazily executed, i.e. it
-// does not actually touch the database until they are run. In general, queries
-// have a runtime of O(N) where N is the number of models that are returned by
-// the query, but using some features may significantly change this.
-func (txn *Transaction) NewQuery(filter *Filter) *Query {
-	return newQuery(txn.colInfo, txn.txn, filter)
-}
-
-// Insert inserts the given model into the database. It returns an error if a
-// model with the same id already exists.
+// Insert queues an operation to insert the given model into the database. It
+// returns an error if a model with the same id already exists. The model will
+// not actually be inserted until the transaction is committed.
 func (txn *Transaction) Insert(model Model) error {
-	return insertWithTransaction(txn.colInfo, txn.txn, model)
+	if err := txn.checkState(); err != nil {
+		return err
+	}
+	return insertWithTransaction(txn.colInfo, txn, model)
 }
 
-// Update updates an existing model in the database. It returns an error if the
-// given model doesn't already exist.
+// Update queues an operation to update an existing model in the database. It
+// returns an error if the given model doesn't already exist. The model will
+// not actually be updated until the transaction is committed.
 func (txn *Transaction) Update(model Model) error {
-	return updateWithTransaction(txn.colInfo, txn.txn, model)
+	if err := txn.checkState(); err != nil {
+		return err
+	}
+	return updateWithTransaction(txn.colInfo, txn, model)
 }
 
-// Delete deletes the model with the given ID from the database. It returns an
-// error if the model doesn't exist in the database.
+// Delete queues an operation to delete the model with the given ID from the
+// database. It returns an error if the model doesn't exist in the database. The
+// model will not actually be deleted until the transaction is committed.
 func (txn *Transaction) Delete(id []byte) error {
-	return deleteWithTransaction(txn.colInfo, txn.txn, id)
+	if err := txn.checkState(); err != nil {
+		return err
+	}
+	return deleteWithTransaction(txn.colInfo, txn, id)
 }

--- a/db/transaction_test.go
+++ b/db/transaction_test.go
@@ -1,0 +1,95 @@
+package db
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransaction(t *testing.T) {
+	db := newTestDB(t)
+	col := db.NewCollection("people", &testModel{})
+
+	ageIndex := col.AddIndex("age", func(m Model) []byte {
+		return []byte(fmt.Sprint(m.(*testModel).Age))
+	})
+
+	// expected is a set of testModels with Age = 42
+	expected := []*testModel{}
+	for i := 0; i < 5; i++ {
+		model := &testModel{
+			Name: "ExpectedPerson_" + strconv.Itoa(i),
+			Age:  42,
+		}
+		require.NoError(t, col.Insert(model))
+		expected = append(expected, model)
+	}
+
+	// Open a transaction.
+	txn, err := col.OpenTransaction()
+	require.NoError(t, err)
+	defer txn.Discard()
+
+	// The WaitGroup will be used to wait for all goroutines to finish.
+	wg := &sync.WaitGroup{}
+
+	// Any models we add after opening the transaction should not affect the query.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 5; i++ {
+			model := &testModel{
+				Name: "OtherPerson_" + strconv.Itoa(i),
+				Age:  42,
+			}
+			require.NoError(t, col.Insert(model))
+		}
+	}()
+
+	// Any models we delete after opening the transaction should not affect the query.
+	idToDelete := expected[2].ID()
+	wg.Add(1)
+	go func(idToDelete []byte) {
+		defer wg.Done()
+		require.NoError(t, col.Delete(idToDelete))
+	}(idToDelete)
+
+	// Any new indexes we add should not affect indexes in the transaction.
+	col.AddIndex("name", func(m Model) []byte {
+		return []byte(m.(*testModel).Name)
+	})
+	assert.Equal(t, []*Index{ageIndex}, txn.colInfo.indexes)
+
+	// Any models inserted or deleted withinin the transaction after is is opened
+	// *should* affect the query.
+	for i := 5; i < 10; i++ {
+		model := &testModel{
+			Name: "ExpectedPerson_" + strconv.Itoa(i),
+			Age:  42,
+		}
+		require.NoError(t, txn.Insert(model))
+		expected = append(expected, model)
+	}
+	// Delete the first and last model.
+	require.NoError(t, txn.Delete(expected[len(expected)-1].ID()))
+	require.NoError(t, txn.Delete(expected[0].ID()))
+	expected = expected[1 : len(expected)-1]
+
+	// Make sure that the query only return results that match the state inside
+	// the transaction.
+	filter := ageIndex.ValueFilter([]byte("42"))
+	query := txn.NewQuery(filter)
+	var actual []*testModel
+	require.NoError(t, query.Run(&actual))
+	assert.Equal(t, expected, actual)
+
+	// Commit the transaction.
+	require.NoError(t, txn.Commit())
+
+	// Wait for any goroutines to finish.
+	wg.Wait()
+}

--- a/db/transaction_test.go
+++ b/db/transaction_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestTransaction(t *testing.T) {
+	t.Parallel()
 	db := newTestDB(t)
 	col := db.NewCollection("people", &testModel{})
 


### PR DESCRIPTION
Fixes #22.

There are a lot of changes here. As part of implementing this new feature (and because I'm worried that #147 was a consequence of too much magic), I decided to simplify the interfaces we're using internally and reduce some of the magic.

Instead of relying on embedded structs like `readOnlyCollection` and `writableCollection`, I've decided to opt for a simpler approach. The main logic for most operations now exists as functions in the __operations.go__ file. Each of these functions accept the pieces that they need as arguments (usually `colInfo` and either `dbReader` or `dbWriter` depending on the type of operation).

Functions which use transactions internally are now split up into two parts. For example, the old `Collection.Update` method is now split into two functions: `update` and `updateWithTransaction`. `update` automatically creates and commits/discards the transaction, whereas `updateWithTransaction` accepts a transaction as an argument instead of creating one. This allows us to share a lot of the same underlying code between the `Collection` and `Transaction` types.

@fabioberger the commits in this PR are well-organized and isolated. If it makes it easier, you can review one commit at a time.