### PR TITLE
Add type suffixes to all keys when logging

### DIFF
--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -73,6 +73,7 @@ func main() {
 	// TODO(albrow): Don't use global settings for logger.
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.Level(config.Verbosity))
+	log.AddHook(loghooks.NewKeySuffixHook())
 
 	// Parse private key file
 	privKey, err := initPrivateKey(config.PrivateKeyPath)

--- a/core/core.go
+++ b/core/core.go
@@ -104,6 +104,7 @@ func New(config Config) (*App, error) {
 	// Configure logger
 	// TODO(albrow): Don't use global variables for log settings.
 	log.SetLevel(log.Level(config.Verbosity))
+	log.AddHook(loghooks.NewKeySuffixHook())
 	log.WithFields(map[string]interface{}{
 		"config":  config,
 		"version": "development",

--- a/loghooks/key_suffix_hook.go
+++ b/loghooks/key_suffix_hook.go
@@ -59,7 +59,7 @@ func (h *KeySuffixHook) Fire(entry *log.Entry) error {
 // getTypeForValue returns a string representation of the type of the given val.
 func getTypeForValue(val interface{}) (string, error) {
 	if _, ok := val.(json.Marshaler); ok {
-		// If val implements json.Marhsler, return the type of json.Marshal(val)
+		// If val implements json.Marshaler, return the type of json.Marshal(val)
 		// instead of the type of val.
 		buf := &bytes.Buffer{}
 		if err := json.NewEncoder(buf).Encode(val); err != nil {

--- a/loghooks/key_suffix_hook.go
+++ b/loghooks/key_suffix_hook.go
@@ -2,6 +2,7 @@ package loghooks
 
 import (
 	"bytes"
+	"encoding"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -69,6 +70,11 @@ func getTypeForValue(val interface{}) (string, error) {
 			return "", err
 		}
 		return getTypeForValue(holder)
+	}
+	if _, ok := val.(encoding.TextMarshaler); ok {
+		// The json package always encodes values that implement
+		// encoding.TextMarshaler as a string.
+		return "string", nil
 	}
 
 	underlyingType := getUnderlyingType(reflect.TypeOf(val))

--- a/loghooks/key_suffix_hook_test.go
+++ b/loghooks/key_suffix_hook_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type myStruct struct {
@@ -100,10 +100,6 @@ func TestGetTypeForValue(t *testing.T) {
 			expected: "array",
 		},
 		{
-			input:    map[string]int{},
-			expected: "object",
-		},
-		{
 			input:    myStruct{},
 			expected: "loghooks_myStruct",
 		},
@@ -128,4 +124,16 @@ func TestGetTypeForValue(t *testing.T) {
 	}
 }
 
-// case reflect.Struct:
+func TestKeySuffixHookWithNestedMapType(t *testing.T) {
+	hook := NewKeySuffixHook()
+	entry := &log.Entry{
+		Data: log.Fields{
+			"myMap": map[string]int{"one": 1},
+		},
+	}
+	require.NoError(t, hook.Fire(entry))
+	expectedData := log.Fields{
+		"myMap_json_string": `{"one":1}`,
+	}
+	assert.Equal(t, expectedData, entry.Data)
+}

--- a/loghooks/key_suffix_hook_test.go
+++ b/loghooks/key_suffix_hook_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/0xProject/0x-mesh/constants"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -102,6 +104,11 @@ func TestGetTypeForValue(t *testing.T) {
 		{
 			input:    myStruct{},
 			expected: "loghooks_myStruct",
+		},
+		{
+			// Implements encoding.TextUnmarshaler but not json.Marshaler.
+			input:    constants.NullAddress,
+			expected: "string",
 		},
 		{
 			// We don't expect the case of anonymous structs to come up often, but we

--- a/loghooks/key_suffix_hook_test.go
+++ b/loghooks/key_suffix_hook_test.go
@@ -1,0 +1,131 @@
+package loghooks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type myStruct struct {
+	myInt    int
+	myString string
+}
+
+func TestGetTypeForValue(t *testing.T) {
+	testCases := []struct {
+		input    interface{}
+		expected string
+	}{
+		{
+			input:    true,
+			expected: "bool",
+		},
+		{
+			input:    int(42),
+			expected: "number",
+		},
+		{
+			input:    int8(42),
+			expected: "number",
+		},
+		{
+			input:    int16(42),
+			expected: "number",
+		},
+		{
+			input:    int32(42),
+			expected: "number",
+		},
+		{
+			input:    int64(42),
+			expected: "number",
+		},
+		{
+			input:    uint(42),
+			expected: "number",
+		},
+		{
+			input:    uint8(42),
+			expected: "number",
+		},
+		{
+			input:    uint16(42),
+			expected: "number",
+		},
+		{
+			input:    uint32(42),
+			expected: "number",
+		},
+		{
+			input:    uint64(42),
+			expected: "number",
+		},
+		{
+			input:    float32(42),
+			expected: "number",
+		},
+		{
+			input:    float64(42),
+			expected: "number",
+		},
+		{
+			input:    "foo",
+			expected: "string",
+		},
+		{
+			input:    complex64(42i + 7),
+			expected: "string",
+		},
+		{
+			input:    complex128(42i + 7),
+			expected: "string",
+		},
+		{
+			input:    func() {},
+			expected: "string",
+		},
+		{
+			input:    make(chan struct{}),
+			expected: "string",
+		},
+		{
+			input:    []int{},
+			expected: "array",
+		},
+		{
+			input:    [...]int{},
+			expected: "array",
+		},
+		{
+			input:    map[string]int{},
+			expected: "object",
+		},
+		{
+			input:    myStruct{},
+			expected: "loghooks_myStruct",
+		},
+		{
+			// We don't expect the case of anonymous structs to come up often, but we
+			// do handle it correcly. " ", "{", "}", and ";" are allowed in
+			// Elasticsearch. The resulting string is ugly but at least it is
+			// guaranteed to prevent field mapping conflicts.
+			input: struct {
+				myInt    int
+				myString string
+			}{},
+			expected: "struct { myInt int; myString string }",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCaseInfo := fmt.Sprintf("input: (%T) %v", testCase.input, testCase.input)
+		actual, err := getTypeForValue(testCase.input)
+		require.NoError(t, err, testCaseInfo)
+		assert.Equal(t, testCase.expected, actual, testCaseInfo)
+	}
+}
+
+// case reflect.Struct:


### PR DESCRIPTION
This PR will help fix field mapping conflicts in Elasticsearch. When we have two separate logs with the same field name but different types, Elasticsearch cannot correctly index them, which often results in log messages being lost. If we add a type suffix, it will no longer be possible to have the same field name but different types.