### PR TITLE
Increase default network timeout from 5 to 10 seconds

### DIFF
--- a/p2p/node.go
+++ b/p2p/node.go
@@ -44,7 +44,7 @@ const (
 	peerGraceDuration = 10 * time.Second
 	// defaultNetworkTimeout is the default timeout for network requests (e.g.
 	// connecting to a new peer).
-	defaultNetworkTimeout = 5 * time.Second
+	defaultNetworkTimeout = 10 * time.Second
 	// advertiseTTL is the TTL for our announcement to the discovery network.
 	advertiseTTL = 5 * time.Minute
 	// pubsubProtocolID is the protocol ID to use for pubsub.


### PR DESCRIPTION
We observed some cases where two peers could not connect to one another even though both were located in the continental US. It seems like a good idea to slightly increase the default timeout and we might make further adjustments in the future.