### PR TITLE
Final changes to make all code follow our async conventions

### DIFF
--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -38,6 +38,11 @@ func listenRPC(app *core.App, config standaloneConfig, ctx context.Context) erro
 	go func() {
 		// Wait for the server to start listening and select an address.
 		for rpcServer.Addr() == nil {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
 			time.Sleep(10 * time.Millisecond)
 		}
 		log.WithField("address", rpcServer.Addr().String()).Info("started RPC server")

--- a/core/core.go
+++ b/core/core.go
@@ -334,14 +334,7 @@ func (app *App) Start(ctx context.Context) error {
 		orderWatcherErrChan <- app.orderWatcher.Watch(innerCtx)
 	}()
 
-	// Set up and start the block watcher.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for err := range app.blockWatcher.Errors {
-			log.WithField("error", err).Error("BlockWatcher error encountered")
-		}
-	}()
+	// Start the block watcher.
 	blockWatcherErrChan := make(chan error, 1)
 	wg.Add(1)
 	go func() {

--- a/core/core.go
+++ b/core/core.go
@@ -578,7 +578,8 @@ func (app *App) AddOrders(signedOrdersRaw []*json.RawMessage) (*zeroex.Validatio
 		signedOrder := &zeroex.SignedOrder{}
 		if err := signedOrder.UnmarshalJSON(signedOrderBytes); err != nil {
 			// This error should never happen since the signedOrder already passed the JSON schema validation above
-			log.WithField("signedOrderRaw", string(signedOrderBytes)).Panic("Failed to unmarshal SignedOrder")
+			log.WithField("signedOrderRaw", string(signedOrderBytes)).Error("Failed to unmarshal SignedOrder")
+			return nil, err
 		}
 		schemaValidOrders = append(schemaValidOrders, signedOrder)
 	}

--- a/db/escape.go
+++ b/db/escape.go
@@ -25,7 +25,7 @@ func escape(value []byte) []byte {
 }
 
 // unescape is the inverse of escape.
-func unescape(value []byte) []byte {
+func unescape(value []byte) ([]byte, error) {
 	reader := bufio.NewReader(bytes.NewBuffer(value))
 	unescaped := []byte{}
 	for {
@@ -42,7 +42,8 @@ func unescape(value []byte) []byte {
 				log.WithFields(log.Fields{
 					"error": err.Error(),
 					"value": hex.Dump(value),
-				}).Panic("unexpected error in unescape")
+				}).Error("unexpected error in unescape")
+				return nil, err
 			}
 			if next == 'c' {
 				unescaped = append(unescaped, ':')
@@ -53,5 +54,5 @@ func unescape(value []byte) []byte {
 			unescaped = append(unescaped, b)
 		}
 	}
-	return unescaped
+	return unescaped, nil
 }

--- a/db/escape_test.go
+++ b/db/escape_test.go
@@ -28,7 +28,8 @@ var trickyByteValues = [][]byte{
 func TestEscapeUnescape(t *testing.T) {
 	t.Parallel()
 	for _, expected := range trickyByteValues {
-		actual := unescape(escape(expected))
+		actual, err := unescape(escape(expected))
+		require.NoError(t, err)
 		assert.Equal(t, expected, actual)
 	}
 }

--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -422,6 +422,12 @@ func (w *Watcher) getLogsInBlockRange(ctx context.Context, from, to int) ([]type
 
 				select {
 				case <-ctx.Done():
+					indexToLogResult[index] = logRequestResult{
+						From: b.FromBlock,
+						To:   b.ToBlock,
+						Err:  errors.New("context was canceled"),
+						Logs: []types.Log{},
+					}
 					return
 				default:
 				}

--- a/ethereum/blockwatch/block_watcher_test.go
+++ b/ethereum/blockwatch/block_watcher_test.go
@@ -214,7 +214,9 @@ func TestGetMissedEventsToBackfillSomeMissed(t *testing.T) {
 	config.Client = fakeClient
 	watcher := New(config)
 
-	events, err := watcher.getMissedEventsToBackfill()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events, err := watcher.getMissedEventsToBackfill(ctx)
 	require.NoError(t, err)
 	assert.Len(t, events, 1)
 
@@ -246,7 +248,9 @@ func TestGetMissedEventsToBackfillNoneMissed(t *testing.T) {
 	config.Client = fakeClient
 	watcher := New(config)
 
-	events, err := watcher.getMissedEventsToBackfill()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events, err := watcher.getMissedEventsToBackfill(ctx)
 	require.NoError(t, err)
 	assert.Len(t, events, 0)
 
@@ -482,13 +486,16 @@ func TestGetLogsInBlockRange(t *testing.T) {
 	defer meshDB.Close()
 	config.MeshDB = meshDB
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for _, testCase := range testCases {
 		fakeLogClient, err := newFakeLogClient(testCase.RangeToFilterLogsResponse)
 		require.NoError(t, err)
 		config.Client = fakeLogClient
 		watcher := New(config)
 
-		logs, furthestBlockProcessed := watcher.getLogsInBlockRange(testCase.From, testCase.To)
+		logs, furthestBlockProcessed := watcher.getLogsInBlockRange(ctx, testCase.From, testCase.To)
 		require.Equal(t, testCase.FurthestBlockProcessed, furthestBlockProcessed, testCase.Label)
 		require.Equal(t, testCase.Logs, logs, testCase.Label)
 		assert.Equal(t, len(testCase.RangeToFilterLogsResponse), fakeLogClient.Count())

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -118,7 +118,7 @@ func New(ctx context.Context, config Config) (*Node, error) {
 		var err error
 		kadDHT, err = NewDHT(ctx, h)
 		if err != nil {
-			log.WithField("error", err).Fatal("could not create DHT")
+			log.WithField("error", err).Error("could not create DHT")
 		}
 		return kadDHT, err
 	}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -45,12 +45,14 @@ func (s *Server) Listen(ctx context.Context) error {
 	}
 	s.rpcServer = rpc.NewServer()
 	if err := s.rpcServer.RegisterName("mesh", rpcService); err != nil {
-		log.WithField("error", err.Error()).Fatal("could not register RPC service")
+		log.WithField("error", err.Error()).Error("could not register RPC service")
+		return err
 	}
 	listener, err := net.Listen("tcp4", s.addr)
 	if err != nil {
 		s.mut.Unlock()
-		log.WithField("error", err.Error()).Fatal("could not start listener")
+		log.WithField("error", err.Error()).Error("could not start listener")
+		return err
 	}
 	s.listener = listener
 	s.mut.Unlock()


### PR DESCRIPTION
Fixes #96.

Depends on #307. After that PR is merged I'll change the base branch for this one to `development`.

Summary of changes:
- Make `core.App.Start` blocking.
- Remove `core.App.Stop`.
- Avoid `log.Panic` and `log.Fatal` whenever possible (there are some lingering cases where e.g., we pass a function into another function and don't have a good way to return errors).
- Remove the `blockwatch.Watcher.Errors` channel. For non-critical errors, we log them in `blockwatch.Watcher` directly. For critical errors, we return them in `blockwatch.Watcher.Watch`. This makes `blockwatch` more aligned with the rest of our async code.
- Don't start any goroutines without a way to stop them (usually by waiting for `ctx.Done()` but sometimes with short timeouts or other signals).