### PR TITLE
Incorporate onOrderEvents callback in integration tests

### DIFF
--- a/integration-tests/browser/src/index.ts
+++ b/integration-tests/browser/src/index.ts
@@ -16,14 +16,13 @@ import { Mesh, OrderEvent, SignedOrder, BigNumber } from '@0x/mesh-browser';
     });
 
     // This handler will be called whenever an order is added, expired,
-    // canceled, or filled.
-    // TODO(albrow): Log this event and check for it in the integration tests
-    // instead of relying on the interal logs from the core package.
-    // mesh.onOrderEvents((events: Array<OrderEvent>) => {
-    //     for (let event of events) {
-    //         // console.log('received order event: ' + JSON.stringify(event));
-    //     }
-    // });
+    // canceled, or filled. We will check for certain events to be logged in the
+    // integration tests.
+    mesh.onOrderEvents((events: Array<OrderEvent>) => {
+        for (let event of events) {
+            console.log(JSON.stringify(event));
+        }
+    });
 
     // Start Mesh *after* we set up the handlers.
     await mesh.startAsync();


### PR DESCRIPTION
The previous version of the integration tests did not cover the `onOrderEvents` callback and instead looked directly at the logs coming from Mesh (e.g. the `core` and `p2p` packages). This PR improves the tests by explicitly logging events that come through the `onOrderEvents` callback and then checking for the logs we expect.

I also thought about checking the `mesh_subscribe orders` RPC endpoint, but doing that right now is prohibitively complicated due to unpredictable timing in the order of events. It's hard to make sure we subscribe to the RPC endpoint in time to receive the order, and if we aren't subscribed, we'll simply miss it. In addition, unlike the `onOrderEvents` callback, the `rpc` package is already tested elsewhere. So in order to make sure the standalone node receives the order sent by the browser node, we still just look at the logs coming from the standalone node.