### PR TITLE
keys: Add browser support

### DIFF
--- a/keys/fs.go
+++ b/keys/fs.go
@@ -1,0 +1,20 @@
+// +build !js
+
+package keys
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+func readFile(path string) ([]byte, error) {
+	return ioutil.ReadFile(path)
+}
+
+func mkdirAll(dir string) error {
+	return os.MkdirAll(dir, os.ModePerm)
+}
+
+func writeFile(path string, data []byte) error {
+	return ioutil.WriteFile(path, data, os.ModePerm)
+}

--- a/keys/fs_js.go
+++ b/keys/fs_js.go
@@ -33,6 +33,9 @@ func localStorageReadFile(path string) (data []byte, err error) {
 	}()
 	key := getKey(path)
 	rawData := js.Global().Get("localStorage").Call("getItem", key)
+	if rawData == js.Undefined() || rawData == js.Null() {
+		return nil, os.ErrNotExist
+	}
 	return base64.StdEncoding.DecodeString(rawData.String())
 }
 

--- a/keys/fs_js.go
+++ b/keys/fs_js.go
@@ -1,0 +1,131 @@
+// +build js,wasm
+
+package keys
+
+import (
+	"encoding/hex"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"syscall/js"
+)
+
+func readFile(path string) ([]byte, error) {
+	if isBrowserFSSupported() {
+		return browserFSReadFile(path)
+	}
+	return ioutil.ReadFile(path)
+}
+
+func browserFSReadFile(path string) (data []byte, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			if jsErr, ok := e.(js.Error); ok {
+				err = convertJSError(jsErr)
+			}
+		}
+	}()
+	options := map[string]interface{}{
+		"encoding": "hex",
+	}
+	rawData := js.Global().Get("browserFS").Call("readFileSync", path, options)
+	return hex.DecodeString(rawData.String())
+}
+
+func mkdirAll(dir string) error {
+	if isBrowserFSSupported() {
+		return browserFSMkdirall(dir)
+	}
+	return os.MkdirAll(dir, os.ModePerm)
+}
+
+func browserFSMkdirall(dir string) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			if jsErr, ok := e.(js.Error); ok {
+				err = convertJSError(jsErr)
+			}
+		}
+	}()
+	// Note: mkdirAll is not supported by BrowserFS so we have to manually create
+	// each directory.
+	names := strings.Split(dir, string(os.PathSeparator))
+	for i := range names {
+		partialPath := filepath.Join(names[:i+1]...)
+		if err := browserFSMkdir(partialPath); err != nil {
+			if os.IsExist(err) {
+				// If the directory already exists, that's fine.
+				continue
+			}
+		}
+	}
+	return nil
+}
+
+func browserFSMkdir(dir string) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			if jsErr, ok := e.(js.Error); ok {
+				err = convertJSError(jsErr)
+			}
+		}
+	}()
+	js.Global().Get("browserFS").Call("mkdirSync", dir, int(os.ModePerm))
+	return nil
+}
+
+func writeFile(path string, data []byte) error {
+	if isBrowserFSSupported() {
+		return browserFSWriteFile(path, data)
+	}
+	return ioutil.WriteFile(path, data, os.ModePerm)
+}
+
+func browserFSWriteFile(path string, data []byte) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			if jsErr, ok := e.(js.Error); ok {
+				err = convertJSError(jsErr)
+			}
+		}
+	}()
+	// The naive approach of using `string(data)` for the data to write doesn't
+	// work, regardless of the encoding used. Encoding to hex seems like the most
+	// reliable way to do it.
+	options := map[string]interface{}{
+		"encoding": "hex",
+	}
+	js.Global().Get("browserFS").Call("writeFileSync", path, hex.EncodeToString(data), options)
+	return nil
+}
+
+// isBrowserFSSupported returns true if BrowserFS is supported. It does this by
+// checking for the global "browserFS" object.
+func isBrowserFSSupported() bool {
+	return js.Global().Get("browserFS") != js.Null() && js.Global().Get("browserFS") != js.Undefined()
+}
+
+// convertJSError converts an error returned by the BrowserFS API into a Go
+// error. This is important because Go expects certain types of errors to be
+// returned (e.g. ENOENT when a file doesn't exist) and programs often change
+// their behavior depending on the type of error.
+func convertJSError(err js.Error) error {
+	if err.Value == js.Undefined() || err.Value == js.Null() {
+		return nil
+	}
+	// TODO(albrow): Convert to os.PathError when possible/appropriate.
+	if code := err.Get("code"); code != js.Undefined() && code != js.Null() {
+		switch code.String() {
+		case "ENOENT":
+			return os.ErrNotExist
+		case "EISDIR":
+			return syscall.EISDIR
+		case "EEXIST":
+			return os.ErrExist
+			// TODO(albrow): Fill in more codes here.
+		}
+	}
+	return err
+}

--- a/keys/fs_js.go
+++ b/keys/fs_js.go
@@ -3,129 +3,82 @@
 package keys
 
 import (
-	"encoding/hex"
+	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
-	"strings"
-	"syscall"
 	"syscall/js"
 )
 
+// keyPrefix is a prefix applied to all entries in localStorage.
+const keyPrefix = "0x-mesh-keys:"
+
+// getKey returns the localStorage key corresponding to the given path.
+func getKey(path string) string {
+	return keyPrefix + path
+}
+
 func readFile(path string) ([]byte, error) {
-	if isBrowserFSSupported() {
-		return browserFSReadFile(path)
+	if isLocalStorageSupported() {
+		return localStorageReadFile(path)
 	}
 	return ioutil.ReadFile(path)
 }
 
-func browserFSReadFile(path string) (data []byte, err error) {
+func localStorageReadFile(path string) (data []byte, err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			if jsErr, ok := e.(js.Error); ok {
-				err = convertJSError(jsErr)
-			}
+			err = convertRecoverErr(e)
 		}
 	}()
-	options := map[string]interface{}{
-		"encoding": "hex",
-	}
-	rawData := js.Global().Get("browserFS").Call("readFileSync", path, options)
-	return hex.DecodeString(rawData.String())
+	key := getKey(path)
+	rawData := js.Global().Get("localStorage").Call("getItem", key)
+	return base64.StdEncoding.DecodeString(rawData.String())
 }
 
 func mkdirAll(dir string) error {
-	if isBrowserFSSupported() {
-		return browserFSMkdirall(dir)
+	if isLocalStorageSupported() {
+		return localStorageMkdirall(dir)
 	}
 	return os.MkdirAll(dir, os.ModePerm)
 }
 
-func browserFSMkdirall(dir string) (err error) {
-	defer func() {
-		if e := recover(); e != nil {
-			if jsErr, ok := e.(js.Error); ok {
-				err = convertJSError(jsErr)
-			}
-		}
-	}()
-	// Note: mkdirAll is not supported by BrowserFS so we have to manually create
-	// each directory.
-	names := strings.Split(dir, string(os.PathSeparator))
-	for i := range names {
-		partialPath := filepath.Join(names[:i+1]...)
-		if err := browserFSMkdir(partialPath); err != nil {
-			if os.IsExist(err) {
-				// If the directory already exists, that's fine.
-				continue
-			}
-		}
-	}
-	return nil
-}
-
-func browserFSMkdir(dir string) (err error) {
-	defer func() {
-		if e := recover(); e != nil {
-			if jsErr, ok := e.(js.Error); ok {
-				err = convertJSError(jsErr)
-			}
-		}
-	}()
-	js.Global().Get("browserFS").Call("mkdirSync", dir, int(os.ModePerm))
+func localStorageMkdirall(dir string) (err error) {
+	// We don't need to mkdir in localStorage because each path corresponds
+	// exactly to one key.
 	return nil
 }
 
 func writeFile(path string, data []byte) error {
-	if isBrowserFSSupported() {
-		return browserFSWriteFile(path, data)
+	if isLocalStorageSupported() {
+		return localStorageWriteFile(path, data)
 	}
 	return ioutil.WriteFile(path, data, os.ModePerm)
 }
 
-func browserFSWriteFile(path string, data []byte) (err error) {
+func localStorageWriteFile(path string, data []byte) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
-			if jsErr, ok := e.(js.Error); ok {
-				err = convertJSError(jsErr)
-			}
+			err = convertRecoverErr(e)
 		}
 	}()
-	// The naive approach of using `string(data)` for the data to write doesn't
-	// work, regardless of the encoding used. Encoding to hex seems like the most
-	// reliable way to do it.
-	options := map[string]interface{}{
-		"encoding": "hex",
-	}
-	js.Global().Get("browserFS").Call("writeFileSync", path, hex.EncodeToString(data), options)
+	key := getKey(path)
+	encodedData := base64.StdEncoding.EncodeToString(data)
+	js.Global().Get("localStorage").Call("setItem", key, encodedData)
 	return nil
 }
 
-// isBrowserFSSupported returns true if BrowserFS is supported. It does this by
-// checking for the global "browserFS" object.
-func isBrowserFSSupported() bool {
-	return js.Global().Get("browserFS") != js.Null() && js.Global().Get("browserFS") != js.Undefined()
+// isLocalStorageSupported returns true if localStorage is supported. It does
+// this by checking for the global "localStorage" object.
+func isLocalStorageSupported() bool {
+	return js.Global().Get("localStorage") != js.Null() && js.Global().Get("localStorage") != js.Undefined()
 }
 
-// convertJSError converts an error returned by the BrowserFS API into a Go
-// error. This is important because Go expects certain types of errors to be
-// returned (e.g. ENOENT when a file doesn't exist) and programs often change
-// their behavior depending on the type of error.
-func convertJSError(err js.Error) error {
-	if err.Value == js.Undefined() || err.Value == js.Null() {
-		return nil
+func convertRecoverErr(e interface{}) error {
+	switch e := e.(type) {
+	case error:
+		return e
+	default:
+		return fmt.Errorf("recovered with non-error: %v", e)
 	}
-	// TODO(albrow): Convert to os.PathError when possible/appropriate.
-	if code := err.Get("code"); code != js.Undefined() && code != js.Null() {
-		switch code.String() {
-		case "ENOENT":
-			return os.ErrNotExist
-		case "EISDIR":
-			return syscall.EISDIR
-		case "EEXIST":
-			return os.ErrExist
-			// TODO(albrow): Fill in more codes here.
-		}
-	}
-	return err
 }

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -2,15 +2,13 @@ package keys
 
 import (
 	"crypto/rand"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 
 	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
 )
 
 func GetPrivateKeyFromPath(path string) (p2pcrypto.PrivKey, error) {
-	keyBytes, err := ioutil.ReadFile(path)
+	keyBytes, err := readFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +25,7 @@ func GetPrivateKeyFromPath(path string) (p2pcrypto.PrivKey, error) {
 
 func GenerateAndSavePrivateKey(path string) (p2pcrypto.PrivKey, error) {
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+	if err := mkdirAll(dir); err != nil {
 		return nil, err
 	}
 	privKey, _, err := p2pcrypto.GenerateSecp256k1Key(rand.Reader)
@@ -39,7 +37,7 @@ func GenerateAndSavePrivateKey(path string) (p2pcrypto.PrivKey, error) {
 		return nil, err
 	}
 	encodedKey := p2pcrypto.ConfigEncodeKey(keyBytes)
-	if err := ioutil.WriteFile(path, []byte(encodedKey), os.ModePerm); err != nil {
+	if err := writeFile(path, []byte(encodedKey)); err != nil {
 		return nil, err
 	}
 	return privKey, nil

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -1,0 +1,26 @@
+package keys
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAndGetKey(t *testing.T) {
+	path := "/tmp/keys/" + uuid.New().String()
+	generatedKey, err := GenerateAndSavePrivateKey(path)
+	require.NoError(t, err)
+	gotKey, err := GetPrivateKeyFromPath(path)
+	require.NoError(t, err)
+	assert.Equal(t, generatedKey, gotKey)
+}
+
+func TestGetKeyNotExists(t *testing.T) {
+	nonExistentPath := "/tmp/keys/" + uuid.New().String()
+	_, err := GetPrivateKeyFromPath(nonExistentPath)
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err), "error should be a NotExist error, but got: (%T) %s", err, err)
+}


### PR DESCRIPTION
This PR adds browser support to the `keys` package. We do this by mocking a small part of the filesystem using `localStorage`. This allows browser to retain the same private key and peer ID between refreshes.