### PR TITLE
p2p: Fix public IP hack for browser environments

### DIFF
--- a/p2p/node.go
+++ b/p2p/node.go
@@ -484,7 +484,7 @@ func newAddrsFactory(advertiseAddrs []ma.Multiaddr) func([]ma.Multiaddr) []ma.Mu
 }
 
 func getPublicIP() (string, error) {
-	res, err := http.Get("https://ifconfig.me")
+	res, err := http.Get("https://ifconfig.me/ip")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
https://ifconfig.me responds with different results depending on the value of the `User-Agent` header. For browser environments, it responds with HTML and for non-browser environments it responds with your IP address in plain text. Adding `/ip` to the URL results in the same behavior regardless of user agent.