### PR TITLE
Add a timeout of 30s (per package) for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test-all: test-go test-wasm
 
 .PHONY: test-go
 test-go:
-	go test ./... -race
+	go test ./... -race -timeout 30s
 
 
 .PHONY: test-wasm


### PR DESCRIPTION
Fixes #183. 

Go offers a `--timeout` flag which will cause `go test` to fail if the tests for any package take too long. It would technically be better to go through each test and eliminate situations where the test could hang. In practice, that can be difficult and it is easy to miss some edge cases. I think the `--timeout` flag will be good enough.