### PR TITLE
Add a new Count method for counting all models in a collection

### DIFF
--- a/db/col_info.go
+++ b/db/col_info.go
@@ -35,7 +35,13 @@ func (info *colInfo) copy() *colInfo {
 }
 
 func (info *colInfo) prefix() []byte {
-	return []byte(fmt.Sprintf("model:%s", info.name))
+	return []byte(fmt.Sprintf("model:%s", escape([]byte(info.name))))
+}
+
+// countKey returns the key used to store a count of the number of models in the
+// collection.
+func (info *colInfo) countKey() []byte {
+	return []byte(fmt.Sprintf("count:%s", escape([]byte(info.name))))
 }
 
 func (info *colInfo) primaryKeyForModel(model Model) []byte {

--- a/db/collection.go
+++ b/db/collection.go
@@ -48,6 +48,11 @@ func (c *Collection) FindAll(models interface{}) error {
 	return findAll(c.info, c.ldb, models)
 }
 
+// Count returns the number of models in the collection.
+func (c *Collection) Count() (int, error) {
+	return count(c.info, c.ldb)
+}
+
 // Insert inserts the given model into the database. It returns an error if a
 // model with the same id already exists.
 func (c *Collection) Insert(model Model) error {

--- a/db/snapshot.go
+++ b/db/snapshot.go
@@ -47,6 +47,11 @@ func (s *Snapshot) FindAll(models interface{}) error {
 	return findAll(s.colInfo, s.snapshot, models)
 }
 
+// Count returns the number of models in the collection.
+func (s *Snapshot) Count() (int, error) {
+	return count(s.colInfo, s.snapshot)
+}
+
 // New Query creates and returns a new query with the given filter. By default,
 // a query will return all models that match the filter in ascending byte order
 // according to their index values. The query offers methods that can be used to

--- a/db/snapshot_test.go
+++ b/db/snapshot_test.go
@@ -61,4 +61,7 @@ func TestSnapshot(t *testing.T) {
 	var actual []*testModel
 	require.NoError(t, query.Run(&actual))
 	assert.Equal(t, expected, actual)
+	actualCount, err := snapshot.Count()
+	require.NoError(t, err)
+	assert.Equal(t, len(expected), actualCount)
 }


### PR DESCRIPTION
Required for #73 and #167.

The implementation is to keep the count of all models in the collection stored in a separate key and update it on each insert/delete. This does reduce insert/delete performance slightly, but we think it is worth it since it changes count operations from `O(N)` to `O(1)`.

```diff
- BenchmarkInsert-12                                        	  100000	     16363 ns/op
+ BenchmarkInsert-12                                        	  100000	     19481 ns/op
- BenchmarkDelete-12                                        	  100000	     15089 ns/op
+ BenchmarkDelete-12                                        	  100000	     16921 ns/op
- BenchmarkTransactionInsert100-12                          	    3000	    903916 ns/op
+ BenchmarkTransactionInsert100-12                          	    2000	   1040102 ns/op
- BenchmarkTransactionInsert1000-12                         	     200	   7380367 ns/op
+ BenchmarkTransactionInsert1000-12                         	     200	   9453033 ns/op
- BenchmarkTransactionInsert10000-12                        	      30	  67534611 ns/op
+ BenchmarkTransactionInsert10000-12                        	      20	  84806707 ns/op
```