### PR TITLE
cmd/mesh: Exit the process if the database is closed

### DIFF
--- a/cmd/mesh/main.go
+++ b/cmd/mesh/main.go
@@ -59,6 +59,6 @@ func main() {
 		}
 	}()
 
-	// Block forever or until the app is closed.
-	select {}
+	// Block until there is an error or the app is closed.
+	<-ctx.Done()
 }


### PR DESCRIPTION
Should fix #319. It's difficult to test because I can't reproduce the original error.

I did do a bit of manual testing by adding some code to forcibly close the database after 30 seconds. I can confirm that in this case Mesh exited and logged the error as expected.