### PR TITLE
Automatically generate private key if needed

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -29,7 +29,6 @@ docker run \
 -e ETHEREUM_NETWORK_ID="1" \
 -e ETHEREUM_RPC_URL="https://mainnet.infura.io/v3/a9a23d2566e542629179d6372ace13c9" \
 -e VERBOSITY=5 \
--e PRIVATE_KEY_PATH="" \
 -e USE_BOOTSTRAP_LIST=false \
 -e BLOCK_POLLING_INTERVAL="5s" \
 0xorg/mesh:latest

--- a/cmd/mesh-keygen/main.go
+++ b/cmd/mesh-keygen/main.go
@@ -4,13 +4,11 @@
 package main
 
 import (
-	"crypto/rand"
-	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
 
-	p2pcrypto "github.com/libp2p/go-libp2p-crypto"
+	"github.com/0xProject/0x-mesh/keys"
+
 	"github.com/plaid/go-envvar/envvar"
 )
 
@@ -22,25 +20,12 @@ type envVars struct {
 func main() {
 	env := envVars{}
 	if err := envvar.Parse(&env); err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	if _, err := os.Stat(env.PrivateKeyPath); !os.IsNotExist(err) {
 		log.Fatalf("Key file: %s already exists. If you really want to overwrite it, delete the file and try again.", env.PrivateKeyPath)
 	}
-	dir := filepath.Dir(env.PrivateKeyPath)
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		log.Fatal(err)
-	}
-	privKey, _, err := p2pcrypto.GenerateSecp256k1Key(rand.Reader)
-	if err != nil {
-		log.Fatal(err)
-	}
-	keyBytes, err := p2pcrypto.MarshalPrivateKey(privKey)
-	if err != nil {
-		log.Fatal(err)
-	}
-	encodedKey := p2pcrypto.ConfigEncodeKey(keyBytes)
-	if err := ioutil.WriteFile(env.PrivateKeyPath, []byte(encodedKey), os.ModePerm); err != nil {
+	if _, err := keys.GenerateAndSavePrivateKey(env.PrivateKeyPath); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/mesh-keygen/main.go
+++ b/cmd/mesh-keygen/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/0xProject/0x-mesh/keys"
-
 	"github.com/plaid/go-envvar/envvar"
 )
 

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -1,0 +1,46 @@
+package keys
+
+import (
+	"crypto/rand"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	p2pcrypto "github.com/libp2p/go-libp2p-crypto"
+)
+
+func GetPrivateKeyFromPath(path string) (p2pcrypto.PrivKey, error) {
+	keyBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	decodedKey, err := p2pcrypto.ConfigDecodeKey(string(keyBytes))
+	if err != nil {
+		return nil, err
+	}
+	priv, err := p2pcrypto.UnmarshalPrivateKey(decodedKey)
+	if err != nil {
+		return nil, err
+	}
+	return priv, nil
+}
+
+func GenerateAndSavePrivateKey(path string) (p2pcrypto.PrivKey, error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return nil, err
+	}
+	privKey, _, err := p2pcrypto.GenerateSecp256k1Key(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	keyBytes, err := p2pcrypto.MarshalPrivateKey(privKey)
+	if err != nil {
+		return nil, err
+	}
+	encodedKey := p2pcrypto.ConfigEncodeKey(keyBytes)
+	if err := ioutil.WriteFile(path, []byte(encodedKey), os.ModePerm); err != nil {
+		return nil, err
+	}
+	return privKey, nil
+}

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -5,10 +5,12 @@ package p2p
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"sort"
 	"testing"
 	"time"
 
+	p2pcrypto "github.com/libp2p/go-libp2p-crypto"
 	p2pnet "github.com/libp2p/go-libp2p-net"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
@@ -75,10 +77,12 @@ func (n *testNotifee) OpenedStream(network p2pnet.Network, stream p2pnet.Stream)
 // purposes.
 func newTestNode(t *testing.T) *Node {
 	t.Helper()
+	privKey, _, err := p2pcrypto.GenerateSecp256k1Key(rand.Reader)
+	require.NoError(t, err)
 	config := Config{
 		Topic:            testTopic,
-		ListenPort:       0,  // Let OS randomly choose an open port.
-		PrivateKeyPath:   "", // Randomly generate a new private key.
+		ListenPort:       0, // Let OS randomly choose an open port.
+		PrivateKey:       privKey,
 		MessageHandler:   &dummyMessageHandler{},
 		RendezvousString: testRendezvousString,
 	}


### PR DESCRIPTION
Fixes https://github.com/0xProject/0x-mesh/issues/146.

I think we should leave the `mesh-keygen` binary in place in case people want more manual control. In most cases, it is not needed.