### PR TITLE
p2p: Add WebSocket addresses to bootstrap list

### DIFF
--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -22,7 +22,6 @@ import (
 	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
 	p2pnet "github.com/libp2p/go-libp2p-core/network"
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	"github.com/libp2p/go-libp2p/p2p/host/relay"
@@ -154,16 +153,8 @@ func main() {
 
 	// Protect each other bootstrap peer via the connection manager so that we
 	// maintain an active connection to them.
-	for _, addr := range p2p.BootstrapPeers {
-		idString, err := addr.ValueForProtocol(ma.P_IPFS)
-		if err != nil {
-			log.WithField("error", err).Fatal("could not extract peer id from bootstrap peer")
-		}
-		id, err := peer.IDB58Decode(idString)
-		if err != nil {
-			log.WithField("error", err).Fatal("could not extract peer id from bootstrap peer")
-		}
-		connManager.Protect(id, "bootstrap-peer")
+	for _, addrInfo := range p2p.BootstrapPeers {
+		connManager.Protect(addrInfo.ID, "bootstrap-peer")
 	}
 
 	log.WithFields(map[string]interface{}{

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -7,9 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/libp2p/go-libp2p-core/peer"
-
 	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	dhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
@@ -20,27 +19,67 @@ import (
 const dhtProtocolID = protocol.ID("/0x-mesh-dht/version/1")
 
 // BootstrapPeers is a list of peers to use for bootstrapping the DHT.
-var BootstrapPeers []multiaddr.Multiaddr
+var BootstrapPeers []peer.AddrInfo
 
 func init() {
-	for _, s := range []string{
-		"/ip4/3.214.190.67/tcp/60558/ipfs/16Uiu2HAmGx8Z6gdq5T5AQE54GMtqDhDFhizywTy1o28NJbAMMumF",
-		"/ip4/18.200.96.60/tcp/60558/ipfs/16Uiu2HAkwsDZk4LzXy2rnWANRsyBjB4fhjnsNeJmjgsBqxPGTL32",
-		"/ip4/13.232.193.142/tcp/60558/ipfs/16Uiu2HAkykwoBxwyvoEbaEkuKMeKrmJDPZ2uKFPUKtqd2JbGHUNH",
-		"/dns4/bootstrap-0.mesh.0x.org/tcp/60558/ipfs/16Uiu2HAmGx8Z6gdq5T5AQE54GMtqDhDFhizywTy1o28NJbAMMumF",
-		"/dns4/bootstrap-1.mesh.0x.org/tcp/60558/ipfs/16Uiu2HAkwsDZk4LzXy2rnWANRsyBjB4fhjnsNeJmjgsBqxPGTL32",
-		"/dns4/bootstrap-2.mesh.0x.org/tcp/60558/ipfs/16Uiu2HAkykwoBxwyvoEbaEkuKMeKrmJDPZ2uKFPUKtqd2JbGHUNH",
+	for _, rawInfo := range []struct {
+		addrs  []string
+		peerID string
+	}{
+		{
+			addrs: []string{
+				"/ip4/3.214.190.67/tcp/60558",
+				"/ip4/3.214.190.67/tcp/60559/ws",
+				"/dns4/bootstrap-0.mesh.0x.org/tcp/60558",
+				"/dns4/bootstrap-0.mesh.0x.org/tcp/60559/ws",
+			},
+			peerID: "16Uiu2HAmGx8Z6gdq5T5AQE54GMtqDhDFhizywTy1o28NJbAMMumF",
+		},
+		{
+			addrs: []string{
+				"/ip4/18.200.96.60/tcp/60558",
+				"/ip4/18.200.96.60/tcp/60559/ws",
+				"/dns4/bootstrap-1.mesh.0x.org/tcp/60558",
+				"/dns4/bootstrap-1.mesh.0x.org/tcp/60559/ws",
+			},
+			peerID: "16Uiu2HAkwsDZk4LzXy2rnWANRsyBjB4fhjnsNeJmjgsBqxPGTL32",
+		},
+		{
+			addrs: []string{
+				"/ip4/13.232.193.142/tcp/60558",
+				"/ip4/13.232.193.142/tcp/60559/ws",
+				"/dns4/bootstrap-2.mesh.0x.org/tcp/60558",
+				"/dns4/bootstrap-2.mesh.0x.org/tcp/60559/ws",
+			},
+			peerID: "16Uiu2HAkykwoBxwyvoEbaEkuKMeKrmJDPZ2uKFPUKtqd2JbGHUNH",
+		},
 
 		// These nodes are provided by the libp2p community on a best-effort basis.
 		// We're using them as a backup for increased redundancy.
-		"/ip4/34.201.54.78/tcp/4001/p2p/12D3KooWHwJDdbx73qiBpSCJfg4RuYyzqnLUwfLBqzn77TSy7kRX",
-		"/ip4/18.204.221.103/tcp/4001/p2p/12D3KooWQS6Gsr2kLZvF7DVtoRFtj24aar5jvz88LvJePrawM3EM",
+		{
+			addrs:  []string{"/ip4/34.201.54.78/tcp/4001"},
+			peerID: "12D3KooWHwJDdbx73qiBpSCJfg4RuYyzqnLUwfLBqzn77TSy7kRX",
+		},
+		{
+			addrs:  []string{"/ip4/18.204.221.103/tcp/4001"},
+			peerID: "12D3KooWQS6Gsr2kLZvF7DVtoRFtj24aar5jvz88LvJePrawM3EM",
+		},
 	} {
-		ma, err := multiaddr.NewMultiaddr(s)
+		peerID, err := peer.IDB58Decode(rawInfo.peerID)
 		if err != nil {
 			panic(err)
 		}
-		BootstrapPeers = append(BootstrapPeers, ma)
+		addrInfo := peer.AddrInfo{
+			ID: peerID,
+		}
+		for _, rawAddr := range rawInfo.addrs {
+			addr, err := multiaddr.NewMultiaddr(rawAddr)
+			if err != nil {
+				panic(err)
+			}
+			addrInfo.Addrs = append(addrInfo.Addrs, addr)
+		}
+		BootstrapPeers = append(BootstrapPeers, addrInfo)
 	}
 }
 
@@ -49,25 +88,21 @@ func ConnectToBootstrapList(ctx context.Context, host host.Host) error {
 	connectCtx, cancel := context.WithTimeout(ctx, defaultNetworkTimeout)
 	defer cancel()
 	wg := sync.WaitGroup{}
-	for _, addr := range BootstrapPeers {
-		peerInfo, err := peer.AddrInfoFromP2pAddr(addr)
-		if err != nil {
-			return err
-		}
+	for _, peerInfo := range BootstrapPeers {
 		if peerInfo.ID == host.ID() {
 			// Don't connect to self.
 			continue
 		}
 		wg.Add(1)
-		go func() {
+		go func(peerInfo peer.AddrInfo) {
 			defer wg.Done()
-			if err := host.Connect(connectCtx, *peerInfo); err != nil {
+			if err := host.Connect(connectCtx, peerInfo); err != nil {
 				log.WithFields(map[string]interface{}{
 					"error":    err.Error(),
 					"peerInfo": peerInfo,
 				}).Warn("failed to connect to bootstrap peer")
 			}
-		}()
+		}(peerInfo)
 	}
 	wg.Wait()
 


### PR DESCRIPTION
Related to #360. If each bootstrap nodes is advertising a WebSocket address, we should also update our bootstrap list to include those addresses.

This PR assumes that each bootstrap node will be listening for TCP connections on port `60558` and WebSocket connections on port `60559`.