### PR TITLE
expirationwatch: Use consistent asynchronous API

### DIFF
--- a/expirationwatch/expiration_watcher.go
+++ b/expirationwatch/expiration_watcher.go
@@ -104,6 +104,7 @@ func (w *Watcher) Watch(ctx context.Context, pollingInterval time.Duration) erro
 	for {
 		select {
 		case <-ctx.Done():
+			ticker.Stop()
 			close(w.expiredItems)
 			return nil
 		case <-ticker.C:


### PR DESCRIPTION
As mentioned in #96, we are moving towards making our asynchronous APIs more consistent across all packages. This PR applies the new conventions to the `expirationwatch` package only.

One consequence of making this change one package at a time is that there are some places where we need to awkwardly bridge the various old asynchronous coding styles with the new style. Some things will get uglier before they get prettier. For example, we are now creating contexts and storing cancel funcs for the sole purpose of passing them into `expirationwatch.Watcher.Watch`. But after all packages transition to the new conventions, we will be able to inherit from a parent context instead of creating a new one.

Since we are changing the API anyways, I also wanted to rename `Start` to `Watch` and `Receive` to `ExpiredItems`. This mimics methods from the standard library like [`http.ListenAndServe`](https://golang.org/pkg/net/http/#ListenAndServe) in that they are more descriptive than generic names like `Start` and `Stop`.