### PR TITLE
zeroex: Treat partially fillable orders as invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming release
 
+### Breaking changes 🛠 
+
+- Modified Mesh's validation logic to reject and consider invalid any _partially fillable_ orders (#333)
+
 ### Bug fixes 🐞 
 
 - Added `"declaration": true,` to TS client's `tsconfig.json` so that downstream projects can use it's TS typings. (#325)

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -31,8 +31,8 @@ var MainnetOrderValidatorAddress = common.HexToAddress("0x9463e518dea6810309563c
 // GanacheOrderValidatorAddress is the ganache snapshot OrderValidator contract address
 var GanacheOrderValidatorAddress = common.HexToAddress("0x32eecaf51dfea9618e9bc94e9fbfddb1bbdcba15")
 
-// The context timeout length to use for requests to getOrdersAndTradersInfoTimeout
-const getOrdersAndTradersInfoTimeout = 15 * time.Second
+// The context timeout length to use for requests to getOrderRelevantStateTimeout
+const getOrderRelevantStateTimeout = 15 * time.Second
 
 // The context timeout length to use for requests to getCoordinatorEndpoint
 const getCoordinatorEndpointTimeout = 10 * time.Second
@@ -311,7 +311,7 @@ func (o *OrderValidator) BatchValidate(rawSignedOrders []*SignedOrder, areNewOrd
 			for {
 				// Pass a context with a 15 second timeout to `GetOrderRelevantStates` in order to avoid
 				// any one request from taking longer then 15 seconds
-				ctx, cancel := context.WithTimeout(context.Background(), getOrdersAndTradersInfoTimeout)
+				ctx, cancel := context.WithTimeout(context.Background(), getOrderRelevantStateTimeout)
 				defer cancel()
 				opts := &bind.CallOpts{
 					Pending: false,

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -381,7 +381,10 @@ func (o *OrderValidator) BatchValidate(rawSignedOrders []*SignedOrder, areNewOrd
 						})
 						continue
 					case OSFillable:
-						if fillableTakerAssetAmount.Cmp(big.NewInt(0)) == 0 {
+						remainingTakerAssetAmount := big.NewInt(0).Sub(signedOrder.TakerAssetAmount, orderInfo.OrderTakerAssetFilledAmount)
+						// If `fillableTakerAssetAmount` != `remainingTakerAssetAmount`, the order is partially fillable. We consider
+						// partially fillable orders as invalid
+						if fillableTakerAssetAmount.Cmp(remainingTakerAssetAmount) != 0 {
 							validationResults.Rejected = append(validationResults.Rejected, &RejectedOrderInfo{
 								OrderHash:   orderHash,
 								SignedOrder: signedOrder,

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -622,7 +622,6 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && !oldAmountIsMoreThenNewAmount {
 			// The order is now fillable for more then it was before. E.g.:
 			// 1. A fill txn reverted (block-reorg)
-			// 2. Traders added missing balance/allowance increasing the order's fillability
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,
 				SignedOrder:              order.SignedOrder,


### PR DESCRIPTION
0x has this quirk where an order can be _partially fillable_. What this means is that the order maker has a sufficient balance/allowance to fill some portion of the outstanding order but _not the total remaining amount_. We used to consider any order that can be filled for a non-zero amount as valid. This PR introduces a breaking change to instead consider any order where the `fillableAmount` != `remainingAmount` to be considered invalid. 

After doing an empirical analysis of existing 0x orderbooks, the only orders that we've found in this state were mistakes. Additionally, it makes batch fill methods less effective, since the 0x smart contracts do not validate balance/allowance amounts before fills but rely on the`token transfer` reverting to detect insufficient funds/allowance. This can happed for partially filled orders and so we've decided to simply reject these orders from the onset. This change also reduces the cognitive load on devs building on 0x, since they can now rely on the `filled` mapping on the smart contract to know how much of an order is still fillable. 