### PR TITLE
Temporarily don't accept orders with a senderAddress

### DIFF
--- a/core/validation.go
+++ b/core/validation.go
@@ -162,7 +162,7 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*zeroex.Validation
 			continue
 		}
 		// Note(albrow): Orders with a sender address can be canceled or invalidated
-		// off-chain which is difficult to suppport since we need to prune
+		// off-chain which is difficult to support since we need to prune
 		// canceled/invalidated orders from the database. We can special-case some
 		// sender addresses over time. (For example we already have support for
 		// validating Coordinator orders. What we're missing is a way to effeciently

--- a/core/validation.go
+++ b/core/validation.go
@@ -163,7 +163,7 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*zeroex.Validation
 		}
 		// Note(albrow): Orders with a sender address can be canceled or invalidated
 		// off-chain which is difficult to suppport since we need to prune
-		// canceled/invalidated orders from the database. We can special case some
+		// canceled/invalidated orders from the database. We can special-case some
 		// sender addresses over time. (For example we already have support for
 		// validating Coordinator orders. What we're missing is a way to effeciently
 		// remove orders that are soft-canceled via the Coordinator API).

--- a/core/validation.go
+++ b/core/validation.go
@@ -162,7 +162,7 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*zeroex.Validation
 			continue
 		}
 		// Note(albrow): Orders with a sender address can be canceled or invalidated
-		// off-chain which is difficult to suppport since we need to purne
+		// off-chain which is difficult to suppport since we need to prune
 		// canceled/invalidated orders from the database. We can special case some
 		// sender addresses over time. (For example we already have support for
 		// validating Coordinator orders. What we're missing is a way to effeciently


### PR DESCRIPTION
The comment in the code explains why we want to do this. We plan to add support for some known sender addresses out-of-the-box and will eventually allow users to pass in custom validation logic (which can include additional third-party sender addresses).