### PR TITLE
Fix bug when unmarshaling OrderEvent

### DIFF
--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -1,6 +1,8 @@
 package zeroex
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"testing"
@@ -11,54 +13,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var fakeExchangeContractAddress = common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c48")
+
+var testOrder = &Order{
+	MakerAddress:          constants.GanacheAccount0,
+	TakerAddress:          constants.NullAddress,
+	SenderAddress:         constants.NullAddress,
+	FeeRecipientAddress:   constants.NullAddress,
+	MakerAssetData:        constants.NullAddress.Bytes(),
+	TakerAssetData:        constants.NullAddress.Bytes(),
+	ExchangeAddress:       fakeExchangeContractAddress,
+	Salt:                  big.NewInt(200),
+	MakerFee:              big.NewInt(201),
+	TakerFee:              big.NewInt(202),
+	MakerAssetAmount:      big.NewInt(203),
+	TakerAssetAmount:      big.NewInt(204),
+	ExpirationTimeSeconds: big.NewInt(205),
+}
+
 func TestGenerateOrderHash(t *testing.T) {
-	fakeExchangeContractAddress := common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c48")
-
-	order := Order{
-		MakerAddress:          constants.NullAddress,
-		TakerAddress:          constants.NullAddress,
-		SenderAddress:         constants.NullAddress,
-		FeeRecipientAddress:   constants.NullAddress,
-		MakerAssetData:        constants.NullAddress.Bytes(),
-		TakerAssetData:        constants.NullAddress.Bytes(),
-		ExchangeAddress:       fakeExchangeContractAddress,
-		Salt:                  big.NewInt(0),
-		MakerFee:              big.NewInt(0),
-		TakerFee:              big.NewInt(0),
-		MakerAssetAmount:      big.NewInt(0),
-		TakerAssetAmount:      big.NewInt(0),
-		ExpirationTimeSeconds: big.NewInt(0),
-	}
-
 	// expectedOrderHash copied over from canonical order hashing test in Typescript library
-	expectedOrderHash := common.HexToHash("0x434c6b41e2fb6dfcfe1b45c4492fb03700798e9c1afc6f801ba6203f948c1fa7")
-	actualOrderHash, err := order.ComputeOrderHash()
+	expectedOrderHash := common.HexToHash("0x3fcd58a6613265e2b0deba902d7ff693f330a0af6e5b04805b44bbffd8a415d3")
+	actualOrderHash, err := testOrder.ComputeOrderHash()
 	require.NoError(t, err)
 	assert.Equal(t, expectedOrderHash, actualOrderHash)
 }
 
 func TestSignOrder(t *testing.T) {
-	fakeExchangeContractAddress := common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c48")
-
-	order := &Order{
-		MakerAddress:          constants.GanacheAccount0,
-		TakerAddress:          constants.NullAddress,
-		SenderAddress:         constants.NullAddress,
-		FeeRecipientAddress:   constants.NullAddress,
-		MakerAssetData:        constants.NullAddress.Bytes(),
-		TakerAssetData:        constants.NullAddress.Bytes(),
-		ExchangeAddress:       fakeExchangeContractAddress,
-		Salt:                  big.NewInt(0),
-		MakerFee:              big.NewInt(0),
-		TakerFee:              big.NewInt(0),
-		MakerAssetAmount:      big.NewInt(0),
-		TakerAssetAmount:      big.NewInt(0),
-		ExpirationTimeSeconds: big.NewInt(0),
-	}
-	signedOrder, err := SignTestOrder(order)
+	signedOrder, err := SignTestOrder(testOrder)
 	require.NoError(t, err)
 
-	expectedSignature := "0x1c3582f06356a1314dbf1c0e534c4d8e92e59b056ee607a7ff5a825f5f2cc5e6151c5cc7fdd420f5608e4d5bef108e42ad90c7a4b408caef32e24374cf387b0d7603"
+	expectedSignature := "0x1c54a8db1f96a1851886d966b46ceff87c4c2bba6e1b2e3da7e183912b9a328334633f08385016ee5f94dcb3c7a9ca80c2de59de14b73607b2c4eaf64f3d89915103"
 	actualSignature := fmt.Sprintf("0x%s", common.Bytes2Hex(signedOrder.Signature))
 	assert.Equal(t, expectedSignature, actualSignature)
+}
+
+func TestMarshalUnmarshalOrderEvent(t *testing.T) {
+	signedOrder, err := SignTestOrder(testOrder)
+	require.NoError(t, err)
+	orderHash, err := signedOrder.ComputeOrderHash()
+	require.NoError(t, err)
+	orderEvent := OrderEvent{
+		OrderHash:                orderHash,
+		SignedOrder:              signedOrder,
+		Kind:                     EKOrderAdded,
+		FillableTakerAssetAmount: big.NewInt(2000),
+		TxHash:                   common.HexToHash("0x3fcd58a6613265e2b0deba902d7ff693f330a0af6e5b04805b44bbffd8a415d3"),
+	}
+
+	buf := &bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(buf).Encode(orderEvent))
+	var decoded OrderEvent
+	require.NoError(t, json.NewDecoder(buf).Decode(&decoded))
+	assert.Equal(t, orderEvent, decoded)
 }


### PR DESCRIPTION
Without this fix, attempting to subscribe to orders will result in an error:

```
RPC_ADDRESS="ws://localhost:60147" ETHEREUM_RPC_URL="http://localhost:8545" go run cmd/demo/subscribe_to_orders/main.go
panic: math/big: cannot unmarshal "\"2000\"" into a *big.Int

goroutine 1 [running]:
main.main()
	/Users/alex/programming/go/src/github.com/0xProject/0x-mesh/cmd/demo/subscribe_to_orders/main.go:46 +0x53e
exit status 2
```

This is happening because we implemented a custom `MarshalJSON` method for `OrderEvent` but never implemented the corresponding `UnmarshalJSON` method. I also added a test in __order_test.go__ to cover this case.