### PR TITLE
zeroex: remove checksum from address fields in Order when marshalling to JSON

### DIFF
--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/0xProject/0x-mesh/ethereum"
 	"github.com/0xProject/0x-mesh/ethereum/wrappers"
@@ -351,17 +352,17 @@ func (s SignedOrder) MarshalJSON() ([]byte, error) {
 	}
 
 	signedOrderBytes, err := json.Marshal(SignedOrderJSON{
-		MakerAddress:          s.MakerAddress.Hex(),
+		MakerAddress:          strings.ToLower(s.MakerAddress.String()),
 		MakerAssetData:        makerAssetData,
-		MakerAssetAmount:      s.MakerAssetAmount.String(),
+		MakerAssetAmount:      strings.ToLower(s.MakerAssetAmount.String()),
 		MakerFee:              s.MakerFee.String(),
-		TakerAddress:          s.TakerAddress.Hex(),
+		TakerAddress:          strings.ToLower(s.TakerAddress.String()),
 		TakerAssetData:        takerAssetData,
 		TakerAssetAmount:      s.TakerAssetAmount.String(),
 		TakerFee:              s.TakerFee.String(),
-		SenderAddress:         s.SenderAddress.Hex(),
-		ExchangeAddress:       s.ExchangeAddress.Hex(),
-		FeeRecipientAddress:   s.FeeRecipientAddress.Hex(),
+		SenderAddress:         strings.ToLower(s.SenderAddress.String()),
+		ExchangeAddress:       strings.ToLower(s.ExchangeAddress.String()),
+		FeeRecipientAddress:   strings.ToLower(s.FeeRecipientAddress.String()),
 		ExpirationTimeSeconds: s.ExpirationTimeSeconds.String(),
 		Salt:                  s.Salt.String(),
 		Signature:             signature,

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -352,17 +352,17 @@ func (s SignedOrder) MarshalJSON() ([]byte, error) {
 	}
 
 	signedOrderBytes, err := json.Marshal(SignedOrderJSON{
-		MakerAddress:          strings.ToLower(s.MakerAddress.String()),
+		MakerAddress:          strings.ToLower(s.MakerAddress.Hex()),
 		MakerAssetData:        makerAssetData,
-		MakerAssetAmount:      strings.ToLower(s.MakerAssetAmount.String()),
+		MakerAssetAmount:      s.MakerAssetAmount.String(),
 		MakerFee:              s.MakerFee.String(),
-		TakerAddress:          strings.ToLower(s.TakerAddress.String()),
+		TakerAddress:          strings.ToLower(s.TakerAddress.Hex()),
 		TakerAssetData:        takerAssetData,
 		TakerAssetAmount:      s.TakerAssetAmount.String(),
 		TakerFee:              s.TakerFee.String(),
-		SenderAddress:         strings.ToLower(s.SenderAddress.String()),
-		ExchangeAddress:       strings.ToLower(s.ExchangeAddress.String()),
-		FeeRecipientAddress:   strings.ToLower(s.FeeRecipientAddress.String()),
+		SenderAddress:         strings.ToLower(s.SenderAddress.Hex()),
+		ExchangeAddress:       strings.ToLower(s.ExchangeAddress.Hex()),
+		FeeRecipientAddress:   strings.ToLower(s.FeeRecipientAddress.Hex()),
 		ExpirationTimeSeconds: s.ExpirationTimeSeconds.String(),
 		Salt:                  s.Salt.String(),
 		Signature:             signature,


### PR DESCRIPTION
## Overview
Simply adding a call to `strings.ToLower()` on all address fields when marshalling a `SignedOrder` to JSON. Tests (run with `make test-all`) pass and functionality seems normal. Please advise if a different approach is preferred.

Should close #257.

## Notes
Here is the output I got from a `mesh_subscription` message after adding a valid order (compare to sample in original issue).

```json
{
	"jsonrpc": "2.0",
	"method": "mesh_subscription",
	"params": {
		"subscription": "0x5375e6c2d24cb11874a79ea90e7851f",
		"result": [{
			"fillableTakerAssetAmount": "0",
			"kind": "EXPIRED",
			"orderHash": "0x222f59940699cb7f7743d68e95cc952eabef58dd3ef22629811f0da6ff8b29aa",
			"signedOrder": {
				"makerAddress": "0x5409ed021d9299bf6814279a6a1411a7e866a631",
				"makerAssetData": "0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064",
				"makerAssetAmount": "1000000000000000000",
				"makerFee": "0",
				"takerAddress": "0x0000000000000000000000000000000000000000",
				"takerAssetData": "0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3",
				"takerAssetAmount": "98000000000000000000",
				"takerFee": "0",
				"senderAddress": "0x0000000000000000000000000000000000000000",
				"exchangeAddress": "0x48bacb9266a570d521063ef5dd96e61686dbe788",
				"feeRecipientAddress": "0x0000000000000000000000000000000000000000",
				"expirationTimeSeconds": "1563239813",
				"salt": "50548472960658633474509830344688430210810445656575157876862263167070060655407",
				"signature": "0x1c197ae36570bec706392e00594be1127caafe36f4a8093ed558039056cbb709553101ac01526e768d1d6c575cc7bf65dca4e140c27cb52228f2fba6278e19426a02"
			},
			"txHashes": []
		}]
	}
}
```

Let me know if think this should be done somewhere else, differently, etc... Or if someone else has already tackled it!