### PR TITLE
Listen on public addresses and enable relay

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -13,10 +13,12 @@ import (
 	"github.com/0xProject/0x-mesh/p2p"
 	"github.com/0xProject/0x-mesh/zeroex"
 	"github.com/0xProject/0x-mesh/zeroex/orderwatch"
+	"github.com/albrow/stringset"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/event"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
+	ma "github.com/multiformats/go-multiaddr"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -27,6 +29,7 @@ const (
 	ethereumRPCRequestTimeout   = 30 * time.Second
 	ethWatcherPollingInterval   = 5 * time.Second
 	peerConnectTimeout          = 60 * time.Second
+	checkNewAddrInterval        = 20 * time.Second
 )
 
 // Config is a set of configuration options for 0x Mesh.
@@ -152,14 +155,16 @@ func (app *App) Start() error {
 	go func() {
 		err := app.node.Start()
 		if err != nil {
-			log.WithField("error", err.Error()).Error("core node returned error")
+			log.WithField("error", err.Error()).Error("p2p node returned error")
 			app.Close()
 		}
 	}()
+	addrs := app.node.Multiaddrs()
+	go app.periodicallyCheckForNewAddrs(addrs)
 	log.WithFields(map[string]interface{}{
-		"multiaddress": app.node.Multiaddrs(),
-		"peerID":       app.node.ID().String(),
-	}).Info("started core node")
+		"addresses": addrs,
+		"peerID":    app.node.ID().String(),
+	}).Info("started p2p node")
 
 	// TODO(albrow) we might want to match the synchronous API of p2p.Node which
 	// returns any fatal errors. As it currently stands, if one of these watchers
@@ -181,6 +186,27 @@ func (app *App) Start() error {
 	log.Info("started ETH balance watcher")
 
 	return nil
+}
+
+func (app *App) periodicallyCheckForNewAddrs(startingAddrs []ma.Multiaddr) {
+	seenAddrs := stringset.New()
+	for _, addr := range startingAddrs {
+		seenAddrs.Add(addr.String())
+	}
+	// TODO: There might be a more efficient way to do this if we have access to
+	// an event bus. See: https://github.com/libp2p/go-libp2p/issues/467
+	for {
+		time.Sleep(checkNewAddrInterval)
+		newAddrs := app.node.Multiaddrs()
+		for _, addr := range newAddrs {
+			if !seenAddrs.Contains(addr.String()) {
+				log.WithFields(map[string]interface{}{
+					"address": addr,
+				}).Info("found new listen address")
+				seenAddrs.Add(addr.String())
+			}
+		}
+	}
 }
 
 // AddOrders can be used to add orders to Mesh. It validates the given orders

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -144,7 +144,8 @@ func New(config Config) (*Node, error) {
 	}
 
 	// Set up the transport and the host.
-	hostAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", config.ListenPort))
+	// Note: 0.0.0.0 will use all available addresses.
+	hostAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", config.ListenPort))
 	if err != nil {
 		cancel()
 		return nil, err
@@ -153,7 +154,6 @@ func New(config Config) (*Node, error) {
 	opts := []libp2p.Option{
 		libp2p.ListenAddrs(hostAddr),
 		libp2p.Identity(privKey),
-		libp2p.DisableRelay(),
 		libp2p.ConnectionManager(connManager),
 	}
 	if config.Insecure {


### PR DESCRIPTION
Up until now, we have only been listening on the local address 127.0.0.1. This PR should make it possible for two peers on different networks to find one another (even if they are behind NATs).