### PR TITLE
blockwatch: Fix number to hex encoding bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Upcoming release
 
+### Bug fixes 🐞 
+
+- Fix bug where block number would sometimes be converted to hex with a leading zero, an invalid hex value per the [Ethereum JSON-RPC specification](https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding). ([#353](https://github.com/0xProject/0x-mesh/pull/353))
+
+## v3.0.0-beta
+
 ### Breaking changes 🛠 
 
 - Modified Mesh's validation logic to reject and consider invalid any _partially fillable_ orders. While this is

--- a/ethereum/blockwatch/client.go
+++ b/ethereum/blockwatch/client.go
@@ -3,13 +3,13 @@ package blockwatch
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/0xProject/0x-mesh/meshdb"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -61,7 +61,7 @@ func (rc *RpcClient) HeaderByNumber(number *big.Int) (*meshdb.MiniHeader, error)
 	if number == nil {
 		blockParam = "latest"
 	} else {
-		blockParam = fmt.Sprintf("0x%s", common.Bytes2Hex(number.Bytes()))
+		blockParam = hexutil.EncodeBig(number)
 	}
 	shouldIncludeTransactions := false
 


### PR DESCRIPTION
Fixes: #342 & #323 

Use `hexutil.EncodeBig` instead of `Bytes2Hex` when converting `BigInt` to hex to avoid leading zeroes which are considered invalid encoding by the Ethereum JSON-RPC spec.