### PR TITLE
Increase sleep duration in some transaction tests (again)

### DIFF
--- a/db/global_transaction_test.go
+++ b/db/global_transaction_test.go
@@ -140,7 +140,7 @@ func TestGlobalTransaction(t *testing.T) {
 	// that the mutexes are the thing enforcing that no new collections are
 	// created and no new writes are made to the db state until after the global
 	// transaction is committed.
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(transactionTestSleepDuration)
 
 	// Signal that we are about to commit the transaction, then commit it.
 	commitSignal <- struct{}{}
@@ -337,7 +337,7 @@ func TestGlobalTransactionExclusion(t *testing.T) {
 		}()
 	}()
 
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(transactionTestSleepDuration)
 	discardSignal <- struct{}{}
 	require.NoError(t, txn.Discard())
 

--- a/db/transaction_test.go
+++ b/db/transaction_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// transactionTestSleepDuration is passed to time.Sleep in some transaction tests
+// involving timing between multiple goroutines.
+const transactionTestSleepDuration = 50 * time.Millisecond
+
 func TestTransaction(t *testing.T) {
 	t.Parallel()
 	db := newTestDB(t)
@@ -252,7 +256,7 @@ func TestTransactionExclusion(t *testing.T) {
 	}()
 
 	// A short sleep is necessary to ensure that the goroutines have time to run.
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(transactionTestSleepDuration)
 	discardSignal <- struct{}{}
 	require.NoError(t, txn.Discard())
 


### PR DESCRIPTION
See https://github.com/0xProject/0x-mesh/pull/211. It looks like we didn't go far enough in that PR and some transaction tests are still occasionally failing on CI. This PR increases the sleep duration from 5ms to 50ms.