### PR TITLE
core: Fix message schema validation issue

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -94,6 +94,7 @@ type App struct {
 	ethWatcher                *ethereum.ETHWatcher
 	orderValidator            *zeroex.OrderValidator
 	orderJSONSchema           *gojsonschema.Schema
+	meshMessageJSONSchema     *gojsonschema.Schema
 	snapshotExpirationWatcher *expirationwatch.Watcher
 	muIdToSnapshotInfo        sync.Mutex
 	idToSnapshotInfo          map[string]snapshotInfo
@@ -177,6 +178,10 @@ func New(config Config) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+	meshMessageJSONSchema, err := setupMeshMessageSchemaValidator()
+	if err != nil {
+		return nil, err
+	}
 
 	app := &App{
 		config:                    config,
@@ -187,6 +192,7 @@ func New(config Config) (*App, error) {
 		ethWatcher:                ethWatcher,
 		orderValidator:            orderValidator,
 		orderJSONSchema:           orderJSONSchema,
+		meshMessageJSONSchema:     meshMessageJSONSchema,
 		snapshotExpirationWatcher: snapshotExpirationWatcher,
 		idToSnapshotInfo:          map[string]snapshotInfo{},
 	}

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -85,7 +85,7 @@ func (app *App) HandleMessages(messages []*p2p.Message) error {
 			continue
 		}
 
-		result, err := app.schemaValidateOrder(msg.Data)
+		result, err := app.schemaValidateMeshMessage(msg.Data)
 		if err != nil {
 			log.WithFields(map[string]interface{}{
 				"error": err,

--- a/core/validation.go
+++ b/core/validation.go
@@ -60,12 +60,37 @@ var (
 	hexSchemaLoader         = gojsonschema.NewStringLoader(`{"id":"/hexSchema","type":"string","pattern":"^0x(([0-9a-fA-F][0-9a-fA-F])+)?$"}`)
 	orderSchemaLoader       = gojsonschema.NewStringLoader(`{"id":"/orderSchema","properties":{"makerAddress":{"$ref":"/addressSchema"},"takerAddress":{"$ref":"/addressSchema"},"makerFee":{"$ref":"/wholeNumberSchema"},"takerFee":{"$ref":"/wholeNumberSchema"},"senderAddress":{"$ref":"/addressSchema"},"makerAssetAmount":{"$ref":"/wholeNumberSchema"},"takerAssetAmount":{"$ref":"/wholeNumberSchema"},"makerAssetData":{"$ref":"/hexSchema"},"takerAssetData":{"$ref":"/hexSchema"},"salt":{"$ref":"/wholeNumberSchema"},"exchangeAddress":{"$ref":"/addressSchema"},"feeRecipientAddress":{"$ref":"/addressSchema"},"expirationTimeSeconds":{"$ref":"/wholeNumberSchema"}},"required":["makerAddress","takerAddress","makerFee","takerFee","senderAddress","makerAssetAmount","takerAssetAmount","makerAssetData","takerAssetData","salt","exchangeAddress","feeRecipientAddress","expirationTimeSeconds"],"type":"object"}`)
 	signedOrderSchemaLoader = gojsonschema.NewStringLoader(`{"id":"/signedOrderSchema","allOf":[{"$ref":"/orderSchema"},{"properties":{"signature":{"$ref":"/hexSchema"}},"required":["signature"]}]}`)
+	meshMessageSchemaLoader = gojsonschema.NewStringLoader(`{"id":"/meshMessageSchema","properties":{"MessageType":{"type":"string"},"Order":{"$ref":"/signedOrderSchema"}},"required":["MessageType","Order"]}`)
 )
 
 // RejectedOrderKind values
 const (
 	MeshValidation = zeroex.RejectedOrderKind("MESH_VALIDATION")
 )
+
+func setupMeshMessageSchemaValidator() (*gojsonschema.Schema, error) {
+	sl := gojsonschema.NewSchemaLoader()
+	if err := sl.AddSchemas(addressSchemaLoader); err != nil {
+		return nil, err
+	}
+	if err := sl.AddSchemas(wholeNumberSchemaLoader); err != nil {
+		return nil, err
+	}
+	if err := sl.AddSchemas(hexSchemaLoader); err != nil {
+		return nil, err
+	}
+	if err := sl.AddSchemas(orderSchemaLoader); err != nil {
+		return nil, err
+	}
+	if err := sl.AddSchemas(signedOrderSchemaLoader); err != nil {
+		return nil, err
+	}
+	schema, err := sl.Compile(meshMessageSchemaLoader)
+	if err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
 
 func setupOrderSchemaValidator() (*gojsonschema.Schema, error) {
 	sl := gojsonschema.NewSchemaLoader()
@@ -92,6 +117,17 @@ func (app *App) schemaValidateOrder(o []byte) (*gojsonschema.Result, error) {
 	orderLoader := gojsonschema.NewBytesLoader(o)
 
 	result, err := app.orderJSONSchema.Validate(orderLoader)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (app *App) schemaValidateMeshMessage(o []byte) (*gojsonschema.Result, error) {
+	messageLoader := gojsonschema.NewBytesLoader(o)
+
+	result, err := app.meshMessageJSONSchema.Validate(messageLoader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes: #233 233

Replace order schema validation on incoming messages with Mesh message schema validation since the orders are wrapped inside a message payload:

```json
{
    "MessageType": "order",
    "Order": {
        "makerAddress": "0x5409ED021D9299bf6814279A6A1411A7e866A631",
        "makerAssetData": "0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c",
        "makerAssetAmount": "1000",
        "makerFee": "0",
        "takerAddress": "0x0000000000000000000000000000000000000000",
        "takerAssetData": "0xf47261b00000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082",
        "takerAssetAmount": "2000",
        "takerFee": "0",
        "senderAddress": "0x0000000000000000000000000000000000000000",
        "exchangeAddress": "0x48BaCB9266a570d521063EF5dD96e61686DbE788",
        "feeRecipientAddress": "0xA258b39954ceF5cB142fd567A46cDdB31a670124",
        "expirationTimeSeconds": "1563100870",
        "salt": "1548619145450",
        "signature": "0x1b254b253f6ea117f90fc630cffb2724611d06db699d18e58f605e375d9a0001d83ab3392805dee1f03bada356cba2eee5ae6bcbaf840c1cc269674ac6260c070603"
    }
}
```