### PR TITLE
Improve logging

### DIFF
--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -164,7 +164,7 @@ func (n *notifee) Connected(network p2pnet.Network, conn p2pnet.Conn) {
 	log.WithFields(map[string]interface{}{
 		"peerID":       conn.RemotePeer(),
 		"multiaddress": conn.RemoteMultiaddr(),
-	}).Trace("connected to peer")
+	}).Info("connected to peer")
 }
 
 // Disconnected is called when a connection closed
@@ -172,7 +172,7 @@ func (n *notifee) Disconnected(network p2pnet.Network, conn p2pnet.Conn) {
 	log.WithFields(map[string]interface{}{
 		"peerID":       conn.RemotePeer(),
 		"multiaddress": conn.RemoteMultiaddr(),
-	}).Trace("disconnected from peer")
+	}).Info("disconnected from peer")
 }
 
 // OpenedStream is called when a stream opened

--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/0xProject/0x-mesh/keys"
+	"github.com/0xProject/0x-mesh/loghooks"
 	"github.com/0xProject/0x-mesh/p2p"
 	libp2p "github.com/libp2p/go-libp2p"
 	autonat "github.com/libp2p/go-libp2p-autonat-svc"
@@ -88,6 +89,9 @@ func main() {
 	if err != nil {
 		log.WithField("error", err).Fatal("could not create host")
 	}
+
+	// Add the peer ID hook to the logger.
+	log.AddHook(loghooks.NewPeerIDHook(basicHost.ID()))
 
 	// Set up the notifee.
 	basicHost.Network().Notify(&notifee{})

--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -130,8 +130,7 @@ func main() {
 	}
 
 	log.WithFields(map[string]interface{}{
-		"addrs":  basicHost.Addrs(),
-		"peerID": basicHost.ID(),
+		"addrs": basicHost.Addrs(),
 	}).Info("started bootstrap node")
 
 	// Sleep until stopped
@@ -166,16 +165,16 @@ func (n *notifee) ListenClose(p2pnet.Network, ma.Multiaddr) {}
 // Connected is called when a connection opened
 func (n *notifee) Connected(network p2pnet.Network, conn p2pnet.Conn) {
 	log.WithFields(map[string]interface{}{
-		"peerID":       conn.RemotePeer(),
-		"multiaddress": conn.RemoteMultiaddr(),
+		"remotePeerID":       conn.RemotePeer(),
+		"remoteMultiaddress": conn.RemoteMultiaddr(),
 	}).Info("connected to peer")
 }
 
 // Disconnected is called when a connection closed
 func (n *notifee) Disconnected(network p2pnet.Network, conn p2pnet.Conn) {
 	log.WithFields(map[string]interface{}{
-		"peerID":       conn.RemotePeer(),
-		"multiaddress": conn.RemoteMultiaddr(),
+		"remotePeerID":       conn.RemotePeer(),
+		"remoteMultiaddress": conn.RemoteMultiaddr(),
 	}).Info("disconnected from peer")
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -259,7 +259,6 @@ func (app *App) Start() error {
 	go app.periodicallyCheckForNewAddrs(addrs)
 	log.WithFields(map[string]interface{}{
 		"addresses": addrs,
-		"peerID":    app.node.ID().String(),
 	}).Info("started p2p node")
 
 	// TODO(albrow) we might want to match the synchronous API of p2p.Node which

--- a/core/core.go
+++ b/core/core.go
@@ -17,6 +17,7 @@ import (
 	"github.com/0xProject/0x-mesh/ethereum/blockwatch"
 	"github.com/0xProject/0x-mesh/expirationwatch"
 	"github.com/0xProject/0x-mesh/keys"
+	"github.com/0xProject/0x-mesh/loghooks"
 	"github.com/0xProject/0x-mesh/meshdb"
 	"github.com/0xProject/0x-mesh/p2p"
 	"github.com/0xProject/0x-mesh/rpc"
@@ -217,6 +218,9 @@ func New(config Config) (*App, error) {
 		return nil, err
 	}
 	app.node = node
+
+	// Add the peer ID hook to the logger.
+	log.AddHook(loghooks.NewPeerIDHook(node.ID()))
 
 	return app, nil
 }

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -130,10 +130,14 @@ func (app *App) HandleMessages(messages []*p2p.Message) error {
 		// decode it into an order. Append it to the list of orders to validate and
 		// update peer scores accordingly.
 		log.WithFields(map[string]interface{}{
+			"orderHash": orderHash,
+			"from":      msg.From.String(),
+		}).Info("received new valid order from peer")
+		log.WithFields(map[string]interface{}{
 			"order":     order,
 			"orderHash": orderHash,
 			"from":      msg.From.String(),
-		}).Trace("received order from peer")
+		}).Trace("all fields for new valid order received from peer")
 		orders = append(orders, order)
 		orderHashToMessage[orderHash] = msg
 		app.handlePeerScoreEvent(msg.From, psValidMessage)

--- a/loghooks/peer_id_hook.go
+++ b/loghooks/peer_id_hook.go
@@ -1,0 +1,31 @@
+package loghooks
+
+import (
+	peer "github.com/libp2p/go-libp2p-peer"
+	log "github.com/sirupsen/logrus"
+)
+
+// PeerIDHook is a logger hook that injects the peer ID in all logs when
+// possible.
+type PeerIDHook struct {
+	peerID string
+}
+
+// NewPeerIDHook creates and returns a new PeerIDHook with the given peer ID.
+func NewPeerIDHook(peerID peer.ID) *PeerIDHook {
+	return &PeerIDHook{peerID: peer.IDB58Encode(peerID)}
+}
+
+// Ensure that PeerIDHook implements log.Hook.
+var _ log.Hook = &PeerIDHook{}
+
+func (h *PeerIDHook) Levels() []log.Level {
+	return log.AllLevels
+}
+
+func (h *PeerIDHook) Fire(entry *log.Entry) error {
+	if _, found := entry.Data["myPeerID"]; !found {
+		entry.Data["myPeerID"] = h.peerID
+	}
+	return nil
+}

--- a/loghooks/peer_id_hook.go
+++ b/loghooks/peer_id_hook.go
@@ -13,7 +13,7 @@ type PeerIDHook struct {
 
 // NewPeerIDHook creates and returns a new PeerIDHook with the given peer ID.
 func NewPeerIDHook(peerID peer.ID) *PeerIDHook {
-	return &PeerIDHook{peerID: peer.IDB58Encode(peerID)}
+	return &PeerIDHook{peerID: peerID.String()}
 }
 
 // Ensure that PeerIDHook implements log.Hook.

--- a/loghooks/peer_id_hook.go
+++ b/loghooks/peer_id_hook.go
@@ -24,8 +24,6 @@ func (h *PeerIDHook) Levels() []log.Level {
 }
 
 func (h *PeerIDHook) Fire(entry *log.Entry) error {
-	if _, found := entry.Data["myPeerID"]; !found {
-		entry.Data["myPeerID"] = h.peerID
-	}
+	entry.Data["myPeerID"] = h.peerID
 	return nil
 }

--- a/p2p/notifee.go
+++ b/p2p/notifee.go
@@ -35,16 +35,16 @@ func (n *notifee) ListenClose(p2pnet.Network, ma.Multiaddr) {}
 // Connected is called when a connection opened
 func (n *notifee) Connected(network p2pnet.Network, conn p2pnet.Conn) {
 	log.WithFields(map[string]interface{}{
-		"peerID":       conn.RemotePeer(),
-		"multiaddress": conn.RemoteMultiaddr(),
+		"remotePeerID":       conn.RemotePeer(),
+		"remoteMultiaddress": conn.RemoteMultiaddr(),
 	}).Trace("connected to peer")
 }
 
 // Disconnected is called when a connection closed
 func (n *notifee) Disconnected(network p2pnet.Network, conn p2pnet.Conn) {
 	log.WithFields(map[string]interface{}{
-		"peerID":       conn.RemotePeer(),
-		"multiaddress": conn.RemoteMultiaddr(),
+		"remotePeerID":       conn.RemotePeer(),
+		"remoteMultiaddress": conn.RemoteMultiaddr(),
 	}).Trace("disconnected from peer")
 }
 
@@ -60,9 +60,9 @@ func (n *notifee) OpenedStream(network p2pnet.Network, stream p2pnet.Stream) {
 			// positive score so the Connection Manager will be less likely to
 			// disconnect them.
 			log.WithFields(map[string]interface{}{
-				"peerID":    stream.Conn().RemotePeer(),
-				"protocol":  stream.Protocol(),
-				"direction": stream.Stat().Direction,
+				"remotePeerID": stream.Conn().RemotePeer(),
+				"protocol":     stream.Protocol(),
+				"direction":    stream.Stat().Direction,
 			}).Debug("found peer who speaks our protocol")
 			n.node.connManager.TagPeer(stream.Conn().RemotePeer(), pubsubProtocolTag, pubsubProtocolScore)
 		}


### PR DESCRIPTION
Summary of changes:

1. Use a [`logrus.Hook`](https://godoc.org/github.com/sirupsen/logrus#Hook) to add a peer ID for all logs when possible.
2. Change "connected to peer" and "disconnected from peer" messages in `mesh-bootstrap` from `Trace` to `Info`. These are the main and only responsibility of bootstrap nodes so it is appropriate to log them.
3. Add a new log message at level `Info` which logs the order hash only for any new valid orders. We still keep the `Trace` message which includes the entire order.
4. Rename some uses of the field name `peerID` to `remotePeerID` for clarity.