### PR TITLE
rpc/mesh: Add heartbeat subscription

### DIFF
--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -20,6 +20,9 @@ import (
 
 var errInternal = errors.New("internal error")
 
+// heartbeatInterval specifies the interval at which to emit heartbeat events to a subscriber
+var heartbeatInterval = 5 * time.Second
+
 type rpcHandler struct {
 	app *core.App
 }
@@ -100,7 +103,7 @@ func SetupHeartbeat(ctx context.Context) (*ethRpc.Subscription, error) {
 	rpcSub := notifier.CreateSubscription()
 
 	go func() {
-		ticker := time.NewTicker(5 * time.Second)
+		ticker := time.NewTicker(heartbeatInterval)
 
 		for {
 			select {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"errors"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -109,3 +110,6 @@ var GanacheAccountToPrivateKey = map[common.Address][]byte{
 	GanacheAccount3: ganacheAccount3PrivateKey,
 	GanacheAccount4: ganacheAccount4PrivateKey,
 }
+
+// ErrInternal is used whenever we don't wish to expose internal errors to a client
+var ErrInternal = errors.New("internal error")

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -54,8 +54,18 @@ func (c *Client) AddPeer(peerInfo peerstore.PeerInfo) error {
 // SubscribeToOrders subscribes a stream of order events
 // Note copied from `go-ethereum` codebase: Slow subscribers will be dropped eventually. Client
 // buffers up to 8000 notifications before considering the subscriber dead. The subscription Err
-//  channel will receive ErrSubscriptionQueueOverflow. Use a sufficiently large buffer on the channel
+// channel will receive ErrSubscriptionQueueOverflow. Use a sufficiently large buffer on the channel
 // or ensure that the channel usually has at least one reader to prevent this issue.
 func (c *Client) SubscribeToOrders(ctx context.Context, ch chan<- []*zeroex.OrderEvent) (*rpc.ClientSubscription, error) {
 	return c.rpcClient.Subscribe(ctx, "mesh", ch, "orders")
+}
+
+// SubscribeToHeartbeat subscribes a stream of heartbeats in order to have certainty that the WS
+// connection is still alive.
+// Note copied from `go-ethereum` codebase: Slow subscribers will be dropped eventually. Client
+// buffers up to 8000 notifications before considering the subscriber dead. The subscription Err
+// channel will receive ErrSubscriptionQueueOverflow. Use a sufficiently large buffer on the channel
+// or ensure that the channel usually has at least one reader to prevent this issue.
+func (c *Client) SubscribeToHeartbeat(ctx context.Context, ch chan<- string) (*rpc.ClientSubscription, error) {
+	return c.rpcClient.Subscribe(ctx, "mesh", ch, "heartbeat")
 }

--- a/rpc/client_server_test.go
+++ b/rpc/client_server_test.go
@@ -24,9 +24,10 @@ import (
 // dummyRPCHandler is used for testing purposes. It allows declaring handlers
 // for some requests or all of them, depending on testing needs.
 type dummyRPCHandler struct {
-	addOrdersHandler         func(orders []*zeroex.SignedOrder) (*zeroex.ValidationResults, error)
-	addPeerHandler           func(peerInfo peerstore.PeerInfo) error
-	subscribeToOrdersHandler func(ctx context.Context) (*rpc.Subscription, error)
+	addOrdersHandler            func(orders []*zeroex.SignedOrder) (*zeroex.ValidationResults, error)
+	addPeerHandler              func(peerInfo peerstore.PeerInfo) error
+	subscribeToOrdersHandler    func(ctx context.Context) (*rpc.Subscription, error)
+	subscribeToHeartbeatHandler func(ctx context.Context) (*rpc.Subscription, error)
 }
 
 func (d *dummyRPCHandler) AddOrders(orders []*zeroex.SignedOrder) (*zeroex.ValidationResults, error) {
@@ -48,6 +49,13 @@ func (d *dummyRPCHandler) SubscribeToOrders(ctx context.Context) (*rpc.Subscript
 		return nil, errors.New("dummyRPCHandler: no handler set for Orders")
 	}
 	return d.subscribeToOrdersHandler(ctx)
+}
+
+func (d *dummyRPCHandler) SubscribeToHeartbeat(ctx context.Context) (*rpc.Subscription, error) {
+	if d.subscribeToHeartbeatHandler == nil {
+		return nil, errors.New("dummyRPCHandler: no handler set for Heartbeat")
+	}
+	return d.subscribeToHeartbeatHandler(ctx)
 }
 
 // newTestServerAndClient returns a server and client which have been connected
@@ -194,5 +202,30 @@ func TestOrdersSubscription(t *testing.T) {
 	assert.NotNil(t, clientSubscription, "clientSubscription not nil")
 
 	// The WaitGroup signals that AddOrder was called on the server-side.
+	wg.Wait()
+}
+
+func TestHeartbeatSubscription(t *testing.T) {
+	ctx := context.Background()
+
+	// Set up the dummy handler with a subscribeToHeartbeatHandler
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	rpcHandler := &dummyRPCHandler{
+		subscribeToHeartbeatHandler: func(ctx context.Context) (*rpc.Subscription, error) {
+			wg.Done()
+			return nil, nil
+		},
+	}
+
+	server, client := newTestServerAndClient(t, rpcHandler)
+	defer server.Close()
+
+	heartbeatChan := make(chan string)
+	clientSubscription, err := client.SubscribeToHeartbeat(ctx, heartbeatChan)
+	require.NoError(t, err)
+	assert.NotNil(t, clientSubscription, "clientSubscription not nil")
+
+	// The WaitGroup signals that Heartbeat was called on the server-side.
 	wg.Wait()
 }

--- a/rpc/client_server_test.go
+++ b/rpc/client_server_test.go
@@ -24,10 +24,9 @@ import (
 // dummyRPCHandler is used for testing purposes. It allows declaring handlers
 // for some requests or all of them, depending on testing needs.
 type dummyRPCHandler struct {
-	addOrdersHandler            func(orders []*zeroex.SignedOrder) (*zeroex.ValidationResults, error)
-	addPeerHandler              func(peerInfo peerstore.PeerInfo) error
-	subscribeToOrdersHandler    func(ctx context.Context) (*rpc.Subscription, error)
-	subscribeToHeartbeatHandler func(ctx context.Context) (*rpc.Subscription, error)
+	addOrdersHandler         func(orders []*zeroex.SignedOrder) (*zeroex.ValidationResults, error)
+	addPeerHandler           func(peerInfo peerstore.PeerInfo) error
+	subscribeToOrdersHandler func(ctx context.Context) (*rpc.Subscription, error)
 }
 
 func (d *dummyRPCHandler) AddOrders(orders []*zeroex.SignedOrder) (*zeroex.ValidationResults, error) {
@@ -49,13 +48,6 @@ func (d *dummyRPCHandler) SubscribeToOrders(ctx context.Context) (*rpc.Subscript
 		return nil, errors.New("dummyRPCHandler: no handler set for Orders")
 	}
 	return d.subscribeToOrdersHandler(ctx)
-}
-
-func (d *dummyRPCHandler) SubscribeToHeartbeat(ctx context.Context) (*rpc.Subscription, error) {
-	if d.subscribeToHeartbeatHandler == nil {
-		return nil, errors.New("dummyRPCHandler: no handler set for Heartbeat")
-	}
-	return d.subscribeToHeartbeatHandler(ctx)
 }
 
 // newTestServerAndClient returns a server and client which have been connected

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -21,13 +21,20 @@ type RPCHandler interface {
 	AddOrders(orders []*zeroex.SignedOrder) (*zeroex.ValidationResults, error)
 	// AddPeer is called when the client sends an AddPeer request.
 	AddPeer(peerInfo peerstore.PeerInfo) error
-	// SubscribeToOrders is called when a client sends a Subscribe to orderStream request
+	// SubscribeToOrders is called when a client sends a Subscribe to `orders` request
 	SubscribeToOrders(ctx context.Context) (*rpc.Subscription, error)
+	// SubscribeToHeartbeat is called when a client sends a Subscribe to `heartbeat` request
+	SubscribeToHeartbeat(ctx context.Context) (*rpc.Subscription, error)
 }
 
-// Orders calls rpcHandler.Orders and returns the rpc subscription.
+// Orders calls rpcHandler.SubscribeToOrders and returns the rpc subscription.
 func (s *rpcService) Orders(ctx context.Context) (*rpc.Subscription, error) {
 	return s.rpcHandler.SubscribeToOrders(ctx)
+}
+
+// Heartbeat calls rpcHandler.SubscribeToHeartbeat and returns the rpc subscription.
+func (s *rpcService) Heartbeat(ctx context.Context) (*rpc.Subscription, error) {
+	return s.rpcHandler.SubscribeToHeartbeat(ctx)
 }
 
 // AddOrders calls rpcHandler.AddOrders and returns the validation results.

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -2,13 +2,22 @@ package rpc
 
 import (
 	"context"
+	"net"
+	"strings"
+	"time"
 
+	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/zeroex"
 	"github.com/ethereum/go-ethereum/rpc"
+	ethRpc "github.com/ethereum/go-ethereum/rpc"
 	peer "github.com/libp2p/go-libp2p-peer"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
+	log "github.com/sirupsen/logrus"
 )
+
+// minHeartbeatInterval specifies the interval at which to emit heartbeat events to a subscriber
+var minHeartbeatInterval = 5 * time.Second
 
 // rpcService is an /ethereum/go-ethereum/rpc compatible service.
 type rpcService struct {
@@ -23,8 +32,6 @@ type RPCHandler interface {
 	AddPeer(peerInfo peerstore.PeerInfo) error
 	// SubscribeToOrders is called when a client sends a Subscribe to `orders` request
 	SubscribeToOrders(ctx context.Context) (*rpc.Subscription, error)
-	// SubscribeToHeartbeat is called when a client sends a Subscribe to `heartbeat` request
-	SubscribeToHeartbeat(ctx context.Context) (*rpc.Subscription, error)
 }
 
 // Orders calls rpcHandler.SubscribeToOrders and returns the rpc subscription.
@@ -34,7 +41,75 @@ func (s *rpcService) Orders(ctx context.Context) (*rpc.Subscription, error) {
 
 // Heartbeat calls rpcHandler.SubscribeToHeartbeat and returns the rpc subscription.
 func (s *rpcService) Heartbeat(ctx context.Context) (*rpc.Subscription, error) {
-	return s.rpcHandler.SubscribeToHeartbeat(ctx)
+	log.Debug("received heartbeat subscription request via RPC")
+	subscription, err := SetupHeartbeat(ctx)
+	if err != nil {
+		log.WithField("error", err.Error()).Error("internal error in `mesh_subscribe` to `heartbeat` RPC call")
+		return nil, constants.ErrInternal
+	}
+	return subscription, nil
+}
+
+// SetupHeartbeat sets up the heartbeat for a subscription
+func SetupHeartbeat(ctx context.Context) (*ethRpc.Subscription, error) {
+	notifier, supported := ethRpc.NotifierFromContext(ctx)
+	if !supported {
+		return &ethRpc.Subscription{}, ethRpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		for {
+			select {
+			case err := <-rpcSub.Err():
+				log.WithField("err", err).Error("rpcSub returned an error")
+				return
+			case <-notifier.Closed():
+				return
+			default:
+				// Continue
+			}
+
+			start := time.Now()
+
+			err := notifier.Notify(rpcSub.ID, "tick")
+			if err != nil {
+				// TODO(fabio): The current implementation of `notifier.Notify` returns a
+				// `write: broken pipe` error when it is called _after_ the client has
+				// disconnected but before the corresponding error is received on the
+				// `rpcSub.Err()` channel. This race-condition is not problematic beyond
+				// the unnecessary computation and log spam resulting from it. Once this is
+				// fixed upstream, give all logs an `Error` severity.
+				logEntry := log.WithFields(map[string]interface{}{
+					"error":            err.Error(),
+					"subscriptionType": "heartbeat",
+				})
+				message := "error while calling notifier.Notify"
+				// If the network connection disconnects for longer then ~2mins and then comes
+				// back up, we've noticed the call to `notifier.Notify` return `i/o timeout`
+				// `net.OpError` errors everytime it's called and no values are sent over
+				// `rpcSub.Err()` nor `notifier.Closed()`. In order to stop the error from
+				// endlessly re-occuring, we unsubscribe and return for encountering this type of
+				// error.
+				if _, ok := err.(*net.OpError); ok {
+					logEntry.Trace(message)
+					return
+				}
+				if strings.Contains(err.Error(), "write: broken pipe") {
+					logEntry.Trace(message)
+				} else {
+					logEntry.Error(message)
+				}
+			}
+
+			// Wait MinCleanupInterval before emitting the next heartbeat.
+			time.Sleep(minHeartbeatInterval - time.Since(start))
+
+		}
+	}()
+
+	return rpcSub, nil
 }
 
 // AddOrders calls rpcHandler.AddOrders and returns the validation results.


### PR DESCRIPTION
Fixes: https://github.com/0xProject/0x-mesh/issues/170

The MARKET Protocol team requested the addition of a heartbeat subscription to the Mesh WS interface so that they could properly handle lost connections that might otherwise be hard to detect. 