### PR TITLE
cmd: `cut-release` improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Automatically collapse generated files in GitHub.
 ethereum/wrappers/*.go  linguist-generated=true
+docs/json-rpc-clients/typescript/*.md  linguist-generated=true
 

--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -107,6 +107,12 @@ func updateHardCodedVersions(version string) {
 	regex = `version(.*)= "(.*)"`
 	updateFileWithRegex(corePath, regex, newVersionString)
 
+	// Update `beta_telemetry_node/docker-compose.yml`
+	dockerComposePath := "examples/beta_telemetry_node/docker-compose.yml"
+	newVersionString = fmt.Sprintf(`image: 0xorg/mesh:%s`, version)
+	regex = `image: 0xorg/mesh:(.*)`
+	updateFileWithRegex(dockerComposePath, regex, newVersionString)
+
 	// Update badge in README.md
 	pathToMDFilesWithBadges := []string{"README.md", "docs/USAGE.md", "docs/DEVELOPMENT.md", "docs/DEPLOYMENT.md"}
 	doubleDashVersion := strings.Replace(version, "-", "--", -1)


### PR DESCRIPTION
- Update version in beta `docker-compose.yml` file
- Instruct Github to auto-collapse generated MD files in PR review.