### PR TITLE
Use major version only for rendezvous string and topic

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -222,11 +222,11 @@ func New(config Config) (*App, error) {
 }
 
 func getPubSubTopic(networkID int) string {
-	return fmt.Sprintf("/0x-orders/network/%d/version/0.0.1", networkID)
+	return fmt.Sprintf("/0x-orders/network/%d/version/1", networkID)
 }
 
 func getRendezvous(networkID int) string {
-	return fmt.Sprintf("/0x-mesh/network/%d/version/0.0.1", networkID)
+	return fmt.Sprintf("/0x-mesh/network/%d/version/1", networkID)
 }
 
 func initPrivateKey(path string) (p2pcrypto.PrivKey, error) {


### PR DESCRIPTION
This change makes it so that peers running different versions will still be able to find and communicate with one another as long as we don't break backwards compatibility. If we do break backwards compatibility, we can change the major version to `2`.