### PR TITLE
Use AddrsFactory to advertise public IP addresses in mesh-bootstrap

### DIFF
--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -213,8 +213,8 @@ func (n *notifee) OpenedStream(network p2pnet.Network, stream p2pnet.Stream) {}
 // ClosedStream is called when a stream closed
 func (n *notifee) ClosedStream(network p2pnet.Network, stream p2pnet.Stream) {}
 
-func newAddrsFactory(adverticeAddresses []ma.Multiaddr) func([]ma.Multiaddr) []ma.Multiaddr {
+func newAddrsFactory(advertiseAddrs []ma.Multiaddr) func([]ma.Multiaddr) []ma.Multiaddr {
 	return func([]ma.Multiaddr) []ma.Multiaddr {
-		return adverticeAddresses
+		return advertiseAddrs
 	}
 }


### PR DESCRIPTION
This will allow bootstrap nodes to advertise the correct public IP address (before they were advertising the Docker subnet address).