### PR TITLE
Don't log Ethereum RPC URL

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -55,7 +55,7 @@ type Config struct {
 	P2PListenPort int `envvar:"P2P_LISTEN_PORT" default:"0"`
 	// EthereumRPCURL is the URL of an Etheruem node which supports the JSON RPC
 	// API.
-	EthereumRPCURL string `envvar:"ETHEREUM_RPC_URL"`
+	EthereumRPCURL string `envvar:"ETHEREUM_RPC_URL" json:"-"`
 	// EthereumNetworkID is the network ID to use when communicating with
 	// Ethereum.
 	EthereumNetworkID int `envvar:"ETHEREUM_NETWORK_ID"`


### PR DESCRIPTION
I realized that the Ethereum RPC URL often includes API keys from providers like Infura. In some cases people don't care about leaking these keys (we even include ours in some documentation to make it easier for people to get started). But there are other cases where it can affect billing or rate-limiting so it's best to play it safe and not log it. 