### PR TITLE
Add backup bootstrap nodes

### DIFF
--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -29,6 +29,8 @@ func init() {
 		"/dns4/bootstrap-0.mesh.0x.org/tcp/60558/ipfs/16Uiu2HAmGx8Z6gdq5T5AQE54GMtqDhDFhizywTy1o28NJbAMMumF",
 		"/dns4/bootstrap-1.mesh.0x.org/tcp/60558/ipfs/16Uiu2HAkwsDZk4LzXy2rnWANRsyBjB4fhjnsNeJmjgsBqxPGTL32",
 		"/dns4/bootstrap-2.mesh.0x.org/tcp/60558/ipfs/16Uiu2HAkykwoBxwyvoEbaEkuKMeKrmJDPZ2uKFPUKtqd2JbGHUNH",
+		"/ip4/34.201.54.78/tcp/4001/p2p/12D3KooWHwJDdbx73qiBpSCJfg4RuYyzqnLUwfLBqzn77TSy7kRX",
+		"/ip4/18.204.221.103/tcp/4001/p2p/12D3KooWQS6Gsr2kLZvF7DVtoRFtj24aar5jvz88LvJePrawM3EM",
 	} {
 		ma, err := multiaddr.NewMultiaddr(s)
 		if err != nil {

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -29,6 +29,9 @@ func init() {
 		"/dns4/bootstrap-0.mesh.0x.org/tcp/60558/ipfs/16Uiu2HAmGx8Z6gdq5T5AQE54GMtqDhDFhizywTy1o28NJbAMMumF",
 		"/dns4/bootstrap-1.mesh.0x.org/tcp/60558/ipfs/16Uiu2HAkwsDZk4LzXy2rnWANRsyBjB4fhjnsNeJmjgsBqxPGTL32",
 		"/dns4/bootstrap-2.mesh.0x.org/tcp/60558/ipfs/16Uiu2HAkykwoBxwyvoEbaEkuKMeKrmJDPZ2uKFPUKtqd2JbGHUNH",
+
+		// These nodes are provided by the libp2p community on a best-effort basis.
+		// We're using them as a backup for increased redundancy.
 		"/ip4/34.201.54.78/tcp/4001/p2p/12D3KooWHwJDdbx73qiBpSCJfg4RuYyzqnLUwfLBqzn77TSy7kRX",
 		"/ip4/18.204.221.103/tcp/4001/p2p/12D3KooWQS6Gsr2kLZvF7DVtoRFtj24aar5jvz88LvJePrawM3EM",
 	} {


### PR DESCRIPTION
These are temporary backup nodes operated by the libp2p community on a best-effort basis.

Fixes #255