### PR TITLE
db: Change the order of colLock and globalWriteLock

### DIFF
--- a/db/global_transaction.go
+++ b/db/global_transaction.go
@@ -44,8 +44,8 @@ func (db *DB) OpenGlobalTransaction() *GlobalTransaction {
 	// "writer" but we behave like one in the context of an RWMutex. Up to one
 	// write lock for each collection can be held, or one global write lock can be
 	// held at any given time.
-	db.globalWriteLock.Lock()
 	db.colLock.Lock()
+	db.globalWriteLock.Lock()
 	return &GlobalTransaction{
 		db:             db,
 		batchWriter:    db.ldb,
@@ -97,8 +97,8 @@ func (txn *GlobalTransaction) Commit() error {
 		return err
 	}
 	txn.committed = true
-	txn.db.colLock.Unlock()
 	txn.db.globalWriteLock.Unlock()
+	txn.db.colLock.Unlock()
 	return nil
 }
 
@@ -116,8 +116,8 @@ func (txn *GlobalTransaction) Discard() error {
 		return nil
 	}
 	txn.discarded = true
-	txn.db.colLock.Unlock()
 	txn.db.globalWriteLock.Unlock()
+	txn.db.colLock.Unlock()
 	return nil
 }
 

--- a/db/global_transaction_test.go
+++ b/db/global_transaction_test.go
@@ -134,6 +134,14 @@ func TestGlobalTransaction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, actualCount)
 
+	// This short sleep prevents false positives. Without this, the test might
+	// pass simply because the other goroutines did not have time do do anything
+	// before we committed the transaction. We want to rule this out and make sure
+	// that the mutexes are the thing enforcing that no new collections are
+	// created and no new writes are made to the db state until after the global
+	// transaction is committed.
+	time.Sleep(5 * time.Millisecond)
+
 	// Signal that we are about to commit the transaction, then commit it.
 	commitSignal <- struct{}{}
 	require.NoError(t, txn.Commit())


### PR DESCRIPTION
I don't think this will actually fix https://github.com/0xProject/0x-mesh/issues/220 but it's something we should fix anyways.

`colLock` prevents new collections from being created while a global transaction is open. It exists in order to ensure that any new collections also respect the `globalWriteLock`. Prior to this change, it was theoretically possible for a new collection to be created after the `globalWriteLock` was locked but before the `colLock` was locked, meaning there's a chance it would not respect the `globalWriteLock`. The new ordering is more correct (although I think the chances of this causing any problems is pretty minuscule).

I also added a short `time.Sleep` to help prevent false positives in `TestGlobalTransaction`.