### PR TITLE
Check for errors in order subscription script

### DIFF
--- a/cmd/demo/subscribe_to_orders/main.go
+++ b/cmd/demo/subscribe_to_orders/main.go
@@ -36,9 +36,14 @@ func main() {
 	}
 	defer clientSubscription.Unsubscribe()
 
-	for orderEvents := range orderEventsChan {
-		for _, orderEvent := range orderEvents {
-			log.Printf("Received order event: %+v\n", orderEvent)
+	for {
+		select {
+		case orderEvents := <-orderEventsChan:
+			for _, orderEvent := range orderEvents {
+				log.Printf("Received order event: %+v\n", orderEvent)
+			}
+		case err := <-clientSubscription.Err():
+			log.Fatal(err)
 		}
 	}
 }


### PR DESCRIPTION
Without this check, the __subscribe_to_orders__ demo script would not detect when the server end of the connection is closed and would hang indefinitely.