### PR TITLE
blockwatch/core: Fix Kovan incorrect block hash bug

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -89,7 +89,7 @@ func New(config Config) (*App, error) {
 	}
 
 	// Initialize block watcher (but don't start it yet).
-	blockWatcherClient, err := blockwatch.NewRpcClient(ethClient, ethereumRPCRequestTimeout)
+	blockWatcherClient, err := blockwatch.NewRpcClient(config.EthereumRPCURL, ethereumRPCRequestTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -104,6 +104,16 @@ func New(config Config) (*App, error) {
 		Client:              blockWatcherClient,
 	}
 	blockWatcher := blockwatch.New(blockWatcherConfig)
+	go func() {
+		for {
+			select {
+			case err := <-blockWatcher.Errors:
+				log.WithField("error", err).Error("BlockWatcher error encountered")
+			default:
+				// Noop
+			}
+		}
+	}()
 
 	// Initialize order watcher (but don't start it yet).
 	orderWatcher, err := orderwatch.New(db, blockWatcher, ethClient, config.EthereumNetworkID, config.OrderExpirationBuffer)

--- a/core/core.go
+++ b/core/core.go
@@ -106,11 +106,11 @@ func New(config Config) (*App, error) {
 	blockWatcher := blockwatch.New(blockWatcherConfig)
 	go func() {
 		for {
-			select {
-			case err := <-blockWatcher.Errors:
+			err, isOpen := <-blockWatcher.Errors
+			if isOpen {
 				log.WithField("error", err).Error("BlockWatcher error encountered")
-			default:
-				// Noop
+			} else {
+				return // Exit when the error channel is closed
 			}
 		}
 	}()

--- a/core/core.go
+++ b/core/core.go
@@ -267,6 +267,6 @@ func (app *App) Close() {
 	if err := app.orderWatcher.Stop(); err != nil {
 		log.WithField("error", err.Error()).Error("error while closing orderWatcher")
 	}
-	app.blockWatcher.StopPolling()
+	app.blockWatcher.Stop()
 	app.db.Close()
 }

--- a/ethereum/blockchain_lifecycle.go
+++ b/ethereum/blockchain_lifecycle.go
@@ -8,11 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-/**
- * BlockchainLifecycle is a testing utility for taking snapshots of the blockchain
- * state on Ganache and reverting those snapshots at a later point in time. Ganache
- * supports performing multiple snapshots that can then be reverted in LIFO order.
- */
+// BlockchainLifecycle is a testing utility for taking snapshots of the blockchain
+// state on Ganache and reverting those snapshots at a later point in time. Ganache
+// supports performing multiple snapshots that can then be reverted in LIFO order.
 type BlockchainLifecycle struct {
 	rpcClient       *rpc.Client
 	snapshotIdStack []string

--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -118,8 +118,8 @@ func (w *Watcher) startPollingLoop() {
 	}
 }
 
-// StopPolling stops the block poller
-func (w *Watcher) StopPolling() {
+// stopPolling stops the block poller
+func (w *Watcher) stopPolling() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.isWatching = false
@@ -132,7 +132,7 @@ func (w *Watcher) StopPolling() {
 // Stop stops the BlockWatcher
 func (w *Watcher) Stop() {
 	if w.isWatching {
-		w.StopPolling()
+		w.stopPolling()
 	}
 	close(w.Errors)
 }

--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -126,6 +126,7 @@ func (w *Watcher) StopPolling() {
 	if w.ticker != nil {
 		w.ticker.Stop()
 	}
+	close(w.Errors)
 	w.ticker = nil
 }
 

--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -126,8 +126,15 @@ func (w *Watcher) StopPolling() {
 	if w.ticker != nil {
 		w.ticker.Stop()
 	}
-	close(w.Errors)
 	w.ticker = nil
+}
+
+// Stop stops the BlockWatcher
+func (w *Watcher) Stop() {
+	if w.isWatching {
+		w.StopPolling()
+	}
+	close(w.Errors)
 }
 
 // Subscribe allows one to subscribe to the block events emitted by the Watcher.

--- a/ethereum/blockwatch/block_watcher_test.go
+++ b/ethereum/blockwatch/block_watcher_test.go
@@ -87,5 +87,5 @@ func TestWatcherStartStop(t *testing.T) {
 	require.NoError(t, watcher.StartPolling())
 	watcher.stopPolling()
 	require.NoError(t, watcher.StartPolling())
-	watcher.stopPolling()
+	watcher.Stop()
 }

--- a/ethereum/blockwatch/block_watcher_test.go
+++ b/ethereum/blockwatch/block_watcher_test.go
@@ -85,7 +85,7 @@ func TestWatcherStartStop(t *testing.T) {
 	}
 	watcher := New(config)
 	require.NoError(t, watcher.StartPolling())
-	watcher.StopPolling()
+	watcher.stopPolling()
 	require.NoError(t, watcher.StartPolling())
-	watcher.StopPolling()
+	watcher.stopPolling()
 }

--- a/ethereum/blockwatch/client.go
+++ b/ethereum/blockwatch/client.go
@@ -65,6 +65,11 @@ func (rc *RpcClient) HeaderByNumber(number *big.Int) (*meshdb.MiniHeader, error)
 	}
 	shouldIncludeTransactions := false
 
+	// Note(fabio): We use a raw RPC call here instead of `EthClient`'s `BlockByNumber()` method because block
+	// hashes are computed differently on Kovan vs. mainnet, resulting in the wrong block hash being returned by
+	// `BlockByNumber` when using Kovan. By doing a raw RPC call, we can simply use the blockHash returned in the
+	// RPC response rather then re-compute it from the block header.
+	// Source: https://github.com/ethereum/go-ethereum/pull/18166
 	var header GetBlockByNumberResponse
 	err := rc.rpcClient.CallContext(ctx, &header, "eth_getBlockByNumber", blockParam, shouldIncludeTransactions)
 	if err != nil {

--- a/ethereum/blockwatch/client.go
+++ b/ethereum/blockwatch/client.go
@@ -76,9 +76,6 @@ func (rc *RpcClient) HeaderByNumber(number *big.Int) (*meshdb.MiniHeader, error)
 		return nil, err
 	}
 
-	if len(header.Number) < 2 {
-		return nil, errors.New("Block number returned by eth_getBlockByNumber too short")
-	}
 	blockNum, ok := math.ParseBig256(header.Number)
 	if !ok {
 		return nil, errors.New("Failed to parse big.Int value from hex-encoded block number returned from eth_getBlockByNumber")


### PR DESCRIPTION
MarkM mentioned Mesh not firing events when connected to Kovan on our discord.

Turns out Kovan uses a different structure for block headers then mainnet that isn't `rlp` compatible and since we are using go-ethereum's `EthClient`, it is generating incorrect block hashes for Kovan blocks. More details on this discrepancy between mainnet and Kovan here: https://github.com/ethereum/go-ethereum/pull/18166.

The fix is to use a raw JSON RPC request to `eth_blockByNumber` which returns a pre-computed block hash that is always properly formatted instead of re-computing the block hash given the block header struct returned from `EthClient`'s `BlockByNumber()` method.

Additionally, this PR also logs all BlockWatcher errors, which were not being logged previously.