### PR TITLE
Enable AutoNAT service in mesh-bootstrap

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -416,6 +416,14 @@
   version = "v0.0.6"
 
 [[projects]]
+  digest = "1:b92c2db5053b10f0b83bd3d7587aadc0ff247b98326f18e0e747741051a4dba2"
+  name = "github.com/libp2p/go-libp2p-autonat-svc"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8f86551aac295f65a96ca1be488c351c037b61b6"
+  version = "v0.0.6"
+
+[[projects]]
   digest = "1:886a124af6b511b708c6f59925c77142cea9d30adcfc7198134b6e9c4c099cd7"
   name = "github.com/libp2p/go-libp2p-circuit"
   packages = [
@@ -1244,6 +1252,7 @@
     "github.com/ethereum/go-ethereum/accounts/abi",
     "github.com/ethereum/go-ethereum/accounts/abi/bind",
     "github.com/ethereum/go-ethereum/common",
+    "github.com/ethereum/go-ethereum/common/hexutil",
     "github.com/ethereum/go-ethereum/common/math",
     "github.com/ethereum/go-ethereum/core/types",
     "github.com/ethereum/go-ethereum/crypto",
@@ -1254,6 +1263,7 @@
     "github.com/google/uuid",
     "github.com/jpillora/backoff",
     "github.com/libp2p/go-libp2p",
+    "github.com/libp2p/go-libp2p-autonat-svc",
     "github.com/libp2p/go-libp2p-connmgr",
     "github.com/libp2p/go-libp2p-crypto",
     "github.com/libp2p/go-libp2p-discovery",
@@ -1264,6 +1274,7 @@
     "github.com/libp2p/go-libp2p-peerstore",
     "github.com/libp2p/go-libp2p-pubsub",
     "github.com/multiformats/go-multiaddr",
+    "github.com/multiformats/go-multiaddr-dns",
     "github.com/ocdogan/rbt",
     "github.com/plaid/go-envvar/envvar",
     "github.com/sirupsen/logrus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -104,3 +104,7 @@
 [[constraint]]
   name = "github.com/xeipuuv/gojsonschema"
   version = "1.1.0"
+
+[[constraint]]
+  name = "github.com/libp2p/go-libp2p-autonat-svc"
+  version = "0.0.6"

--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"time"
 
+	autonat "github.com/libp2p/go-libp2p-autonat-svc"
+
 	"github.com/0xProject/0x-mesh/keys"
 	"github.com/0xProject/0x-mesh/p2p"
 	libp2p "github.com/libp2p/go-libp2p"
@@ -91,6 +93,11 @@ func main() {
 
 	// Set up the notifee.
 	basicHost.Network().Notify(&notifee{})
+
+	// Enable AutoNAT service.
+	if _, err := autonat.NewAutoNATService(ctx, basicHost); err != nil {
+		log.WithField("error", err).Fatal("could not enable AutoNAT service")
+	}
 
 	// Set up DHT for peer discovery.
 	kadDHT, err := dht.New(ctx, basicHost)


### PR DESCRIPTION
Long-term, we should consider using separate instances for AutoNAT or enabling AutoNAT for all peers when possible (i.e. for non-browser peers with a public IP address). This should work fine for now.