### PR TITLE
Fix bug in Count when models are inserted/deleted inside a transaction

### DIFF
--- a/db/collection.go
+++ b/db/collection.go
@@ -73,6 +73,7 @@ func (c *Collection) Insert(model Model) error {
 		_ = txn.Discard()
 		return err
 	}
+	txn.updateInternalCount(1)
 	if err := txn.Commit(); err != nil {
 		_ = txn.Discard()
 		return err
@@ -103,6 +104,7 @@ func (c *Collection) Delete(id []byte) error {
 		_ = txn.Discard()
 		return err
 	}
+	txn.updateInternalCount(-1)
 	if err := txn.Commit(); err != nil {
 		_ = txn.Discard()
 		return err

--- a/db/global_transaction.go
+++ b/db/global_transaction.go
@@ -13,10 +13,10 @@ type GlobalTransaction struct {
 	readWriter  *readerWithBatchWriter
 	committed   bool
 	discarded   bool
-	// internalCount keeps track of the number of models inserted/deleted within
-	// the transaction for each collection. An Insert increments internalCount and
-	// a Delete decrements it. When the transaction is committed, internalCount is
-	// added to the current count.
+	// internalCounts keeps track of the number of models inserted/deleted within
+	// the transaction for each collection. An Insert increments the count and
+	// a Delete decrements it. When the transaction is committed, the
+	// internal count is added to the current count for each collection.
 	internalCounts map[*Collection]int
 }
 

--- a/db/operations.go
+++ b/db/operations.go
@@ -95,9 +95,6 @@ func insertWithTransaction(info *colInfo, readWriter dbReadWriter, model Model) 
 	if err := saveIndexesWithTransaction(info, readWriter, model); err != nil {
 		return err
 	}
-	if err := updateCountWithTransaction(info, readWriter, 1); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -163,11 +160,6 @@ func deleteWithTransaction(info *colInfo, readWriter dbReadWriter, id []byte) er
 
 	// Delete any index entries.
 	if err := deleteIndexesWithTransaction(info, readWriter, latest); err != nil {
-		return err
-	}
-
-	// Decrement the model count by 1.
-	if err := updateCountWithTransaction(info, readWriter, -1); err != nil {
 		return err
 	}
 

--- a/db/transaction_test.go
+++ b/db/transaction_test.go
@@ -86,6 +86,108 @@ func TestTransaction(t *testing.T) {
 	wg.Wait()
 }
 
+func TestTransactionCount(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	col, err := db.NewCollection("people", &testModel{})
+	require.NoError(t, err)
+
+	// insertedBeforeTransaction is a set of testModels inserted before the
+	// transaction is opened.
+	insertedBeforeTransaction := []*testModel{}
+	for i := 0; i < 10; i++ {
+		model := &testModel{
+			Name: "Before_Transaction_" + strconv.Itoa(i),
+			Age:  i,
+		}
+		require.NoError(t, col.Insert(model))
+		insertedBeforeTransaction = append(insertedBeforeTransaction, model)
+	}
+
+	// Open a transaction.
+	txn := col.OpenTransaction()
+	defer func() {
+		err := txn.Discard()
+		if err != nil && err != ErrCommitted {
+			t.Error(err)
+		}
+	}()
+
+	// Insert some models inside the transaction.
+	for i := 0; i < 7; i++ {
+		model := &testModel{
+			Name: "Inside_Transaction_" + strconv.Itoa(i),
+			Age:  i,
+		}
+		require.NoError(t, txn.Insert(model))
+	}
+
+	// The WaitGroup will be used to wait for all goroutines to finish.
+	wg := &sync.WaitGroup{}
+
+	// Insert some models outside the transaction.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 4; i++ {
+			model := &testModel{
+				Name: "Outside_Transaction_" + strconv.Itoa(i),
+				Age:  42,
+			}
+			require.NoError(t, col.Insert(model))
+		}
+	}()
+
+	// Delete some models inside of the transaction.
+	idsToDeleteInside := [][]byte{
+		insertedBeforeTransaction[0].ID(),
+		insertedBeforeTransaction[1].ID(),
+		insertedBeforeTransaction[2].ID(),
+	}
+	for _, id := range idsToDeleteInside {
+		require.NoError(t, txn.Delete(id))
+	}
+
+	// Delete some models outside of the transaction.
+	idsToDeleteOutside := [][]byte{
+		insertedBeforeTransaction[3].ID(),
+		insertedBeforeTransaction[4].ID(),
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, id := range idsToDeleteOutside {
+			require.NoError(t, col.Delete(id))
+		}
+	}()
+
+	// Make sure that prior to commiting the transaction, Count only includes the
+	// models inserted/deleted before the transaction was open.
+	expectedPreCommitCount := 10
+	actualPreCommitCount, err := col.Count()
+	require.NoError(t, err)
+	assert.Equal(t, expectedPreCommitCount, actualPreCommitCount)
+
+	// Commit the transaction.
+	require.NoError(t, txn.Commit())
+
+	// Wait for any goroutines to finish.
+	wg.Wait()
+
+	// Make sure that after commiting the transaction, Count includes the models
+	// inserted/deleted in the transaction and outside of the transaction.
+	//   10 before transaction.
+	//   +7 inserted inside transaction
+	//   +4 inserted outside transaction
+	//   -3 deleted inside transaction
+	//   -2 deleted outside transaction
+	// = 16 total
+	expectedPostCommitCount := 16
+	actualPostCommitCount, err := col.Count()
+	require.NoError(t, err)
+	assert.Equal(t, expectedPostCommitCount, actualPostCommitCount)
+}
+
 // TestTransactionExclusion is designed to test whether a collection-based
 // transaction has exclusive write access for the collection while open.
 func TestTransactionExclusion(t *testing.T) {


### PR DESCRIPTION
Fixes a bug in `Count`. Before this PR, calling `Insert` or `Delete` inside of a transaction could result in the count becoming incorrect.

After https://github.com/0xProject/0x-mesh/pull/176 is merged, I'll rebase this off of master and change the base branch for the PR.

 Coincidentally, this should also improve performance when inserting or deleting multiple models in a single transaction.