### PR TITLE
zeroex: Add order expiration buffer to zeroex.OrderValdiator

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -165,7 +165,7 @@ func New(config Config) (*App, error) {
 	blockWatcher := blockwatch.New(blockWatcherConfig)
 
 	// Initialize the order validator
-	orderValidator, err := zeroex.NewOrderValidator(ethClient, config.EthereumNetworkID, config.EthereumRPCMaxContentLength)
+	orderValidator, err := zeroex.NewOrderValidator(ethClient, config.EthereumNetworkID, config.EthereumRPCMaxContentLength, config.OrderExpirationBuffer)
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +553,7 @@ func (app *App) AddOrders(signedOrdersRaw []*json.RawMessage) (*zeroex.Validatio
 			log.WithField("signedOrderRaw", string(signedOrderBytes)).Info("Unexpected error while attempting to validate signedOrderJSON against schema")
 			allValidationResults.Rejected = append(allValidationResults.Rejected, &zeroex.RejectedOrderInfo{
 				SignedOrder: signedOrder,
-				Kind:        MeshValidation,
+				Kind:        zeroex.MeshValidation,
 				Status: zeroex.RejectedOrderStatus{
 					Code:    ROInvalidSchemaCode,
 					Message: "order did not pass JSON-schema validation: Malformed JSON or empty payload",
@@ -573,7 +573,7 @@ func (app *App) AddOrders(signedOrdersRaw []*json.RawMessage) (*zeroex.Validatio
 			}
 			allValidationResults.Rejected = append(allValidationResults.Rejected, &zeroex.RejectedOrderInfo{
 				SignedOrder: signedOrder,
-				Kind:        MeshValidation,
+				Kind:        zeroex.MeshValidation,
 				Status:      status,
 			})
 			continue

--- a/core/validation.go
+++ b/core/validation.go
@@ -41,10 +41,6 @@ var (
 		Code:    "OrderAlreadyStoredAndUnfillable",
 		Message: "order is already stored and is unfillable. Mesh keeps unfillable orders in storage for a little while incase a block re-org makes them fillable again",
 	}
-	ROMaxExpirationExceeded = zeroex.RejectedOrderStatus{
-		Code:    "OrderMaxExpirationExceeded",
-		Message: "order expiration too far in the future",
-	}
 	ROIncorrectNetwork = zeroex.RejectedOrderStatus{
 		Code:    "OrderForIncorrectNetwork",
 		Message: "order was created for a different network than the one this Mesh node is configured to support",
@@ -65,11 +61,6 @@ var (
 	orderSchemaLoader       = gojsonschema.NewStringLoader(`{"id":"/orderSchema","properties":{"makerAddress":{"$ref":"/addressSchema"},"takerAddress":{"$ref":"/addressSchema"},"makerFee":{"$ref":"/wholeNumberSchema"},"takerFee":{"$ref":"/wholeNumberSchema"},"senderAddress":{"$ref":"/addressSchema"},"makerAssetAmount":{"$ref":"/wholeNumberSchema"},"takerAssetAmount":{"$ref":"/wholeNumberSchema"},"makerAssetData":{"$ref":"/hexSchema"},"takerAssetData":{"$ref":"/hexSchema"},"salt":{"$ref":"/wholeNumberSchema"},"exchangeAddress":{"$ref":"/addressSchema"},"feeRecipientAddress":{"$ref":"/addressSchema"},"expirationTimeSeconds":{"$ref":"/wholeNumberSchema"}},"required":["makerAddress","takerAddress","makerFee","takerFee","senderAddress","makerAssetAmount","takerAssetAmount","makerAssetData","takerAssetData","salt","exchangeAddress","feeRecipientAddress","expirationTimeSeconds"],"type":"object"}`)
 	signedOrderSchemaLoader = gojsonschema.NewStringLoader(`{"id":"/signedOrderSchema","allOf":[{"$ref":"/orderSchema"},{"properties":{"signature":{"$ref":"/hexSchema"}},"required":["signature"]}]}`)
 	meshMessageSchemaLoader = gojsonschema.NewStringLoader(`{"id":"/meshMessageSchema","properties":{"MessageType":{"type":"string"},"Order":{"$ref":"/signedOrderSchema"}},"required":["MessageType","Order"]}`)
-)
-
-// RejectedOrderKind values
-const (
-	MeshValidation = zeroex.RejectedOrderKind("MESH_VALIDATION")
 )
 
 func setupMeshMessageSchemaValidator() (*gojsonschema.Schema, error) {
@@ -170,7 +161,7 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*zeroex.Validation
 			results.Rejected = append(results.Rejected, &zeroex.RejectedOrderInfo{
 				OrderHash:   orderHash,
 				SignedOrder: order,
-				Kind:        MeshValidation,
+				Kind:        zeroex.MeshValidation,
 				Status:      ROSenderAddressNotAllowed,
 			})
 			continue
@@ -179,7 +170,7 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*zeroex.Validation
 			results.Rejected = append(results.Rejected, &zeroex.RejectedOrderInfo{
 				OrderHash:   orderHash,
 				SignedOrder: order,
-				Kind:        MeshValidation,
+				Kind:        zeroex.MeshValidation,
 				Status:      ROIncorrectNetwork,
 			})
 			continue
@@ -189,8 +180,8 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*zeroex.Validation
 			results.Rejected = append(results.Rejected, &zeroex.RejectedOrderInfo{
 				OrderHash:   orderHash,
 				SignedOrder: order,
-				Kind:        MeshValidation,
-				Status:      ROMaxExpirationExceeded,
+				Kind:        zeroex.MeshValidation,
+				Status:      zeroex.ROMaxExpirationExceeded,
 			})
 			continue
 		}
@@ -199,7 +190,7 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*zeroex.Validation
 				results.Rejected = append(results.Rejected, &zeroex.RejectedOrderInfo{
 					OrderHash:   orderHash,
 					SignedOrder: order,
-					Kind:        MeshValidation,
+					Kind:        zeroex.MeshValidation,
 					Status:      ROMaxOrderSizeExceeded,
 				})
 				continue
@@ -229,7 +220,7 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*zeroex.Validation
 				results.Rejected = append(results.Rejected, &zeroex.RejectedOrderInfo{
 					OrderHash:   orderHash,
 					SignedOrder: order,
-					Kind:        MeshValidation,
+					Kind:        zeroex.MeshValidation,
 					Status:      ROOrderAlreadyStoredAndUnfillable,
 				})
 				continue

--- a/expirationwatch/expiration_watcher.go
+++ b/expirationwatch/expiration_watcher.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/0xProject/0x-mesh/zeroex"
-
 	"github.com/albrow/stringset"
 	"github.com/ocdogan/rbt"
 	log "github.com/sirupsen/logrus"

--- a/expirationwatch/expiration_watcher.go
+++ b/expirationwatch/expiration_watcher.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0xProject/0x-mesh/zeroex"
+
 	"github.com/albrow/stringset"
 	"github.com/ocdogan/rbt"
 	log "github.com/sirupsen/logrus"
@@ -135,15 +137,14 @@ func (w *Watcher) prune() []ExpiredItem {
 			break
 		}
 		expirationTimeSeconds := int64(*key.(*rbt.Int64Key))
-		expirationTimestamp := time.Unix(expirationTimeSeconds, 0)
-		currentTimePlusBuffer := time.Now().Add(w.expirationBuffer)
-		if expirationTimestamp.After(currentTimePlusBuffer) {
+		expirationTime := time.Unix(expirationTimeSeconds, 0)
+		if !zeroex.IsExpired(expirationTime, w.expirationBuffer) {
 			break
 		}
 		ids := value.(stringset.Set)
 		for id := range ids {
 			pruned = append(pruned, ExpiredItem{
-				ExpirationTimestamp: expirationTimestamp,
+				ExpirationTimestamp: expirationTime,
 				ID:                  id,
 			})
 		}

--- a/zeroex/order_validator_test.go
+++ b/zeroex/order_validator_test.go
@@ -133,7 +133,7 @@ func TestBatchValidateOffChainCases(t *testing.T) {
 			&testCase.SignedOrder,
 		}
 
-		orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, constants.TestMaxContentLength)
+		orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, constants.TestMaxContentLength, 0)
 		require.NoError(t, err)
 
 		validationResults := orderValidator.BatchValidate(signedOrders, areNewOrders)
@@ -165,7 +165,7 @@ func TestBatchValidateSignatureInvalid(t *testing.T) {
 	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
 
-	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, constants.TestMaxContentLength)
+	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, constants.TestMaxContentLength, 0)
 	require.NoError(t, err)
 
 	validationResults := orderValidator.BatchValidate(signedOrders, areNewOrders)
@@ -194,7 +194,7 @@ func TestBatchValidateUnregisteredCoordinatorSoftCancels(t *testing.T) {
 	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
 
-	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, constants.TestMaxContentLength)
+	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, constants.TestMaxContentLength, 0)
 	require.NoError(t, err)
 
 	validationResults := orderValidator.BatchValidate(signedOrders, areNewOrders)
@@ -218,7 +218,7 @@ func TestBatchValidateCoordinatorSoftCancels(t *testing.T) {
 
 	ethClient, err := ethclient.Dial(constants.GanacheEndpoint)
 	require.NoError(t, err)
-	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, constants.TestMaxContentLength)
+	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, constants.TestMaxContentLength, 0)
 	require.NoError(t, err)
 
 	// generate a test server so we can capture and inspect the request
@@ -263,7 +263,7 @@ func TestComputeOptimalChunkSizesMaxContentLengthTooLow(t *testing.T) {
 	require.NoError(t, err)
 
 	maxContentLength := singleOrderPayloadSize - 10
-	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, maxContentLength)
+	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, maxContentLength, 0)
 	require.NoError(t, err)
 
 	signedOrders := []*SignedOrder{signedOrder}
@@ -280,7 +280,7 @@ func TestComputeOptimalChunkSizes(t *testing.T) {
 	require.NoError(t, err)
 
 	maxContentLength := singleOrderPayloadSize * 3
-	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, maxContentLength)
+	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, maxContentLength, 0)
 	require.NoError(t, err)
 
 	signedOrders := []*SignedOrder{signedOrder, signedOrder, signedOrder, signedOrder}
@@ -317,7 +317,7 @@ func TestComputeOptimalChunkSizesMultiAssetOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	maxContentLength := singleOrderPayloadSize * 3
-	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, maxContentLength)
+	orderValidator, err := NewOrderValidator(ethClient, constants.TestNetworkID, maxContentLength, 0)
 	require.NoError(t, err)
 
 	signedOrders := []*SignedOrder{signedMultiAssetOrder, signedOrder, signedOrder, signedOrder, signedOrder}


### PR DESCRIPTION
Fixes #341.

The problem was occurring because we did not respect the expiration buffer when validating incoming messages. This PR fixes the issue and also uses the same function `IsExpired` in both the expiration watcher and the order validator to avoid these kinds of issues in the future.