### PR TITLE
Add an overview section to README and clarify purpose of JSON-RPC API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ WARNING: This project is still under active development. Expect breaking changes
 - Market makers can use Mesh to reach a broader audience. Their orders will be
   sent throughout the network and are more likely to be filled.
 - Mesh allows for a new type of relayer called a "serverless relayer". In the
-  serverless relayer model, each users runs Mesh in their browser and there is
+  serverless relayer model, each user runs Mesh in their browser and there is
   no backend server or database. Instead, peers share orders directly with one
   another. (There are pros and cons to this approach and it is probably not
   suitable for all markets).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,35 @@
 
 WARNING: This project is still under active development. Expect breaking changes before the official release.
 
+## Overview
+
+0x Mesh has a lot of different use cases for different categories of users:
+
+- Relayers can use Mesh to share orders with one another and to receive orders
+  from market makers. This allows them to increase the depth of their order
+  books and provide a better user experience.
+- Market makers can use Mesh to reach a broader audience. Their orders will be
+  sent throughout the network and are more likely to be filled.
+- Mesh allows for a new type of relayer called a "serverless relayer". In the
+  serverless relayer model, each users runs Mesh in their browser and there is
+  no backend server or database. Instead, peers share orders directly with one
+  another. (There are pros and cons to this approach and it is probably not
+  suitable for all markets).
+
+0x Mesh is intended to be entirely automatic. It takes care of all the work of
+receiving, sharing, and validating orders so that you can focus on building your
+application. When you run a 0x Mesh node, it will automatically discover peers
+in the network and begin receiving orders from and sending orders to them. You
+do not need to know the identities (e.g., IP address or domain name) of any
+peers in the network ahead of time and they do not need to know about you.
+
+Developers can use the JSON-RPC API to interact with a Mesh node that they
+control. The API allows you to send orders into the network, receive any new
+orders, and get notified when the status of an existing order changes (e.g. when
+it is filled, canceled, or expired). Under the hood, Mesh performs efficient
+order validation and order book pruning, which takes out a lot of the hard work
+for developers.
+
 ## Deployment
 
 [The Deployment Guide](docs/DEPLOYMENT.md)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,6 +4,14 @@ Welcome to the [0x Mesh](https://github.com/0xProject/0x-mesh) Usage
 Guide! This guide will help you interact with 0x Mesh via a JSON-RPC API once
 you have it up and running.
 
+The JSON-RPC API is intended to be a *private* API. The API should only be
+accessible to the developers running the Mesh node and should not be exposed to
+the public. The API runs on a separate port from the peer-to-peer protocols and
+access to it can be controlled via a firewall.
+
+Peers in the network do not use the JSON-RPC API and instead use a peer-to-peer
+PubSub mechanism (usually this is not something you need to worry about).
+
 ## Similarities to the Ethereum JSON-RPC API
 
 Our JSON-RPC API is very similar to the


### PR DESCRIPTION
Based on feedback we have received from users, our current documentation does not do a great job of explaining what Mesh is at a high level and how it can be used. This PR helps address that by adding an "Overview" section to the README and clarifying on the purpose of the JSON-RPC API.