### PR TITLE
Add database benchmarks

### DIFF
--- a/db/collection_benchmark_test.go
+++ b/db/collection_benchmark_test.go
@@ -1,0 +1,168 @@
+package db
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkInsert(b *testing.B) {
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		model := &testModel{
+			Name: fmt.Sprintf("person_%d", i),
+			Age:  i,
+		}
+		b.StartTimer()
+		err := col.Insert(model)
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}
+
+func BenchmarkFindByIDHot(b *testing.B) {
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	model := &testModel{
+		Name: "foo",
+		Age:  42,
+	}
+	require.NoError(b, col.Insert(model))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var found testModel
+		err := col.FindByID(model.ID(), &found)
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}
+
+func BenchmarkFindByIDCold(b *testing.B) {
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		model := &testModel{
+			Name: fmt.Sprintf("person_%d", i),
+			Age:  i,
+		}
+		require.NoError(b, col.Insert(model))
+		b.StartTimer()
+		var found testModel
+		err := col.FindByID(model.ID(), &found)
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}
+
+func BenchmarkUpdateHot(b *testing.B) {
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	original := &testModel{
+		Name: "person_0",
+		Age:  0,
+	}
+	require.NoError(b, col.Insert(original))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		updated := &testModel{
+			Name: original.Name,
+			Age:  i + 1,
+		}
+		b.StartTimer()
+		err := col.Update(updated)
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}
+
+func BenchmarkUpdateCold(b *testing.B) {
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		original := &testModel{
+			Name: fmt.Sprintf("person_%d", i),
+			Age:  i,
+		}
+		require.NoError(b, col.Insert(original))
+		updated := &testModel{
+			Name: original.Name,
+			Age:  i + 1,
+		}
+		b.StartTimer()
+		err := col.Update(updated)
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}
+
+func BenchmarkFindAll100(b *testing.B) {
+	benchmarkFindAll(b, 100)
+}
+
+func BenchmarkFindAll1000(b *testing.B) {
+	benchmarkFindAll(b, 1000)
+}
+
+func benchmarkFindAll(b *testing.B, count int) {
+	b.Helper()
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	expected := []*testModel{}
+	for i := 0; i < count; i++ {
+		model := &testModel{
+			Name: "person_%d" + strconv.Itoa(i),
+			Age:  i,
+		}
+		require.NoError(b, col.Insert(model))
+		expected = append(expected, model)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var actual []*testModel
+		err := col.FindAll(&actual)
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}
+
+func BenchmarkDelete(b *testing.B) {
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		model := &testModel{
+			Name: "person_%d" + strconv.Itoa(i),
+			Age:  i,
+		}
+		require.NoError(b, col.Insert(model))
+		b.StartTimer()
+		err := col.Delete(model.ID())
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -17,7 +17,7 @@ func (tm *testModel) ID() []byte {
 	return []byte(tm.Name)
 }
 
-func newTestDB(t *testing.T) *DB {
+func newTestDB(t require.TestingT) *DB {
 	db, err := Open("/tmp/leveldb_testing/" + uuid.New().String())
 	require.NoError(t, err)
 	return db

--- a/db/query_benchmark_test.go
+++ b/db/query_benchmark_test.go
@@ -1,0 +1,165 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const defaultTargetNickname = "target"
+
+func setupQueryBenchmark(b *testing.B) (db *DB, col *Collection, nicknameIndex *Index) {
+	b.Helper()
+	db = newTestDB(b)
+	col = db.NewCollection("people", &testModel{})
+	nicknameIndex = col.AddMultiIndex("nicknames", func(m Model) [][]byte {
+		person := m.(*testModel)
+		indexValues := make([][]byte, len(person.Nicknames))
+		for i, nickname := range person.Nicknames {
+			indexValues[i] = []byte(nickname)
+		}
+		return indexValues
+	})
+	return db, col, nicknameIndex
+}
+
+func insertModelsForQueryBenchmark(b *testing.B, col *Collection, targetNickname string, targetCount int, otherCount int) {
+	txn := col.OpenTransaction()
+
+	defer func() {
+		_ = txn.Discard()
+	}()
+	// Insert targetCount models with nickname = targetNickname
+	for i := 0; i < targetCount; i++ {
+		model := &testModel{
+			Name:      fmt.Sprintf("person_%d", i),
+			Age:       i,
+			Nicknames: []string{targetNickname},
+		}
+		require.NoError(b, txn.Insert(model))
+	}
+	// Insert otherCount with nickname != targetnickName
+	for i := 0; i < otherCount; i++ {
+		model := &testModel{
+			Name:      fmt.Sprintf("person_%d", i),
+			Age:       i,
+			Nicknames: []string{fmt.Sprintf("not_%s_%d", targetNickname, i)},
+		}
+		require.NoError(b, txn.Insert(model))
+	}
+	require.NoError(b, txn.Commit())
+}
+
+func benchmarkQueryFind(b *testing.B, targetCount int, total int) {
+	benchmarkQueryFindWithMaxAndOffset(b, targetCount, total, 0, 0)
+}
+
+func BenchmarkQueryFind100OutOf100(b *testing.B) {
+	benchmarkQueryFind(b, 100, 100)
+}
+
+func BenchmarkQueryFind100OutOf1000(b *testing.B) {
+	benchmarkQueryFind(b, 100, 1000)
+}
+
+func BenchmarkQueryFind100OutOf10000(b *testing.B) {
+	benchmarkQueryFind(b, 100, 10000)
+}
+
+func BenchmarkQueryFind1000OutOf1000(b *testing.B) {
+	benchmarkQueryFind(b, 1000, 1000)
+}
+
+func BenchmarkQueryFind1000OutOf10000(b *testing.B) {
+	benchmarkQueryFind(b, 1000, 10000)
+}
+
+func BenchmarkQueryFind10000OutOf10000(b *testing.B) {
+	benchmarkQueryFind(b, 10000, 10000)
+}
+
+func benchmarkQueryCount(b *testing.B, targetCount int, total int) {
+	db, col, nicknameIndex := setupQueryBenchmark(b)
+	defer db.Close()
+	insertModelsForQueryBenchmark(b, col, defaultTargetNickname, targetCount, total-targetCount)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		query := col.NewQuery(nicknameIndex.ValueFilter([]byte(defaultTargetNickname)))
+		_, err := query.Count()
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}
+
+func BenchmarkQueryCount100OutOf100(b *testing.B) {
+	benchmarkQueryCount(b, 100, 100)
+}
+
+func BenchmarkQueryCount100OutOf1000(b *testing.B) {
+	benchmarkQueryCount(b, 100, 1000)
+}
+
+func BenchmarkQueryCount100OutOf10000(b *testing.B) {
+	benchmarkQueryCount(b, 100, 10000)
+}
+
+func BenchmarkQueryCount1000OutOf1000(b *testing.B) {
+	benchmarkQueryCount(b, 1000, 1000)
+}
+
+func BenchmarkQueryCount1000OutOf10000(b *testing.B) {
+	benchmarkQueryCount(b, 1000, 10000)
+}
+
+func BenchmarkQueryCount10000OutOf10000(b *testing.B) {
+	benchmarkQueryCount(b, 10000, 10000)
+}
+
+func benchmarkQueryFindWithMaxAndOffset(b *testing.B, targetCount int, total int, max int, offset int) {
+	db, col, nicknameIndex := setupQueryBenchmark(b)
+	defer db.Close()
+	insertModelsForQueryBenchmark(b, col, defaultTargetNickname, targetCount, total-targetCount)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		query := col.NewQuery(nicknameIndex.ValueFilter([]byte(defaultTargetNickname)))
+		var actual []*testModel
+		err := query.Max(max).Offset(offset).Run(&actual)
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}
+
+func BenchmarkQueryFind1000OutOf10000Max100Offset0(b *testing.B) {
+	benchmarkQueryFindWithMaxAndOffset(b, 1000, 10000, 100, 0)
+}
+
+func BenchmarkQueryFind1000OutOf10000Max100Offset100(b *testing.B) {
+	benchmarkQueryFindWithMaxAndOffset(b, 1000, 10000, 100, 100)
+}
+
+func BenchmarkQueryFind1000OutOf10000Max100Offset900(b *testing.B) {
+	benchmarkQueryFindWithMaxAndOffset(b, 1000, 10000, 100, 900)
+}
+
+func BenchmarkQueryFind1000OutOf10000Max100Offset1000(b *testing.B) {
+	benchmarkQueryFindWithMaxAndOffset(b, 1000, 10000, 100, 1000)
+}
+
+func BenchmarkQueryFind10000OutOf10000Max1000Offset0(b *testing.B) {
+	benchmarkQueryFindWithMaxAndOffset(b, 10000, 10000, 1000, 0)
+}
+
+func BenchmarkQueryFind10000OutOf10000Max1000Offset1000(b *testing.B) {
+	benchmarkQueryFindWithMaxAndOffset(b, 10000, 10000, 1000, 1000)
+}
+
+func BenchmarkQueryFind10000OutOf10000Max1000Offset9000(b *testing.B) {
+	benchmarkQueryFindWithMaxAndOffset(b, 10000, 10000, 1000, 9000)
+}
+
+func BenchmarkQueryFind10000OutOf10000Max1000Offset10000(b *testing.B) {
+	benchmarkQueryFindWithMaxAndOffset(b, 10000, 10000, 1000, 10000)
+}

--- a/db/snapshot_benchmark_test.go
+++ b/db/snapshot_benchmark_test.go
@@ -1,0 +1,51 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkGetSnapshot(b *testing.B) {
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	for i := 0; i < 1000; i++ {
+		model := &testModel{
+			Name: fmt.Sprintf("person_%d", i),
+			Age:  i,
+		}
+		require.NoError(b, col.Insert(model))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		snapshot, err := col.GetSnapshot()
+		b.StopTimer()
+		require.NoError(b, err)
+		snapshot.Release()
+		b.StartTimer()
+	}
+}
+
+func BenchmarkSnapshotFindByID(b *testing.B) {
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	model := &testModel{
+		Name: "foo",
+		Age:  42,
+	}
+	require.NoError(b, col.Insert(model))
+	snapshot, err := col.GetSnapshot()
+	require.NoError(b, err)
+	defer snapshot.Release()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var found testModel
+		err := snapshot.FindByID(model.ID(), &found)
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}

--- a/db/transaction_benchmark_test.go
+++ b/db/transaction_benchmark_test.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkTransactionInsert100(b *testing.B) {
+	benchmarkTransactionInsert(b, 100)
+}
+
+func BenchmarkTransactionInsert1000(b *testing.B) {
+	benchmarkTransactionInsert(b, 1000)
+}
+
+func BenchmarkTransactionInsert10000(b *testing.B) {
+	benchmarkTransactionInsert(b, 10000)
+}
+
+func benchmarkTransactionInsert(b *testing.B, count int) {
+	b.Helper()
+	db := newTestDB(b)
+	defer db.Close()
+	col := db.NewCollection("people", &testModel{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		txn := col.OpenTransaction()
+		defer func() {
+			_ = txn.Discard()
+		}()
+		for j := 0; j < count; j++ {
+			model := &testModel{
+				Name: fmt.Sprintf("person_%d_%d", i, j),
+				Age:  j,
+			}
+			err := txn.Insert(model)
+			b.StopTimer()
+			require.NoError(b, err)
+			b.StartTimer()
+		}
+		err := txn.Commit()
+		b.StopTimer()
+		require.NoError(b, err)
+		b.StartTimer()
+	}
+}


### PR DESCRIPTION
~~Still WIP because I want to add more benchmarks~~ (update: no longer WIP). After #152 is merged, I'll change the base branch for this PR to master.

Fixes #25.

Initial results:

```
BenchmarkInsert-12          	     100	  23137166 ns/op
BenchmarkFindByIDHot-12     	  200000	      6269 ns/op
BenchmarkFindByIDCold-12    	    3000	    720604 ns/op
BenchmarkUpdateHot-12       	     100	  18108763 ns/op
BenchmarkUpdateCold-12      	     100	  25675224 ns/op
BenchmarkFindAll100-12      	    5000	    299330 ns/op
BenchmarkFindAll1000-12     	      50	  30901471 ns/op
BenchmarkDelete-12          	     100	  13867095 ns/op
```

Right away I can tell that `Insert`, `Update`, and `Delete` are a lot slower than I expected (on the order of 10-25ms). In contrast, `FindByID` takes ~6µs, which is a difference of 4 orders of magnitude! (Or ~700µs for models that are not in the cache; still a difference of 2 orders of magnitude).

Each of the slower operations involves a transaction internally, which make me think that even small transactions are extraordinarily slow. I think we can use a [`Batch`](https://godoc.org/github.com/syndtr/goleveldb/leveldb#Batch) instead of a transaction in some cases, which could drastically improve performance. Another idea is to create our own in-process locking system as the basis for `Transaction` which doesn't rely on OS-level file locks. It should work fine as long as we don't allow two processes to access the same database file at once.