### PR TITLE
orderwatch: Remove null txHashes & fix uninstantiated map issue

### DIFF
--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -226,7 +226,8 @@ func (w *Watcher) startCleanupWorker() {
 			hashToOrderWithTxHashes := map[common.Hash]*OrderWithTxHashes{}
 			for _, order := range orders {
 				hashToOrderWithTxHashes[order.Hash] = &OrderWithTxHashes{
-					Order: order,
+					Order:    order,
+					TxHashes: map[common.Hash]interface{}{},
 				}
 			}
 			w.generateOrderEventsIfChanged(hashToOrderWithTxHashes)

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -507,7 +507,7 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 	orderEvents := []*zeroex.OrderEvent{}
 	for _, acceptedOrderInfo := range validationResults.Accepted {
 		orderWithTxHashes := hashToOrderWithTxHashes[acceptedOrderInfo.OrderHash]
-		txHashes := make([]common.Hash, len(orderWithTxHashes.TxHashes))
+		txHashes := []common.Hash{}
 		for txHash := range orderWithTxHashes.TxHashes {
 			txHashes = append(txHashes, txHash)
 		}
@@ -573,7 +573,7 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 				if !ok {
 					logger.WithField("rejectedOrderStatus", rejectedOrderInfo.Status).Panic("No OrderEventKind corresponding to RejectedOrderStatus")
 				}
-				txHashes := make([]common.Hash, len(orderWithTxHashes.TxHashes))
+				txHashes := []common.Hash{}
 				for txHash := range orderWithTxHashes.TxHashes {
 					txHashes = append(txHashes, txHash)
 				}

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -507,9 +507,11 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 	orderEvents := []*zeroex.OrderEvent{}
 	for _, acceptedOrderInfo := range validationResults.Accepted {
 		orderWithTxHashes := hashToOrderWithTxHashes[acceptedOrderInfo.OrderHash]
-		txHashes := []common.Hash{}
+		txHashes := make([]common.Hash, len(orderWithTxHashes.TxHashes))
+		txHashIndex := 0
 		for txHash := range orderWithTxHashes.TxHashes {
-			txHashes = append(txHashes, txHash)
+			txHashes[txHashIndex] = txHash
+			txHashIndex++
 		}
 		order := orderWithTxHashes.Order
 		oldFillableAmount := order.FillableTakerAssetAmount
@@ -573,9 +575,11 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 				if !ok {
 					logger.WithField("rejectedOrderStatus", rejectedOrderInfo.Status).Panic("No OrderEventKind corresponding to RejectedOrderStatus")
 				}
-				txHashes := []common.Hash{}
+				txHashes := make([]common.Hash, len(orderWithTxHashes.TxHashes))
+				txHashIndex := 0
 				for txHash := range orderWithTxHashes.TxHashes {
-					txHashes = append(txHashes, txHash)
+					txHashes[txHashIndex] = txHash
+					txHashIndex++
 				}
 				orderEvent := &zeroex.OrderEvent{
 					OrderHash:                rejectedOrderInfo.OrderHash,


### PR DESCRIPTION
During testing I noticed that OrderEvents consistently had 2 txHashes, with the first one always being the null address. By inspecting the code, I saw we are appending to an array created using `make()` which pre-created len number of zero-value entries. I've decided to fix by reverting to using `[]common.Hash{}` instead of `make()`. Although less efficient, in the subsequent looping over the map, we don't have a readily available index to use in replacing the zero-values and so this feels like the cleanest approach.

I additionally noticed we weren't instantiating `TxHashes` in the cleanup job, which would have caused later code to attempt to treat a `nil` value as an instantiated map.