### PR TITLE
fix log format for order schema validation errors

### DIFF
--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -95,8 +95,12 @@ func (app *App) HandleMessages(messages []*p2p.Message) error {
 			continue
 		}
 		if !result.Valid() {
+			formattedErrors := make([]string, len(result.Errors()))
+			for i, resultError := range result.Errors() {
+				formattedErrors[i] = resultError.String()
+			}
 			log.WithFields(map[string]interface{}{
-				"errors": result.Errors(),
+				"errors": formattedErrors,
 				"from":   msg.From,
 			}).Trace("order schema validation failed for message")
 			app.handlePeerScoreEvent(msg.From, psInvalidMessage)


### PR DESCRIPTION
Before:

```json
{
  "errors": [
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {},
    {}
  ],
  "from": "16Uiu2HAmR4gZRrrq7K3g6PGmFc6ojSFrv8nhjEyWbk42vAQG7VzP",
  "level": "trace",
  "msg": "order schema validation failed for message",
  "time": "2019-07-11T17:25:09-07:00"
}
```

After: 

```json
{
  "errors": [
    "(root): makerAddress is required",
    "(root): takerAddress is required",
    "(root): makerFee is required",
    "(root): takerFee is required",
    "(root): senderAddress is required",
    "(root): makerAssetAmount is required",
    "(root): takerAssetAmount is required",
    "(root): makerAssetData is required",
    "(root): takerAssetData is required",
    "(root): salt is required",
    "(root): exchangeAddress is required",
    "(root): feeRecipientAddress is required",
    "(root): expirationTimeSeconds is required",
    "(root): signature is required",
    "(root): Must validate all the schemas (allOf)"
  ],
  "from": "16Uiu2HAmR4gZRrrq7K3g6PGmFc6ojSFrv8nhjEyWbk42vAQG7VzP",
  "level": "trace",
  "msg": "order schema validation failed for message",
  "time": "2019-07-11T17:27:43-07:00"
}
```