### PR TITLE
Reduce verbosity for dial backoff errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1277,6 +1277,7 @@
     "github.com/libp2p/go-libp2p-protocol",
     "github.com/libp2p/go-libp2p-pubsub",
     "github.com/libp2p/go-libp2p-routing",
+    "github.com/libp2p/go-libp2p-swarm",
     "github.com/multiformats/go-multiaddr",
     "github.com/multiformats/go-multiaddr-dns",
     "github.com/ocdogan/rbt",


### PR DESCRIPTION
Currently our logs are filled with a lot of "dial backoff" errors. This happens pretty often when a peer disconnects from the network. This PR reduces the verbosity of those errors to make our logs leaner and more useful.