### PR TITLE
loghooks: Add some previously uncovered types to KeySuffixHook

### DIFF
--- a/loghooks/key_suffix_hook.go
+++ b/loghooks/key_suffix_hook.go
@@ -76,9 +76,21 @@ func getTypeForValue(val interface{}) (string, error) {
 		// encoding.TextMarshaler as a string.
 		return "string", nil
 	}
+	if _, ok := val.(error); ok {
+		// The json package always encodes values that implement
+		// error as a string.
+		return "string", nil
+	}
 
 	underlyingType := getUnderlyingType(reflect.TypeOf(val))
 	switch kind := underlyingType.Kind(); kind {
+	case reflect.Ptr:
+		reflectVal := reflect.ValueOf(val)
+		if !reflectVal.IsNil() {
+			return getTypeForValue(reflectVal.Elem())
+		} else {
+			return "null", nil
+		}
 	case reflect.Bool:
 		return "bool", nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:

--- a/loghooks/key_suffix_hook_test.go
+++ b/loghooks/key_suffix_hook_test.go
@@ -1,7 +1,9 @@
 package loghooks
 
 import (
+	"errors"
 	"fmt"
+	"syscall"
 	"testing"
 
 	"github.com/0xProject/0x-mesh/constants"
@@ -86,6 +88,14 @@ func TestGetTypeForValue(t *testing.T) {
 			expected: "string",
 		},
 		{
+			input:    errors.New("this is an error"),
+			expected: "string",
+		},
+		{
+			input:    syscall.Errno(1),
+			expected: "string",
+		},
+		{
 			input:    func() {},
 			expected: "string",
 		},
@@ -103,6 +113,10 @@ func TestGetTypeForValue(t *testing.T) {
 		},
 		{
 			input:    myStruct{},
+			expected: "loghooks_myStruct",
+		},
+		{
+			input:    &myStruct{},
 			expected: "loghooks_myStruct",
 		},
 		{


### PR DESCRIPTION
I noticed the correct suffix was not being added for certain types in the logs. This PR should fix the issue.