### PR TITLE
zeroex: Cache order hash calculations

### DIFF
--- a/meshdb/meshdb_test.go
+++ b/meshdb/meshdb_test.go
@@ -58,6 +58,9 @@ func TestOrderCRUDOperations(t *testing.T) {
 		IsRemoved:                false,
 	}
 	require.NoError(t, meshDB.Orders.Insert(order))
+	// We need to call ResetHash so that unexported hash field is equal in later
+	// assertions.
+	signedOrder.ResetHash()
 
 	// Find
 	foundOrder := &Order{}

--- a/rpc/client_server_test.go
+++ b/rpc/client_server_test.go
@@ -157,6 +157,10 @@ func TestAddOrdersSuccess(t *testing.T) {
 	assert.Len(t, validationResponse.Accepted, 1)
 	assert.Len(t, validationResponse.Rejected, 0)
 
+	// We need to call ResetHash so that unexported hash field is equal in later
+	// assertions.
+	signedTestOrder.ResetHash()
+
 	acceptedOrderInfo := validationResponse.Accepted[0]
 	assert.Equal(t, expectedOrderHash, acceptedOrderInfo.OrderHash, "orderHashes did not match")
 	assert.Equal(t, signedTestOrder, acceptedOrderInfo.SignedOrder, "signedOrder did not match")
@@ -213,6 +217,10 @@ func TestGetOrdersSuccess(t *testing.T) {
 	assert.Len(t, getOrdersResponse.OrdersInfos, 1)
 
 	assert.Equal(t, returnedSnapshotID, getOrdersResponse.SnapshotID, "SnapshotID did not match")
+
+	// We need to call ResetHash so that unexported hash field is equal in later
+	// assertions.
+	signedTestOrder.ResetHash()
 
 	orderInfo := getOrdersResponse.OrdersInfos[0]
 	assert.Equal(t, expectedOrderHash, orderInfo.OrderHash, "orderHashes did not match")

--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -64,6 +64,11 @@ func TestMarshalUnmarshalOrderEvent(t *testing.T) {
 	buf := &bytes.Buffer{}
 	require.NoError(t, json.NewEncoder(buf).Encode(orderEvent))
 	var decoded OrderEvent
+
+	// We need to call ResetHash so that unexported hash field is equal in later
+	// assertions.
+	signedOrder.ResetHash()
+
 	require.NoError(t, json.NewDecoder(buf).Decode(&decoded))
 	assert.Equal(t, orderEvent, decoded)
 }


### PR DESCRIPTION
Copied over from #167, this PR introduces a performance optimization by caching order hashes instead of computing them multiple times for the same order. 

This optimization has become increasingly relevant as we're testing Mesh in the browser. Performance profiling in Firefox and Chrome revealed that computing order hashes was taking a significant amount of CPU time. This PR reduces it from 2.5% total CPU time to 0.6%.