### PR TITLE
Reduce verbosity of "fetching block logs" message

### DIFF
--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -516,7 +516,7 @@ func (w *Watcher) filterLogsRecurisively(from, to int, allLogs []types.Log) ([]t
 	log.WithFields(map[string]interface{}{
 		"from": from,
 		"to":   to,
-	}).Info("Fetching block logs")
+	}).Trace("Fetching block logs")
 	numBlocks := to - from
 	topics := [][]common.Hash{}
 	if len(w.topics) > 0 {


### PR DESCRIPTION
@fabioberger I think the verbosity of this log should change from `Info` to `Trace`. Whenever I run Mesh locally for quick tests, this log message is taking up a large percentage of the total number of logs. I don't think it is helpful to see hundreds of logs for what is a pretty common occurrence. What do you think?