### PR TITLE
core/p2p/rpc: Add support for a custom topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 ### Breaking changes 🛠 
 
+- Modified `mesh_getStats` so that it returns the topics used in the pubsub layer differentiated between those that are published to, and those that the node is subscribed to. Mesh nodes can publish to multiple topics but only ever subscribe to a single topic. ([#349](https://github.com/0xProject/0x-mesh/pull/349))
+
+### Features ✅ 
+
+- Added the ability to specify a custom pubsub topic at instantiation and have the Mesh node receive orders exclusively from peers subscribed to the same topic. ([#349](https://github.com/0xProject/0x-mesh/pull/349))
+
+## v3.0.0-beta
+
+### Breaking changes 🛠 
+
 - Modified Mesh's validation logic to reject and consider invalid any _partially fillable_ orders. While this is
   technically a breaking change, partially fillable orders are rare in the wild and we don't expect this will
   affect many users. ([#333](https://github.com/0xProject/0x-mesh/pull/333))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v6.0.0-beta
+
+### Breaking changes 🛠 
+
+- Modified `mesh_getStats` so that it returns the topics used in the pubsub layer differentiated between those that are published to, and those that the node is subscribed to. Mesh nodes can publish to multiple topics but only ever subscribe to a single topic. ([#349](https://github.com/0xProject/0x-mesh/pull/349))
+
+### Features ✅ 
+
+- Added the ability to specify a custom pubsub topic at instantiation and have the Mesh node receive orders exclusively from peers subscribed to the same topic. ([#349](https://github.com/0xProject/0x-mesh/pull/349))
+
 ## v5.0.0-beta
 
 ### Breaking changes 🛠 
@@ -55,16 +65,6 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 - Fixed bug where block number would sometimes be converted to hex with a leading zero, an invalid hex value per the [Ethereum JSON-RPC specification](https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding). ([#353](https://github.com/0xProject/0x-mesh/pull/353))
 - Fixed bug which resulted in orders that were close to expiring being re-added and removed multiple times, resulting in multiple ADDED and EXPIRED events for the same order ([#352](https://github.com/0xProject/0x-mesh/pull/352)).
-
-## v3.0.0-beta
-
-### Breaking changes 🛠 
-
-- Modified `mesh_getStats` so that it returns the topics used in the pubsub layer differentiated between those that are published to, and those that the node is subscribed to. Mesh nodes can publish to multiple topics but only ever subscribe to a single topic. ([#349](https://github.com/0xProject/0x-mesh/pull/349))
-
-### Features ✅ 
-
-- Added the ability to specify a custom pubsub topic at instantiation and have the Mesh node receive orders exclusively from peers subscribed to the same topic. ([#349](https://github.com/0xProject/0x-mesh/pull/349))
 
 ## v3.0.0-beta
 

--- a/core/core.go
+++ b/core/core.go
@@ -391,14 +391,22 @@ func (app *App) Start(ctx context.Context) error {
 		blockWatcherErrChan <- app.blockWatcher.Watch(innerCtx)
 	}()
 
+	defaultTopic := getDefaultPubSubTopic(app.config.EthereumNetworkID)
+	publishTopics := []string{defaultTopic}
+	subscribeTopic := defaultTopic
+	if app.config.CustomTopic != "" {
+		publishTopics = append(publishTopics, app.config.CustomTopic)
+		subscribeTopic = app.config.CustomTopic
+	}
+
 	// Initialize the p2p node.
 	bootstrapList := p2p.DefaultBootstrapList
 	if app.config.BootstrapList != "" {
 		bootstrapList = strings.Split(app.config.BootstrapList, ",")
 	}
 	nodeConfig := p2p.Config{
-		DefaultTopic:     getDefaultPubSubTopic(app.config.EthereumNetworkID),
-		CustomTopic:      app.config.CustomTopic,
+		PublishTopics:    publishTopics,
+		SubscribeTopic:   subscribeTopic,
 		TCPPort:          app.config.P2PTCPPort,
 		WebSocketsPort:   app.config.P2PWebSocketsPort,
 		Insecure:         false,

--- a/core/core.go
+++ b/core/core.go
@@ -114,7 +114,8 @@ type Config struct {
 	//    }
 	//
 	CustomContractAddresses string `envvar:"CUSTOM_CONTRACT_ADDRESSES" default:""`
-	// CustomTopic is an additional custom topic the Mesh node should send/receive orders to/from
+	// CustomTopic is an additional topic the Mesh node should send orders to. If specified, the node will also
+	// exclusively receive orders from peers also subscribed to the custom topic.
 	CustomTopic string `envvar:"CUSTOM_TOPIC" default:""`
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -277,6 +277,17 @@ func getDefaultPubSubTopic(networkID int) string {
 	return fmt.Sprintf("/0x-orders/network/%d/version/1", networkID)
 }
 
+func getPublishAndSubscribeTopics(networkID int, customTopic string) (publishTopics []string, subscribeTopic string) {
+	defaultTopic := getDefaultPubSubTopic(networkID)
+	publishTopics = []string{defaultTopic}
+	subscribeTopic = defaultTopic
+	if customTopic != "" {
+		publishTopics = append(publishTopics, customTopic)
+		subscribeTopic = customTopic
+	}
+	return publishTopics, subscribeTopic
+}
+
 func getRendezvous(networkID int) string {
 	return fmt.Sprintf("/0x-mesh/network/%d/version/1", networkID)
 }
@@ -391,13 +402,7 @@ func (app *App) Start(ctx context.Context) error {
 		blockWatcherErrChan <- app.blockWatcher.Watch(innerCtx)
 	}()
 
-	defaultTopic := getDefaultPubSubTopic(app.config.EthereumNetworkID)
-	publishTopics := []string{defaultTopic}
-	subscribeTopic := defaultTopic
-	if app.config.CustomTopic != "" {
-		publishTopics = append(publishTopics, app.config.CustomTopic)
-		subscribeTopic = app.config.CustomTopic
-	}
+	publishTopics, subscribeTopic := getPublishAndSubscribeTopics(app.config.EthereumNetworkID, app.config.CustomTopic)
 
 	// Initialize the p2p node.
 	bootstrapList := p2p.DefaultBootstrapList
@@ -705,13 +710,7 @@ func (app *App) GetStats() (*rpc.GetStatsResponse, error) {
 		return nil, err
 	}
 
-	defaultTopic := getDefaultPubSubTopic(app.config.EthereumNetworkID)
-	publishTopics := []string{defaultTopic}
-	subscribeTopic := defaultTopic
-	if app.config.CustomTopic != "" {
-		publishTopics = append(publishTopics, app.config.CustomTopic)
-		subscribeTopic = app.config.CustomTopic
-	}
+	publishTopics, subscribeTopic := getPublishAndSubscribeTopics(app.config.EthereumNetworkID, app.config.CustomTopic)
 	response := &rpc.GetStatsResponse{
 		Version:           version,
 		PublishTopics:     publishTopics,

--- a/core/core.go
+++ b/core/core.go
@@ -114,6 +114,8 @@ type Config struct {
 	//    }
 	//
 	CustomContractAddresses string `envvar:"CUSTOM_CONTRACT_ADDRESSES" default:""`
+	// CustomTopic is an additional custom topic the Mesh node should send/receive orders to/from
+	CustomTopic string `envvar:"CUSTOM_TOPIC" default:""`
 }
 
 type snapshotInfo struct {
@@ -270,7 +272,7 @@ func unquoteConfig(config Config) Config {
 	return config
 }
 
-func getPubSubTopic(networkID int) string {
+func getDefaultPubSubTopic(networkID int) string {
 	return fmt.Sprintf("/0x-orders/network/%d/version/1", networkID)
 }
 
@@ -394,7 +396,8 @@ func (app *App) Start(ctx context.Context) error {
 		bootstrapList = strings.Split(app.config.BootstrapList, ",")
 	}
 	nodeConfig := p2p.Config{
-		Topic:            getPubSubTopic(app.config.EthereumNetworkID),
+		DefaultTopic:     getDefaultPubSubTopic(app.config.EthereumNetworkID),
+		CustomTopic:      app.config.CustomTopic,
 		TCPPort:          app.config.P2PTCPPort,
 		WebSocketsPort:   app.config.P2PWebSocketsPort,
 		Insecure:         false,
@@ -693,9 +696,13 @@ func (app *App) GetStats() (*rpc.GetStatsResponse, error) {
 		return nil, err
 	}
 
+	topics := []string{getDefaultPubSubTopic(app.config.EthereumNetworkID)}
+	if app.config.CustomTopic != "" {
+		topics = append(topics, app.config.CustomTopic)
+	}
 	response := &rpc.GetStatsResponse{
 		Version:           version,
-		PubSubTopic:       getPubSubTopic(app.config.EthereumNetworkID),
+		PubSubTopics:      topics,
 		Rendezvous:        getRendezvous(app.config.EthereumNetworkID),
 		PeerID:            app.peerID.String(),
 		EthereumNetworkID: app.config.EthereumNetworkID,

--- a/core/core.go
+++ b/core/core.go
@@ -705,13 +705,17 @@ func (app *App) GetStats() (*rpc.GetStatsResponse, error) {
 		return nil, err
 	}
 
-	topics := []string{getDefaultPubSubTopic(app.config.EthereumNetworkID)}
+	defaultTopic := getDefaultPubSubTopic(app.config.EthereumNetworkID)
+	publishTopics := []string{defaultTopic}
+	subscribeTopic := defaultTopic
 	if app.config.CustomTopic != "" {
-		topics = append(topics, app.config.CustomTopic)
+		publishTopics = append(publishTopics, app.config.CustomTopic)
+		subscribeTopic = app.config.CustomTopic
 	}
 	response := &rpc.GetStatsResponse{
 		Version:           version,
-		PubSubTopics:      topics,
+		PublishTopics:     publishTopics,
+		SubscribeTopic:    subscribeTopic,
 		Rendezvous:        getRendezvous(app.config.EthereumNetworkID),
 		PeerID:            app.peerID.String(),
 		EthereumNetworkID: app.config.EthereumNetworkID,

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -81,7 +81,8 @@ func newTestNode(t *testing.T, ctx context.Context, notifee p2pnet.Notifiee) *No
 	privKey, _, err := p2pcrypto.GenerateSecp256k1Key(rand.Reader)
 	require.NoError(t, err)
 	config := Config{
-		Topic:            testTopic,
+		DefaultTopic:     testTopic,
+		CustomTopic:      "",
 		PrivateKey:       privKey,
 		MessageHandler:   &dummyMessageHandler{},
 		RendezvousString: testRendezvousString,
@@ -235,13 +236,13 @@ loop:
 
 	// Send ping from node0 to node1
 	pingMessage := &Message{From: node0.host.ID(), Data: []byte("ping\n")}
-	require.NoError(t, node0.send(pingMessage.Data))
+	require.NoError(t, node0.send(testTopic, pingMessage.Data))
 	const pingPongTimeout = 15 * time.Second
 	expectMessage(t, node1, pingMessage, pingPongTimeout)
 
 	// Send pong from node1 to node0
 	pongMessage := &Message{From: node1.host.ID(), Data: []byte("pong\n")}
-	require.NoError(t, node1.send(pongMessage.Data))
+	require.NoError(t, node1.send(testTopic, pongMessage.Data))
 	expectMessage(t, node0, pongMessage, pingPongTimeout)
 }
 

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -81,8 +81,8 @@ func newTestNode(t *testing.T, ctx context.Context, notifee p2pnet.Notifiee) *No
 	privKey, _, err := p2pcrypto.GenerateSecp256k1Key(rand.Reader)
 	require.NoError(t, err)
 	config := Config{
-		DefaultTopic:     testTopic,
-		CustomTopic:      "",
+		PublishTopics:    []string{testTopic},
+		SubscribeTopic:   testTopic,
 		PrivateKey:       privKey,
 		MessageHandler:   &dummyMessageHandler{},
 		RendezvousString: testRendezvousString,

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -77,7 +77,8 @@ type LatestBlock struct {
 // GetStatsResponse is the response returned for an RPC request to mesh_getStats
 type GetStatsResponse struct {
 	Version           string      `json:"version"`
-	PubSubTopics      []string      `json:"pubSubTopics"`
+	PublishTopics     []string    `json:"publishTopics"`
+	SubscribeTopic    string      `json:"subscribeTopic"`
 	Rendezvous        string      `json:"rendervous"`
 	PeerID            string      `json:"peerID"`
 	EthereumNetworkID int         `json:"ethereumNetworkID"`

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -77,7 +77,7 @@ type LatestBlock struct {
 // GetStatsResponse is the response returned for an RPC request to mesh_getStats
 type GetStatsResponse struct {
 	Version           string      `json:"version"`
-	PubSubTopic       string      `json:"pubSubTopic"`
+	PubSubTopics      []string      `json:"pubSubTopics"`
 	Rendezvous        string      `json:"rendervous"`
 	PeerID            string      `json:"peerID"`
 	EthereumNetworkID int         `json:"ethereumNetworkID"`

--- a/rpc/client_server_test.go
+++ b/rpc/client_server_test.go
@@ -269,7 +269,7 @@ func TestAddPeer(t *testing.T) {
 func TestGetStats(t *testing.T) {
 	expectedGetStatsResponse := &GetStatsResponse{
 		Version:           "development",
-		PubSubTopic:       "/0x-orders/network/development/version/1",
+		PubSubTopics:       []string{"/0x-orders/network/development/version/1"},
 		Rendezvous:        "/0x-mesh/network/development/version/1",
 		PeerID:            "16Uiu2HAmJ827EAibLvJxGMj6BvT1tr2e2ssW4cMtpP15qoQqZGSA",
 		EthereumNetworkID: 42,

--- a/rpc/client_server_test.go
+++ b/rpc/client_server_test.go
@@ -269,7 +269,8 @@ func TestAddPeer(t *testing.T) {
 func TestGetStats(t *testing.T) {
 	expectedGetStatsResponse := &GetStatsResponse{
 		Version:           "development",
-		PubSubTopics:       []string{"/0x-orders/network/development/version/1"},
+		PublishTopics:     []string{"/0x-orders/network/development/version/1"},
+		SubscribeTopic:    "/0x-orders/network/development/version/1",
 		Rendezvous:        "/0x-mesh/network/development/version/1",
 		PeerID:            "16Uiu2HAmJ827EAibLvJxGMj6BvT1tr2e2ssW4cMtpP15qoQqZGSA",
 		EthereumNetworkID: 42,

--- a/rpc/clients/typescript/src/types.ts
+++ b/rpc/clients/typescript/src/types.ts
@@ -343,7 +343,8 @@ export interface LatestBlock {
 
 export interface GetStatsResponse {
     Version: string;
-    PubSubTopics: string[];
+    PublishTopics: string[];
+    SubscribeTopic: string;
     Rendezvous: string;
     PeerID: string;
     EthereumNetworkID: number;

--- a/rpc/clients/typescript/src/types.ts
+++ b/rpc/clients/typescript/src/types.ts
@@ -343,7 +343,7 @@ export interface LatestBlock {
 
 export interface GetStatsResponse {
     Version: string;
-    PubSubTopic: string;
+    PubSubTopics: string[];
     Rendezvous: string;
     PeerID: string;
     EthereumNetworkID: number;


### PR DESCRIPTION
Fixes: #336 

Add support for a single custom topic supplied via ENV VAR that is published to alongside the default topic, but that is exclusively received from.