### PR TITLE
zeroex: Reduce the order validation chunk size from 500 to 300

### DIFF
--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -27,7 +27,7 @@ var MainnetOrderValidatorAddress = common.HexToAddress("0x9463e518dea6810309563c
 var GanacheOrderValidatorAddress = common.HexToAddress("0x32eecaf51dfea9618e9bc94e9fbfddb1bbdcba15")
 
 // The most orders we can validate in a single eth_call without having the request timeout
-const chunkSize = 500
+const chunkSize = 300
 
 // The context timeout length to use for requests to getOrdersAndTradersInfoTimeout
 const getOrdersAndTradersInfoTimeout = 15 * time.Second


### PR DESCRIPTION
This is a temporary fix to address: https://github.com/0xProject/0x-mesh/issues/191

Currently any attempted batch validation including more then 300 orders is likely to fail against Infura and Geth. 

I consider this a temporary fix because the size of orders is variable and the limits on the API calls are most likely triggered by payload size. A more robust solution will involve computing the expected payload size, and also recursive splitting of the payload if the limit was not successfully avoided (e.g., Infura changes their limits without warning -- which has happened before).