### PR TITLE
examples: Disable fragmentation of JS WS client payloads

### DIFF
--- a/examples/javascript_websocket_client/index.js
+++ b/examples/javascript_websocket_client/index.js
@@ -5,7 +5,13 @@ const MESH_WS_ENDPOINT = `ws://localhost:${MESH_WS_PORT}`;
 console.log('Mesh WebSocket endpoint: ', MESH_WS_ENDPOINT);
 
 // Instantiate the WebSocket provider/client
-const websocketProvider = new Web3Providers.WebsocketProvider(MESH_WS_ENDPOINT);
+const websocketProvider = new Web3Providers.WebsocketProvider(MESH_WS_ENDPOINT, {
+    clientConfig: {
+        // For some reason fragmenting the payloads causes the connection to close
+        // Source: https://github.com/theturtle32/WebSocket-Node/issues/359
+        fragmentOutgoingMessages: false,
+    },
+});
 
 // Listen for the close event which will fire if Mesh goes down
 websocketProvider.connection.addEventListener('close', function() {

--- a/examples/javascript_websocket_client/index.ts
+++ b/examples/javascript_websocket_client/index.ts
@@ -99,7 +99,13 @@ console.log('Mesh WebSocket endpoint: ', MESH_WS_ENDPOINT);
 
 (async () => {
     // Instantiate the WebSocket provider/client
-    const websocketProvider = new Web3Providers.WebsocketProvider(MESH_WS_ENDPOINT);
+    const websocketProvider = new Web3Providers.WebsocketProvider(MESH_WS_ENDPOINT, {
+        clientConfig: {
+            // For some reason fragmenting the payloads causes the connection to close
+            // Source: https://github.com/theturtle32/WebSocket-Node/issues/359
+            fragmentOutgoingMessages: false,
+        },
+    } as any);
 
     // Listen for the close event which will fire if Mesh goes down
     (websocketProvider as any).connection.addEventListener('close', () => {


### PR DESCRIPTION
Fixes: #165 