### PR TITLE
db: Implement global transactions

### DIFF
--- a/db/col_info.go
+++ b/db/col_info.go
@@ -8,13 +8,15 @@ import (
 
 // colInfo is a set of information/metadata about a collection.
 type colInfo struct {
+	db        *DB
 	name      string
 	modelType reflect.Type
 	indexes   []*Index
 	// indexMut protects the indexes slice.
 	indexMut sync.RWMutex
 	// writeMut is used by transactions to prevent other goroutines from writing
-	// until the transaction is committed or discarded.
+	// until the transaction is committed or discarded. Needs to be a pointer so
+	// that copies of this colInfo retain the same writeLock.
 	writeMut *sync.Mutex
 }
 
@@ -27,6 +29,7 @@ func (info *colInfo) copy() *colInfo {
 	copy(indexes, info.indexes)
 	info.indexMut.RUnlock()
 	return &colInfo{
+		db:        info.db,
 		name:      info.name,
 		modelType: info.modelType,
 		indexes:   indexes,

--- a/db/collection.go
+++ b/db/collection.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 
@@ -16,16 +17,27 @@ type Collection struct {
 // NewCollection creates and returns a new collection with the given name and
 // model type. You should create exactly one collection for each model type. The
 // collection should typically be created once at the start of your application
-// and re-used.
-func (db *DB) NewCollection(name string, typ Model) *Collection {
-	return &Collection{
+// and re-used. NewCollection returns an error if a collection has already been
+// created with the given name for this db.
+func (db *DB) NewCollection(name string, typ Model) (*Collection, error) {
+	col := &Collection{
 		info: &colInfo{
+			db:        db,
 			name:      name,
 			modelType: reflect.TypeOf(typ),
 			writeMut:  &sync.Mutex{},
 		},
 		ldb: db.ldb,
 	}
+	db.colLock.Lock()
+	defer db.colLock.Unlock()
+	for _, existingCol := range db.collections {
+		if existingCol.info.name == name {
+			return nil, fmt.Errorf("a collection with the name %q already exists", name)
+		}
+	}
+	db.collections = append(db.collections, col)
+	return col, nil
 }
 
 // Name returns the name of the collection.
@@ -57,8 +69,9 @@ func (c *Collection) Count() (int, error) {
 // model with the same id already exists.
 func (c *Collection) Insert(model Model) error {
 	txn := c.OpenTransaction()
-	if err := insertWithTransaction(c.info, txn, model); err != nil {
+	if err := insertWithTransaction(c.info, txn.readWriter, model); err != nil {
 		_ = txn.Discard()
+		return err
 	}
 	if err := txn.Commit(); err != nil {
 		_ = txn.Discard()
@@ -71,8 +84,9 @@ func (c *Collection) Insert(model Model) error {
 // given model doesn't already exist.
 func (c *Collection) Update(model Model) error {
 	txn := c.OpenTransaction()
-	if err := updateWithTransaction(c.info, txn, model); err != nil {
+	if err := updateWithTransaction(c.info, txn.readWriter, model); err != nil {
 		_ = txn.Discard()
+		return err
 	}
 	if err := txn.Commit(); err != nil {
 		_ = txn.Discard()
@@ -85,8 +99,9 @@ func (c *Collection) Update(model Model) error {
 // error if the model doesn't exist in the database.
 func (c *Collection) Delete(id []byte) error {
 	txn := c.OpenTransaction()
-	if err := deleteWithTransaction(c.info, txn, id); err != nil {
+	if err := deleteWithTransaction(c.info, txn.readWriter, id); err != nil {
 		_ = txn.Discard()
+		return err
 	}
 	if err := txn.Commit(); err != nil {
 		_ = txn.Discard()

--- a/db/collection_benchmark_test.go
+++ b/db/collection_benchmark_test.go
@@ -11,7 +11,8 @@ import (
 func BenchmarkInsert(b *testing.B) {
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -30,7 +31,8 @@ func BenchmarkInsert(b *testing.B) {
 func BenchmarkFindByIDHot(b *testing.B) {
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	model := &testModel{
 		Name: "foo",
 		Age:  42,
@@ -49,7 +51,8 @@ func BenchmarkFindByIDHot(b *testing.B) {
 func BenchmarkFindByIDCold(b *testing.B) {
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -70,7 +73,8 @@ func BenchmarkFindByIDCold(b *testing.B) {
 func BenchmarkUpdateHot(b *testing.B) {
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	original := &testModel{
 		Name: "person_0",
 		Age:  0,
@@ -94,7 +98,8 @@ func BenchmarkUpdateHot(b *testing.B) {
 func BenchmarkUpdateCold(b *testing.B) {
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -127,7 +132,8 @@ func benchmarkFindAll(b *testing.B, count int) {
 	b.Helper()
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	expected := []*testModel{}
 	for i := 0; i < count; i++ {
 		model := &testModel{
@@ -150,7 +156,8 @@ func benchmarkFindAll(b *testing.B, count int) {
 func BenchmarkDelete(b *testing.B) {
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()

--- a/db/collection_test.go
+++ b/db/collection_test.go
@@ -9,10 +9,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewCollection(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	_, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
+	_, err = db.NewCollection("people", &testModel{})
+	require.Error(t, err, "Expected an error when creating new collection with the same name")
+}
+
 func TestInsert(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	expected := &testModel{
 		Name: "foo",
 		Age:  42,
@@ -26,7 +36,8 @@ func TestInsert(t *testing.T) {
 func TestFindByID(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	expected := &testModel{
 		Name: "foo",
 		Age:  42,
@@ -40,7 +51,8 @@ func TestFindByID(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	original := &testModel{
 		Name: "foo",
 		Age:  42,
@@ -59,7 +71,8 @@ func TestUpdate(t *testing.T) {
 func TestFindAll(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	expected := []*testModel{}
 	for i := 0; i < 5; i++ {
 		model := &testModel{
@@ -77,7 +90,8 @@ func TestFindAll(t *testing.T) {
 func TestCount(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 
 	// Insert some test models and make sure Count is equal to the number of
 	// models inserted.
@@ -121,7 +135,8 @@ func TestCount(t *testing.T) {
 func TestDelete(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	col.AddIndex("age", func(m Model) []byte {
 		return []byte(fmt.Sprint(m.(*testModel).Age))
 	})
@@ -146,7 +161,8 @@ func TestDelete(t *testing.T) {
 func TestDeleteAfterUpdate(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	col.AddIndex("age", func(m Model) []byte {
 		return []byte(fmt.Sprint(m.(*testModel).Age))
 	})

--- a/db/db.go
+++ b/db/db.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"sync"
+
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -28,7 +30,10 @@ type Model interface {
 
 // DB is the top-level Database.
 type DB struct {
-	ldb *leveldb.DB
+	ldb             *leveldb.DB
+	globalWriteLock sync.RWMutex
+	collections     []*Collection
+	colLock         sync.Mutex
 }
 
 // Open creates a new database using the given file path for permanent storage.

--- a/db/escape_test.go
+++ b/db/escape_test.go
@@ -36,7 +36,8 @@ func TestEscapeUnescape(t *testing.T) {
 func TestFindWithValueWithEscape(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	ageIndex := col.AddIndex("age", func(m Model) []byte {
 		// Note: We add the ':' to the index value to try and trip up the escaping
 		// algorithm.

--- a/db/global_transaction.go
+++ b/db/global_transaction.go
@@ -1,0 +1,135 @@
+package db
+
+import "sync"
+
+// GlobalTransaction is an atomic database transaction across all collections
+// which can be used to guarantee consistency.
+type GlobalTransaction struct {
+	db          *DB
+	mut         sync.Mutex
+	batchWriter dbBatchWriter
+	readWriter  *readerWithBatchWriter
+	committed   bool
+	discarded   bool
+}
+
+// OpenGlobalTransaction opens and returns a new global transaction. While the
+// transaction is open, no other state changes (e.g. Insert, Update, or Delete)
+// can be made to the database (but concurrent reads are still allowed). This
+// includes all collections.
+//
+// No new collections can be created while the global transaction is open.
+// Calling NewCollection while the transaction is open will block until the
+// transaction is committed or discarded.
+//
+// Transactions are atomic, meaning that either:
+//
+//     (1) The transaction will succeed and *all* queued operations will be
+//     applied, or
+//     (2) the transaction will be fail or be discarded, in which case *none* of
+//     the queued operations will be applied.
+//
+// The transaction must be closed once done, either by committing or discarding
+// the transaction. No changes will be made to the database state until the
+// transaction is committed.
+func (db *DB) OpenGlobalTransaction() *GlobalTransaction {
+	// Note we acquire a Lock on the global write mutex. We're not really a
+	// "writer" but we behave like one in the context of an RWMutex. Up to one
+	// write lock for each collection can be held, or one global write lock can be
+	// held at any given time.
+	db.globalWriteLock.Lock()
+	db.colLock.Lock()
+	return &GlobalTransaction{
+		db:          db,
+		batchWriter: db.ldb,
+		readWriter:  newReaderWithBatchWriter(db.ldb),
+	}
+}
+
+// checkState acquires a lock on txn.mut and then calls unsafeCheckState.
+func (txn *GlobalTransaction) checkState() error {
+	txn.mut.Lock()
+	defer txn.mut.Unlock()
+	return txn.unsafeCheckState()
+}
+
+// unsafeCheckState checks the state of the transaction, assuming the caller has
+// already acquired a lock. It returns an error if the transaction has already
+// been committed or discarded.
+func (txn *GlobalTransaction) unsafeCheckState() error {
+	if txn.discarded {
+		return ErrDiscarded
+	} else if txn.committed {
+		return ErrCommitted
+	}
+	return nil
+}
+
+// Commit commits the transaction. If error is not nil, then the transaction is
+// not committed, it can then either be retried or discarded.
+//
+// Other methods should not be called after transaction has been committed.
+func (txn *GlobalTransaction) Commit() error {
+	txn.mut.Lock()
+	defer txn.mut.Unlock()
+	if err := txn.unsafeCheckState(); err != nil {
+		return err
+	}
+	if err := txn.batchWriter.Write(txn.readWriter.batch, nil); err != nil {
+		return err
+	}
+	txn.committed = true
+	txn.db.colLock.Unlock()
+	txn.db.globalWriteLock.Unlock()
+	return nil
+}
+
+// Discard discards the transaction.
+//
+// Other methods should not be called after transaction has been discarded.
+// However, it is safe to call Discard multiple times.
+func (txn *GlobalTransaction) Discard() error {
+	txn.mut.Lock()
+	defer txn.mut.Unlock()
+	if txn.committed {
+		return ErrCommitted
+	}
+	if txn.discarded {
+		return nil
+	}
+	txn.discarded = true
+	txn.db.colLock.Unlock()
+	txn.db.globalWriteLock.Unlock()
+	return nil
+}
+
+// Insert queues an operation to insert the given model into the given
+// collection. It returns an error if a model with the same id already exists.
+// The model will not actually be inserted until the transaction is committed.
+func (txn *GlobalTransaction) Insert(col *Collection, model Model) error {
+	if err := txn.checkState(); err != nil {
+		return err
+	}
+	return insertWithTransaction(col.info, txn.readWriter, model)
+}
+
+// Update queues an operation to update an existing model in the given
+// collection. It returns an error if the given model doesn't already exist. The
+// model will not actually be updated until the transaction is committed.
+func (txn *GlobalTransaction) Update(col *Collection, model Model) error {
+	if err := txn.checkState(); err != nil {
+		return err
+	}
+	return updateWithTransaction(col.info, txn.readWriter, model)
+}
+
+// Delete queues an operation to delete the model with the given ID from the
+// given collection. It returns an error if the model doesn't exist in the
+// database. The model will not actually be deleted until the transaction is
+// committed.
+func (txn *GlobalTransaction) Delete(col *Collection, id []byte) error {
+	if err := txn.checkState(); err != nil {
+		return err
+	}
+	return deleteWithTransaction(col.info, txn.readWriter, id)
+}

--- a/db/global_transaction.go
+++ b/db/global_transaction.go
@@ -26,7 +26,7 @@ type GlobalTransaction struct {
 //
 //     (1) The transaction will succeed and *all* queued operations will be
 //     applied, or
-//     (2) the transaction will be fail or be discarded, in which case *none* of
+//     (2) the transaction will fail or be discarded, in which case *none* of
 //     the queued operations will be applied.
 //
 // The transaction must be closed once done, either by committing or discarding
@@ -66,7 +66,8 @@ func (txn *GlobalTransaction) unsafeCheckState() error {
 }
 
 // Commit commits the transaction. If error is not nil, then the transaction is
-// not committed, it can then either be retried or discarded.
+// not committed, and a new transaction must be created if you wish to retry the
+// operations.
 //
 // Other methods should not be called after transaction has been committed.
 func (txn *GlobalTransaction) Commit() error {

--- a/db/global_transaction_test.go
+++ b/db/global_transaction_test.go
@@ -57,7 +57,7 @@ func TestGlobalTransaction(t *testing.T) {
 		}
 	}()
 
-	// Any models we add to col0 after within the transaction should not affect
+	// Any models we add to col0 within the transaction should not affect
 	// the database state until after it is committed.
 	insideTransaction := []*testModel{}
 	for i := 0; i < 5; i++ {

--- a/db/global_transaction_test.go
+++ b/db/global_transaction_test.go
@@ -1,0 +1,131 @@
+package db
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobalTransaction(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	col0, err := db.NewCollection("people0", &testModel{})
+	require.NoError(t, err)
+	col1, err := db.NewCollection("people1", &testModel{})
+	require.NoError(t, err)
+
+	// expected is a set of testModels with Age = 42
+	expected := []*testModel{}
+	for i := 0; i < 5; i++ {
+		model := &testModel{
+			Name: "ExpectedPerson_" + strconv.Itoa(i),
+			Age:  42,
+		}
+		require.NoError(t, col0.Insert(model))
+		expected = append(expected, model)
+	}
+
+	// Open a global transaction.
+	txn := db.OpenGlobalTransaction()
+	defer func() {
+		err := txn.Discard()
+		if err != nil && err != ErrCommitted {
+			t.Error(err)
+		}
+	}()
+
+	// The WaitGroup will be used to wait for all goroutines to finish.
+	wg := &sync.WaitGroup{}
+
+	// Any models we add to col0 after opening the transaction should not affect
+	// the database state.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 5; i++ {
+			model := &testModel{
+				Name: "OtherPerson_" + strconv.Itoa(i),
+				Age:  42,
+			}
+			require.NoError(t, col0.Insert(model))
+		}
+	}()
+
+	// Any models we add to col1 after opening the transaction should not affect
+	// the database state.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 5; i++ {
+			model := &testModel{
+				Name: "OtherPerson_" + strconv.Itoa(i),
+				Age:  42,
+			}
+			require.NoError(t, col1.Insert(model))
+		}
+	}()
+
+	// Any models we delete after opening the transaction should not affect
+	// the database state.
+	idToDelete := expected[2].ID()
+	wg.Add(1)
+	go func(idToDelete []byte) {
+		defer wg.Done()
+		require.NoError(t, col0.Delete(idToDelete))
+	}(idToDelete)
+
+	// Attempting to add a new collection should block until after the transaction
+	// is committed/discarded. We use two channels to determine the order in which
+	// the two events occurred.
+	// commitSignal is fired right before the transaction is committed.
+	commitSignal := make(chan struct{}, 1)
+	// newCollectionSignal is fired after the new collection has been created.
+	newCollectionSignal := make(chan struct{}, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		select {
+		case <-commitSignal:
+			// Expected outcome. Return from goroutine.
+			return
+		case <-newCollectionSignal:
+			// Not the expected outcome. commitSignal should have fired first.
+			t.Error("new collection was created before the transaction was committed")
+			return
+		}
+	}()
+
+	// TODO(albrow): Test that opening a collection transaction blocks until after
+	// the transaction is committed.
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := db.NewCollection("people2", &testModel{})
+		require.NoError(t, err)
+		// Signal that the new collection was created.
+		newCollectionSignal <- struct{}{}
+	}()
+
+	// Make sure that col0 only contains models that were created before the
+	// transaction was opened.
+	var actual []*testModel
+	require.NoError(t, col0.FindAll(&actual))
+	assert.Equal(t, expected, actual)
+
+	// Make sure that col1 doesn't contain any models (since they were created
+	// after the transaction was opened).
+	actualCount, err := col1.Count()
+	require.NoError(t, err)
+	assert.Equal(t, 0, actualCount)
+
+	// Signal that we are about to commit the transaction, then commit it.
+	commitSignal <- struct{}{}
+	require.NoError(t, txn.Commit())
+
+	// Wait for any goroutines to finish.
+	wg.Wait()
+}

--- a/db/global_transaction_test.go
+++ b/db/global_transaction_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,15 +18,15 @@ func TestGlobalTransaction(t *testing.T) {
 	col1, err := db.NewCollection("people1", &testModel{})
 	require.NoError(t, err)
 
-	// expected is a set of testModels with Age = 42
-	expected := []*testModel{}
+	// beforeTxnOpen is a set of testModels inserted before the transaction is opened.
+	beforeTxnOpen := []*testModel{}
 	for i := 0; i < 5; i++ {
 		model := &testModel{
 			Name: "ExpectedPerson_" + strconv.Itoa(i),
-			Age:  42,
+			Age:  i,
 		}
 		require.NoError(t, col0.Insert(model))
-		expected = append(expected, model)
+		beforeTxnOpen = append(beforeTxnOpen, model)
 	}
 
 	// Open a global transaction.
@@ -41,36 +42,50 @@ func TestGlobalTransaction(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	// Any models we add to col0 after opening the transaction should not affect
-	// the database state.
+	// the database state until after is committed.
+	outsideTransaction := []*testModel{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 5; i++ {
 			model := &testModel{
-				Name: "OtherPerson_" + strconv.Itoa(i),
-				Age:  42,
+				Name: "OutsideTransaction_" + strconv.Itoa(i),
+				Age:  i,
 			}
 			require.NoError(t, col0.Insert(model))
+			outsideTransaction = append(outsideTransaction, model)
 		}
 	}()
 
+	// Any models we add to col0 after within the transaction should not affect
+	// the database state until after it is committed.
+	insideTransaction := []*testModel{}
+	for i := 0; i < 5; i++ {
+		model := &testModel{
+			Name: "InsideTransaction_" + strconv.Itoa(i),
+			Age:  i,
+		}
+		require.NoError(t, txn.Insert(col0, model))
+		insideTransaction = append(insideTransaction, model)
+	}
+
 	// Any models we add to col1 after opening the transaction should not affect
-	// the database state.
+	// the database state until after it is committed.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 5; i++ {
 			model := &testModel{
 				Name: "OtherPerson_" + strconv.Itoa(i),
-				Age:  42,
+				Age:  i,
 			}
 			require.NoError(t, col1.Insert(model))
 		}
 	}()
 
 	// Any models we delete after opening the transaction should not affect
-	// the database state.
-	idToDelete := expected[2].ID()
+	// the database state until after it is committed.
+	idToDelete := beforeTxnOpen[2].ID()
 	wg.Add(1)
 	go func(idToDelete []byte) {
 		defer wg.Done()
@@ -98,9 +113,6 @@ func TestGlobalTransaction(t *testing.T) {
 		}
 	}()
 
-	// TODO(albrow): Test that opening a collection transaction blocks until after
-	// the transaction is committed.
-
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -114,7 +126,7 @@ func TestGlobalTransaction(t *testing.T) {
 	// transaction was opened.
 	var actual []*testModel
 	require.NoError(t, col0.FindAll(&actual))
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, beforeTxnOpen, actual)
 
 	// Make sure that col1 doesn't contain any models (since they were created
 	// after the transaction was opened).
@@ -127,5 +139,97 @@ func TestGlobalTransaction(t *testing.T) {
 	require.NoError(t, txn.Commit())
 
 	// Wait for any goroutines to finish.
+	wg.Wait()
+
+	// Check that all the models are now written.
+	// TODO(albrow): Fix bug with Count and transactions, then we can use Count
+	// instead of FindAll here.
+	var existingModels []*testModel
+	require.NoError(t, col0.FindAll(&existingModels))
+	assert.Len(t, existingModels, 14)
+
+	col1PostTxnCount, err := col1.Count()
+	require.NoError(t, err)
+	assert.Equal(t, 5, col1PostTxnCount)
+}
+
+// TestGlobalTransactionExclusion is designed to test whether a global
+// transaction has exclusive write access for all collections while open.
+func TestGlobalTransactionExclusion(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	col0, err := db.NewCollection("people0", &testModel{})
+	require.NoError(t, err)
+	col1, err := db.NewCollection("people1", &testModel{})
+	require.NoError(t, err)
+
+	txn := db.OpenGlobalTransaction()
+	defer func() {
+		_ = txn.Discard()
+	}()
+
+	// discardSignal is fired right before the original global transaction is
+	// discarded.
+	discardSignal := make(chan struct{}, 1)
+	// newGlobalTxnOpenSignal is fired when a new global transaction is opened.
+	newGlobalTxnOpenSignal := make(chan struct{}, 1)
+	// col0TxnOpenSignal is fired when a transaction on col0 is opened.
+	col0TxnOpenSignal := make(chan struct{}, 1)
+	// col1TxnOpenSignal is fired when a transaction on col1 is opened.
+	col1TxnOpenSignal := make(chan struct{}, 1)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-discardSignal:
+				// Expected outcome. Return from the goroutine.
+				return
+			case <-newGlobalTxnOpenSignal:
+				t.Error("a new global transaction was opened before the first was committed/discarded")
+			case <-col0TxnOpenSignal:
+				t.Error("a new transaction was opened on col0 before the global transaction was committed/discarded")
+			case <-col1TxnOpenSignal:
+				t.Error("a new transaction was opened on col1 before the global transaction was committed/discarded")
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		txn := db.OpenGlobalTransaction()
+		newGlobalTxnOpenSignal <- struct{}{}
+		defer func() {
+			_ = txn.Discard()
+		}()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		txn := col0.OpenTransaction()
+		col0TxnOpenSignal <- struct{}{}
+		defer func() {
+			_ = txn.Discard()
+		}()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		txn := col1.OpenTransaction()
+		col1TxnOpenSignal <- struct{}{}
+		defer func() {
+			_ = txn.Discard()
+		}()
+	}()
+
+	time.Sleep(1 * time.Millisecond)
+	discardSignal <- struct{}{}
+	require.NoError(t, txn.Discard())
+
 	wg.Wait()
 }

--- a/db/index_test.go
+++ b/db/index_test.go
@@ -11,7 +11,8 @@ import (
 func TestInsertWithIndex(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	col.AddIndex("age", func(m Model) []byte {
 		return []byte(fmt.Sprint(m.(*testModel).Age))
 	})
@@ -28,7 +29,8 @@ func TestInsertWithIndex(t *testing.T) {
 func TestUpdateWithIndex(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	col.AddIndex("age", func(m Model) []byte {
 		return []byte(fmt.Sprint(m.(*testModel).Age))
 	})

--- a/db/operations.go
+++ b/db/operations.go
@@ -58,8 +58,8 @@ func findWithIterator(info *colInfo, iter iterator.Iterator, models interface{})
 // given primary key. Useful in cases where the given model may be out of date
 // with what is currently stored in the database. It *doesn't* discard the
 // transaction if there is an error.
-func findExistingModelByPrimaryKeyWithTransaction(info *colInfo, txn *Transaction, primaryKey []byte) (Model, error) {
-	data, err := txn.readerWithBatch.Get(primaryKey, nil)
+func findExistingModelByPrimaryKeyWithTransaction(info *colInfo, readWriter dbReadWriter, primaryKey []byte) (Model, error) {
+	data, err := readWriter.Get(primaryKey, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func findExistingModelByPrimaryKeyWithTransaction(info *colInfo, txn *Transactio
 	return model, nil
 }
 
-func insertWithTransaction(info *colInfo, txn *Transaction, model Model) error {
+func insertWithTransaction(info *colInfo, readWriter dbReadWriter, model Model) error {
 	if len(model.ID()) == 0 {
 		return errors.New("can't insert model with empty ID")
 	}
@@ -84,24 +84,24 @@ func insertWithTransaction(info *colInfo, txn *Transaction, model Model) error {
 		return err
 	}
 	pk := info.primaryKeyForModel(model)
-	if exists, err := txn.readerWithBatch.Has(pk, nil); err != nil {
+	if exists, err := readWriter.Has(pk, nil); err != nil {
 		return err
 	} else if exists {
 		return AlreadyExistsError{ID: model.ID()}
 	}
-	if err := txn.readerWithBatch.Put(pk, data, nil); err != nil {
+	if err := readWriter.Put(pk, data, nil); err != nil {
 		return err
 	}
-	if err := saveIndexesWithTransaction(info, txn, model); err != nil {
+	if err := saveIndexesWithTransaction(info, readWriter, model); err != nil {
 		return err
 	}
-	if err := updateCountWithTransaction(info, txn, 1); err != nil {
+	if err := updateCountWithTransaction(info, readWriter, 1); err != nil {
 		return err
 	}
 	return nil
 }
 
-func updateWithTransaction(info *colInfo, txn *Transaction, model Model) error {
+func updateWithTransaction(info *colInfo, readWriter dbReadWriter, model Model) error {
 	if len(model.ID()) == 0 {
 		return errors.New("can't update model with empty ID")
 	}
@@ -111,18 +111,18 @@ func updateWithTransaction(info *colInfo, txn *Transaction, model Model) error {
 
 	// Check if the model already exists and return an error if not.
 	pk := info.primaryKeyForModel(model)
-	if exists, err := txn.readerWithBatch.Has(pk, nil); err != nil {
+	if exists, err := readWriter.Has(pk, nil); err != nil {
 		return err
 	} else if !exists {
 		return NotFoundError{ID: model.ID()}
 	}
 
 	// Get the existing data for the model and delete any (now outdated) indexes.
-	existingModel, err := findExistingModelByPrimaryKeyWithTransaction(info, txn, pk)
+	existingModel, err := findExistingModelByPrimaryKeyWithTransaction(info, readWriter, pk)
 	if err != nil {
 		return err
 	}
-	if err := deleteIndexesWithTransaction(info, txn, existingModel); err != nil {
+	if err := deleteIndexesWithTransaction(info, readWriter, existingModel); err != nil {
 		return err
 	}
 
@@ -131,16 +131,16 @@ func updateWithTransaction(info *colInfo, txn *Transaction, model Model) error {
 	if err != nil {
 		return err
 	}
-	if err := txn.readerWithBatch.Put(pk, newData, nil); err != nil {
+	if err := readWriter.Put(pk, newData, nil); err != nil {
 		return err
 	}
-	if err := saveIndexesWithTransaction(info, txn, model); err != nil {
+	if err := saveIndexesWithTransaction(info, readWriter, model); err != nil {
 		return err
 	}
 	return nil
 }
 
-func deleteWithTransaction(info *colInfo, txn *Transaction, id []byte) error {
+func deleteWithTransaction(info *colInfo, readWriter dbReadWriter, id []byte) error {
 	if len(id) == 0 {
 		return errors.New("can't delete model with empty ID")
 	}
@@ -148,7 +148,7 @@ func deleteWithTransaction(info *colInfo, txn *Transaction, id []byte) error {
 	// We need to get the latest data because the given model might be out of sync
 	// with the actual data in the database.
 	pk := info.primaryKeyForID(id)
-	latest, err := findExistingModelByPrimaryKeyWithTransaction(info, txn, pk)
+	latest, err := findExistingModelByPrimaryKeyWithTransaction(info, readWriter, pk)
 	if err != nil {
 		if err == leveldb.ErrNotFound {
 			return NotFoundError{ID: id}
@@ -157,30 +157,30 @@ func deleteWithTransaction(info *colInfo, txn *Transaction, id []byte) error {
 	}
 
 	// Delete the primary key.
-	if err := txn.readerWithBatch.Delete(pk, nil); err != nil {
+	if err := readWriter.Delete(pk, nil); err != nil {
 		return err
 	}
 
 	// Delete any index entries.
-	if err := deleteIndexesWithTransaction(info, txn, latest); err != nil {
+	if err := deleteIndexesWithTransaction(info, readWriter, latest); err != nil {
 		return err
 	}
 
 	// Decrement the model count by 1.
-	if err := updateCountWithTransaction(info, txn, -1); err != nil {
+	if err := updateCountWithTransaction(info, readWriter, -1); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func saveIndexesWithTransaction(info *colInfo, txn *Transaction, model Model) error {
+func saveIndexesWithTransaction(info *colInfo, readWriter dbReadWriter, model Model) error {
 	info.indexMut.RLock()
 	defer info.indexMut.RUnlock()
 	for _, index := range info.indexes {
 		keys := index.keysForModel(model)
 		for _, key := range keys {
-			if err := txn.readerWithBatch.Put(key, nil, nil); err != nil {
+			if err := readWriter.Put(key, nil, nil); err != nil {
 				return err
 			}
 		}
@@ -190,13 +190,13 @@ func saveIndexesWithTransaction(info *colInfo, txn *Transaction, model Model) er
 
 // deleteIndexesForModel deletes any indexes computed from the given model. It
 // *doesn't* discard the transaction if there is an error.
-func deleteIndexesWithTransaction(info *colInfo, txn *Transaction, model Model) error {
+func deleteIndexesWithTransaction(info *colInfo, readWriter dbReadWriter, model Model) error {
 	info.indexMut.RLock()
 	defer info.indexMut.RUnlock()
 	for _, index := range info.indexes {
 		keys := index.keysForModel(model)
 		for _, key := range keys {
-			if err := txn.readerWithBatch.Delete(key, nil); err != nil {
+			if err := readWriter.Delete(key, nil); err != nil {
 				return err
 			}
 		}
@@ -221,16 +221,16 @@ func count(info *colInfo, reader dbReader) (int, error) {
 	return count, nil
 }
 
-func updateCountWithTransaction(info *colInfo, txn *Transaction, diff int) error {
-	existingCount, err := count(info, txn.readerWithBatch)
+func updateCountWithTransaction(info *colInfo, readWriter dbReadWriter, diff int) error {
+	existingCount, err := count(info, readWriter)
 	if err != nil {
 		return err
 	}
 	newCount := existingCount + diff
 	if newCount == 0 {
-		return txn.readerWithBatch.Delete(info.countKey(), nil)
+		return readWriter.Delete(info.countKey(), nil)
 	} else {
-		return txn.readerWithBatch.Put(info.countKey(), encodeInt(newCount), nil)
+		return readWriter.Put(info.countKey(), encodeInt(newCount), nil)
 	}
 }
 

--- a/db/query_benchmark_test.go
+++ b/db/query_benchmark_test.go
@@ -12,7 +12,8 @@ const defaultTargetNickname = "target"
 func setupQueryBenchmark(b *testing.B) (db *DB, col *Collection, nicknameIndex *Index) {
 	b.Helper()
 	db = newTestDB(b)
-	col = db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	nicknameIndex = col.AddMultiIndex("nicknames", func(m Model) [][]byte {
 		person := m.(*testModel)
 		indexValues := make([][]byte, len(person.Nicknames))

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestQueryWithValue(t *testing.T) {
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 
 	ageIndex := col.AddIndex("age", func(m Model) []byte {
 		return []byte(fmt.Sprint(m.(*testModel).Age))
@@ -51,7 +52,8 @@ func TestQueryWithValue(t *testing.T) {
 
 func TestQueryWithRange(t *testing.T) {
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 
 	ageIndex := col.AddIndex("age", func(m Model) []byte {
 		return []byte(fmt.Sprint(m.(*testModel).Age))
@@ -74,7 +76,8 @@ func TestQueryWithRange(t *testing.T) {
 
 func TestQueryWithPrefix(t *testing.T) {
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 
 	ageIndex := col.AddIndex("age", func(m Model) []byte {
 		return []byte(fmt.Sprint(m.(*testModel).Age))
@@ -131,7 +134,8 @@ func TestQueryWithPrefix(t *testing.T) {
 
 func TestFindWithValueWithMultiIndex(t *testing.T) {
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	nicknameIndex := col.AddMultiIndex("nicknames", func(m Model) [][]byte {
 		person := m.(*testModel)
 		indexValues := make([][]byte, len(person.Nicknames))
@@ -191,7 +195,8 @@ func TestFindWithValueWithMultiIndex(t *testing.T) {
 
 func TestFindWithRangeWithMultiIndex(t *testing.T) {
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 	nicknameIndex := col.AddMultiIndex("nicknames", func(m Model) [][]byte {
 		person := m.(*testModel)
 		indexValues := make([][]byte, len(person.Nicknames))

--- a/db/snapshot_benchmark_test.go
+++ b/db/snapshot_benchmark_test.go
@@ -10,7 +10,8 @@ import (
 func BenchmarkGetSnapshot(b *testing.B) {
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	for i := 0; i < 1000; i++ {
 		model := &testModel{
 			Name: fmt.Sprintf("person_%d", i),
@@ -31,7 +32,8 @@ func BenchmarkGetSnapshot(b *testing.B) {
 func BenchmarkSnapshotFindByID(b *testing.B) {
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	model := &testModel{
 		Name: "foo",
 		Age:  42,

--- a/db/snapshot_test.go
+++ b/db/snapshot_test.go
@@ -12,7 +12,8 @@ import (
 func TestSnapshot(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 
 	ageIndex := col.AddIndex("age", func(m Model) []byte {
 		return []byte(fmt.Sprint(m.(*testModel).Age))

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -31,7 +31,7 @@ type Transaction struct {
 //
 //     (1) The transaction will succeed and *all* queued operations will be
 //     applied, or
-//     (2) the transaction will be fail or be discarded, in which case *none* of
+//     (2) the transaction will fail or be discarded, in which case *none* of
 //     the queued operations will be applied.
 //
 // The transaction must be closed once done, either by committing or discarding
@@ -72,7 +72,8 @@ func (txn *Transaction) unsafeCheckState() error {
 }
 
 // Commit commits the transaction. If error is not nil, then the transaction is
-// not committed, it can then either be retried or discarded.
+// not committed, and a new transaction must be created if you wish to retry the
+// operations.
 //
 // Other methods should not be called after transaction has been committed.
 func (txn *Transaction) Commit() error {

--- a/db/transaction_benchmark_test.go
+++ b/db/transaction_benchmark_test.go
@@ -23,7 +23,8 @@ func benchmarkTransactionInsert(b *testing.B, count int) {
 	b.Helper()
 	db := newTestDB(b)
 	defer db.Close()
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		txn := col.OpenTransaction()

--- a/db/transaction_test.go
+++ b/db/transaction_test.go
@@ -13,7 +13,8 @@ import (
 func TestTransaction(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
-	col := db.NewCollection("people", &testModel{})
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
 
 	ageIndex := col.AddIndex("age", func(m Model) []byte {
 		return []byte(fmt.Sprint(m.(*testModel).Age))

--- a/meshdb/meshdb.go
+++ b/meshdb/meshdb.go
@@ -79,7 +79,10 @@ func NewMeshDB(path string) (*MeshDB, error) {
 		return nil, err
 	}
 
-	orders := setupOrders(database)
+	orders, err := setupOrders(database)
+	if err != nil {
+		return nil, err
+	}
 
 	return &MeshDB{
 		database:    database,
@@ -88,8 +91,11 @@ func NewMeshDB(path string) (*MeshDB, error) {
 	}, nil
 }
 
-func setupOrders(database *db.DB) *OrdersCollection {
-	col := database.NewCollection("order", &Order{})
+func setupOrders(database *db.DB) (*OrdersCollection, error) {
+	col, err := database.NewCollection("order", &Order{})
+	if err != nil {
+		return nil, err
+	}
 	lastUpdatedIndex := col.AddIndex("lastUpdated", func(m db.Model) []byte {
 		index := []byte(m.(*Order).LastUpdated.UTC().Format(time.RFC3339Nano))
 		return index
@@ -141,11 +147,14 @@ func setupOrders(database *db.DB) *OrdersCollection {
 		MakerAddressAndSaltIndex:             makerAddressAndSaltIndex,
 		LastUpdatedIndex:                     lastUpdatedIndex,
 		IsRemovedIndex:                       isRemovedIndex,
-	}
+	}, nil
 }
 
 func setupMiniHeaders(database *db.DB) (*MiniHeadersCollection, error) {
-	col := database.NewCollection("miniHeader", &MiniHeader{})
+	col, err := database.NewCollection("miniHeader", &MiniHeader{})
+	if err != nil {
+		return nil, err
+	}
 	numberIndex := col.AddIndex("number", func(model db.Model) []byte {
 		// By default, the index is sorted in byte order. In order to sort by
 		// numerical order, we need to pad with zeroes. The maximum length of an


### PR DESCRIPTION
Required for #73 and #167.

This feature will allow us to maintain consistency when modifying the database state for two or more collections at once.