### PR TITLE
db: Tolerate a model being deleted while iterating through index keys

### DIFF
--- a/db/operations.go
+++ b/db/operations.go
@@ -38,7 +38,7 @@ func findWithIterator(info *colInfo, iter iterator.Iterator, models interface{})
 		return err
 	}
 	modelsVal := reflect.ValueOf(models).Elem()
-	for iter.Next() {
+	for iter.Next() && iter.Error() == nil {
 		// We assume that each value in the iterator is the encoded data for some
 		// model.
 		data := iter.Value()
@@ -47,9 +47,6 @@ func findWithIterator(info *colInfo, iter iterator.Iterator, models interface{})
 			return err
 		}
 		modelsVal.Set(reflect.Append(modelsVal, model.Elem()))
-	}
-	if err := iter.Error(); err != nil {
-		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #227.

We inspected the bug and determined that, thankfully, it was not a data integrity issue. The problem is that the `db` package is too strict about what keys are expected to exist at what times. It is technically okay for models to be deleted or added concurrently while we are iterating through an index (it just means we don't include those models in the final results). The fix is to simply relax this constraint and not return an error in the `db` package when this happens.