### PR TITLE
rpc: Use consistent asynchronous API

### DIFF
--- a/cmd/mesh/main.go
+++ b/cmd/mesh/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// Start RPC server.
 	go func() {
-		err := listenRPC(app, config)
+		err := listenRPC(app, config, ctx)
 		if err != nil {
 			app.Close()
 			log.WithField("error", err.Error()).Fatal("RPC server returned error")


### PR DESCRIPTION
Related to #96.