### PR TITLE
Use a custom protocol id for our DHT

### DIFF
--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -11,14 +11,12 @@ import (
 	"os"
 	"time"
 
-	autonat "github.com/libp2p/go-libp2p-autonat-svc"
-
 	"github.com/0xProject/0x-mesh/keys"
 	"github.com/0xProject/0x-mesh/p2p"
 	libp2p "github.com/libp2p/go-libp2p"
+	autonat "github.com/libp2p/go-libp2p-autonat-svc"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	p2pcrypto "github.com/libp2p/go-libp2p-crypto"
-	dht "github.com/libp2p/go-libp2p-kad-dht"
 	p2pnet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
 	ma "github.com/multiformats/go-multiaddr"
@@ -100,7 +98,7 @@ func main() {
 	}
 
 	// Set up DHT for peer discovery.
-	kadDHT, err := dht.New(ctx, basicHost)
+	kadDHT, err := p2p.NewDHT(ctx, basicHost)
 	if err != nil {
 		log.WithField("error", err).Fatal("could not create DHT")
 	}

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -8,10 +8,15 @@ import (
 	"time"
 
 	host "github.com/libp2p/go-libp2p-host"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	dhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
+	protocol "github.com/libp2p/go-libp2p-protocol"
 	"github.com/multiformats/go-multiaddr"
 	log "github.com/sirupsen/logrus"
 )
+
+const dhtProtocolID = protocol.ID("/0x-mesh-dht/version/1")
 
 // BootstrapPeers is a list of peers to use for bootstrapping the DHT.
 var BootstrapPeers []multiaddr.Multiaddr
@@ -67,4 +72,9 @@ func ConnectToBootstrapList(ctx context.Context, host host.Host) error {
 	time.Sleep(2 * time.Second)
 
 	return nil
+}
+
+// NewDHT returns a new Kademlia DHT instance configured to work with 0x Mesh.
+func NewDHT(ctx context.Context, host host.Host) (*dht.IpfsDHT, error) {
+	return dht.New(ctx, host, dhtopts.Protocols(dhtProtocolID))
 }

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -130,7 +130,7 @@ func New(config Config) (*Node, error) {
 	}
 
 	// Set up DHT for peer discovery.
-	kadDHT, err := dht.New(nodeCtx, basicHost)
+	kadDHT, err := NewDHT(nodeCtx, basicHost)
 	if err != nil {
 		cancel()
 		return nil, err


### PR DESCRIPTION
We observed that our bootstrap nodes were connecting to tens of thousands of peers, even though we only have a handful of Mesh nodes running at the moment. Most of the peers were using port 4001, which is the default IPFS port. We think that our DHT was somehow merged with the default IPFS DHT (it's pretty easy to accidentally do this and once it happens they are basically linked forever).

Technically speaking, it isn't a huge problem that a lot of peers are connecting to our bootstrap nodes, but it does have an impact on how quickly our peers can find each other (one of the reasons we decided to spin up our own bootstrap nodes in the first place) and muddies up our logs.

This PR changes the protocol id that we use for the DHT which should keep ours separate from the default IPFS one.