### PR TITLE
db: Add more detail to error when index looks outdated

### DIFF
--- a/db/query.go
+++ b/db/query.go
@@ -195,7 +195,7 @@ func (q *Query) getAndAppendModelIfUnique(index *Index, pkSet stringset.Set, key
 	pkSet.Add(string(pk))
 	data, err := q.reader.Get(pk, nil)
 	if err != nil {
-		return err
+		return fmt.Errorf("db: possibly outdated index (could not get data for primary key %s): %s", pk, err.Error())
 	}
 	model := reflect.New(q.colInfo.modelType)
 	if err := json.Unmarshal(data, model.Interface()); err != nil {


### PR DESCRIPTION
This might help us track down the root cause of #https://github.com/0xProject/0x-mesh/issues/227. 

The db package is supposed to maintain consistency between indexes and model data, even in the case of crashes or failed writes. It does this by using transactions under the hood for inserts, updates, and deletions. If the error is really occurring here it means something went seriously wrong and we lost consistency between the indexes and model data.