### PR TITLE
orderwatch: Update lastUpdated and fillableTakerAssetAmount for order in DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This changelog is a work in progress and may contain notes for versions which ha
 ### Bug fixes 🐞 
 
 - Fixed two related bugs: One where order expiration events would be emitted multiple times and another that meant subsequent fill/cancel events for orders deemed expired were not emitted. Fills/cancels for expired orders will continue to be emitted if they occur within ~4 mins (i.e. 20 blocks) of the expiration ([#385](https://github.com/0xProject/0x-mesh/pull/385)).
+- Fixed a data race-condition in OrderWatcher that could have caused order collection updates to be overwritten in the DB. ([#386](https://github.com/0xProject/0x-mesh/pull/386))
+- Fixed a bug where `fillableTakerAssetAmount` and `lastUpdated` were not always being properly updated in the DB. ([#386](https://github.com/0xProject/0x-mesh/pull/386))
 - Fixed some issues with key prefixes for certain types not being applied correctly to logs ([#375](https://github.com/0xProject/0x-mesh/pull/375)).
 - Fixed an issue where order hashes were not being correctly logged ([#368](https://github.com/0xProject/0x-mesh/pull/368)).
 - Mesh will now properly shut down if the database is unexpectedly closed ([#370](https://github.com/0xProject/0x-mesh/pull/370)).

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -613,10 +613,10 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 			orderEvents = append(orderEvents, orderEvent)
 		} else if oldFillableAmount.Cmp(newFillableAmount) == 0 {
 			// No important state-change happened, simply update lastUpdated timestamp in DB
-			w.updateOrderLastUpdatedAndFillableAmount(order)
+			w.updateOrderDBEntry(order)
 		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && oldAmountIsMoreThenNewAmount {
 			// Order was filled, emit  event and update order in DB
-			w.updateOrderLastUpdatedAndFillableAmount(order)
+			w.updateOrderDBEntry(order)
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,
 				SignedOrder:              order.SignedOrder,
@@ -628,7 +628,7 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && !oldAmountIsMoreThenNewAmount {
 			// The order is now fillable for more then it was before. E.g.: A fill txn reverted (block-reorg)
 			// Update order in DB and emit event
-			w.updateOrderLastUpdatedAndFillableAmount(order)
+			w.updateOrderDBEntry(order)
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,
 				SignedOrder:              order.SignedOrder,
@@ -650,7 +650,7 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 			if oldFillableAmount.Cmp(big.NewInt(0)) == 0 {
 				// If the oldFillableAmount was already 0, this order is already flagged for removal.
 				// Update it's lastUpdated timestamp in DB
-				w.updateOrderLastUpdatedAndFillableAmount(order)
+				w.updateOrderDBEntry(order)
 			} else {
 				// If oldFillableAmount > 0, it got fullyFilled, cancelled, expired or unfunded, emit event
 				w.unwatchOrder(order, big.NewInt(0))
@@ -687,9 +687,8 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 	return nil
 }
 
-func (w *Watcher) updateOrderLastUpdatedAndFillableAmount(order *meshdb.Order) {
+func (w *Watcher) updateOrderDBEntry(order *meshdb.Order) {
 	order.LastUpdated = time.Now().UTC()
-	order.FillableTakerAssetAmount = order.FillableTakerAssetAmount
 	err := w.meshDB.Orders.Update(order)
 	if err != nil {
 		logger.WithFields(logger.Fields{

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -382,7 +382,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 					}
 					return err
 				}
-				order := w.findOrderAndGenerateOrderEvents(exchangeFillEvent.OrderHash)
+				order := w.findOrder(exchangeFillEvent.OrderHash)
 				if order != nil {
 					orders = append(orders, order)
 				}
@@ -397,7 +397,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 					return err
 				}
 				orders = []*meshdb.Order{}
-				order := w.findOrderAndGenerateOrderEvents(exchangeCancelEvent.OrderHash)
+				order := w.findOrder(exchangeCancelEvent.OrderHash)
 				if order != nil {
 					orders = append(orders, order)
 				}
@@ -536,7 +536,7 @@ type OrderWithTxHashes struct {
 	TxHashes map[common.Hash]interface{}
 }
 
-func (w *Watcher) findOrderAndGenerateOrderEvents(orderHash common.Hash) *meshdb.Order {
+func (w *Watcher) findOrder(orderHash common.Hash) *meshdb.Order {
 	order := meshdb.Order{}
 	err := w.meshDB.Orders.FindByID(orderHash.Bytes(), &order)
 	if err != nil {

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -226,7 +226,7 @@ func (w *Watcher) handleExpiration(expiredOrders []expirationwatch.ExpiredItem) 
 			FillableTakerAssetAmount: big.NewInt(0),
 			OrderStatus:              zeroex.OSExpired,
 		}
-		w.unwatchOrder(order, order.FillableTakerAssetAmount)
+		w.unwatchOrder(w.meshDB.Orders, order, order.FillableTakerAssetAmount)
 
 		orderEvent := &zeroex.OrderEvent{
 			OrderHash:                orderInfo.OrderHash,
@@ -565,6 +565,7 @@ func (w *Watcher) findOrders(makerAddress, tokenAddress common.Address, tokenID 
 }
 
 func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[common.Hash]*OrderWithTxHashes) error {
+	ordersColTxn := w.meshDB.Orders.OpenTransaction()
 	signedOrders := []*zeroex.SignedOrder{}
 	for _, orderWithTxHashes := range hashToOrderWithTxHashes {
 		order := orderWithTxHashes.Order
@@ -602,7 +603,7 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 			// A previous event caused this order to be removed from DB because it's
 			// fillableAmount became 0, but it has now been revived (e.g., block re-org
 			// causes order fill txn to get reverted). We need to re-add order and emit an event.
-			w.rewatchOrder(order, acceptedOrderInfo)
+			w.rewatchOrder(ordersColTxn, order, acceptedOrderInfo)
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,
 				SignedOrder:              order.SignedOrder,
@@ -613,10 +614,10 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 			orderEvents = append(orderEvents, orderEvent)
 		} else if oldFillableAmount.Cmp(newFillableAmount) == 0 {
 			// No important state-change happened, simply update lastUpdated timestamp in DB
-			w.updateOrderDBEntry(order)
+			w.updateOrderDBEntry(ordersColTxn, order)
 		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && oldAmountIsMoreThenNewAmount {
 			// Order was filled, emit  event and update order in DB
-			w.updateOrderDBEntry(order)
+			w.updateOrderDBEntry(ordersColTxn, order)
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,
 				SignedOrder:              order.SignedOrder,
@@ -628,7 +629,7 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && !oldAmountIsMoreThenNewAmount {
 			// The order is now fillable for more then it was before. E.g.: A fill txn reverted (block-reorg)
 			// Update order in DB and emit event
-			w.updateOrderDBEntry(order)
+			w.updateOrderDBEntry(ordersColTxn, order)
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,
 				SignedOrder:              order.SignedOrder,
@@ -650,10 +651,10 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 			if oldFillableAmount.Cmp(big.NewInt(0)) == 0 {
 				// If the oldFillableAmount was already 0, this order is already flagged for removal.
 				// Update it's lastUpdated timestamp in DB
-				w.updateOrderDBEntry(order)
+				w.updateOrderDBEntry(ordersColTxn, order)
 			} else {
 				// If oldFillableAmount > 0, it got fullyFilled, cancelled, expired or unfunded, emit event
-				w.unwatchOrder(order, big.NewInt(0))
+				w.unwatchOrder(ordersColTxn, order, big.NewInt(0))
 				kind, ok := zeroex.ConvertRejectOrderCodeToOrderEventKind(rejectedOrderInfo.Status)
 				if !ok {
 					err := fmt.Errorf("no OrderEventKind corresponding to RejectedOrderStatus: %q", rejectedOrderInfo.Status)
@@ -681,15 +682,25 @@ func (w *Watcher) generateOrderEventsIfChanged(hashToOrderWithTxHashes map[commo
 			return err
 		}
 	}
+	if err := ordersColTxn.Commit(); err != nil {
+		logger.WithFields(logger.Fields{
+			"error": err.Error(),
+		}).Error("Failed to commit orders collection transaction")
+	}
+
 	if len(orderEvents) > 0 {
 		w.orderFeed.Send(orderEvents)
 	}
 	return nil
 }
 
-func (w *Watcher) updateOrderDBEntry(order *meshdb.Order) {
+type updatableOrdersCol interface {
+	Update(model db.Model) error
+}
+
+func (w *Watcher) updateOrderDBEntry(u updatableOrdersCol, order *meshdb.Order) {
 	order.LastUpdated = time.Now().UTC()
-	err := w.meshDB.Orders.Update(order)
+	err := u.Update(order)
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"error": err.Error(),
@@ -698,11 +709,11 @@ func (w *Watcher) updateOrderDBEntry(order *meshdb.Order) {
 	}
 }
 
-func (w *Watcher) rewatchOrder(order *meshdb.Order, orderInfo *zeroex.AcceptedOrderInfo) {
+func (w *Watcher) rewatchOrder(u updatableOrdersCol, order *meshdb.Order, orderInfo *zeroex.AcceptedOrderInfo) {
 	order.IsRemoved = false
 	order.LastUpdated = time.Now().UTC()
 	order.FillableTakerAssetAmount = orderInfo.FillableTakerAssetAmount
-	err := w.meshDB.Orders.Update(order)
+	err := u.Update(order)
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"error": err.Error(),
@@ -715,11 +726,11 @@ func (w *Watcher) rewatchOrder(order *meshdb.Order, orderInfo *zeroex.AcceptedOr
 	w.expirationWatcher.Add(expirationTimestamp, order.Hash.Hex())
 }
 
-func (w *Watcher) unwatchOrder(order *meshdb.Order, newFillableAmount *big.Int) {
+func (w *Watcher) unwatchOrder(u updatableOrdersCol, order *meshdb.Order, newFillableAmount *big.Int) {
 	order.IsRemoved = true
 	order.LastUpdated = time.Now().UTC()
 	order.FillableTakerAssetAmount = newFillableAmount
-	err := w.meshDB.Orders.Update(order)
+	err := u.Update(order)
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"error": err.Error(),

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -272,7 +272,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 					}
 					return err
 				}
-				orders, err = w.findOrdersAndGenerateOrderEvents(transferEvent.From, log.Address, nil)
+				orders, err = w.findOrders(transferEvent.From, log.Address, nil)
 				if err != nil {
 					return err
 				}
@@ -290,7 +290,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 				if approvalEvent.Spender != w.contractAddresses.ERC20Proxy {
 					continue
 				}
-				orders, err = w.findOrdersAndGenerateOrderEvents(approvalEvent.Owner, log.Address, nil)
+				orders, err = w.findOrders(approvalEvent.Owner, log.Address, nil)
 				if err != nil {
 					return err
 				}
@@ -304,7 +304,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 					}
 					return err
 				}
-				orders, err = w.findOrdersAndGenerateOrderEvents(transferEvent.From, log.Address, transferEvent.TokenId)
+				orders, err = w.findOrders(transferEvent.From, log.Address, transferEvent.TokenId)
 				if err != nil {
 					return err
 				}
@@ -322,7 +322,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 				if approvalEvent.Approved != w.contractAddresses.ERC721Proxy {
 					continue
 				}
-				orders, err = w.findOrdersAndGenerateOrderEvents(approvalEvent.Owner, log.Address, approvalEvent.TokenId)
+				orders, err = w.findOrders(approvalEvent.Owner, log.Address, approvalEvent.TokenId)
 				if err != nil {
 					return err
 				}
@@ -340,7 +340,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 				if approvalForAllEvent.Operator != w.contractAddresses.ERC721Proxy {
 					continue
 				}
-				orders, err = w.findOrdersAndGenerateOrderEvents(approvalForAllEvent.Owner, log.Address, nil)
+				orders, err = w.findOrders(approvalForAllEvent.Owner, log.Address, nil)
 				if err != nil {
 					return err
 				}
@@ -354,7 +354,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 					}
 					return err
 				}
-				orders, err = w.findOrdersAndGenerateOrderEvents(withdrawalEvent.Owner, log.Address, nil)
+				orders, err = w.findOrders(withdrawalEvent.Owner, log.Address, nil)
 				if err != nil {
 					return err
 				}
@@ -368,7 +368,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 					}
 					return err
 				}
-				orders, err = w.findOrdersAndGenerateOrderEvents(depositEvent.Owner, log.Address, nil)
+				orders, err = w.findOrders(depositEvent.Owner, log.Address, nil)
 				if err != nil {
 					return err
 				}
@@ -553,7 +553,7 @@ func (w *Watcher) findOrderAndGenerateOrderEvents(orderHash common.Hash) *meshdb
 	return &order
 }
 
-func (w *Watcher) findOrdersAndGenerateOrderEvents(makerAddress, tokenAddress common.Address, tokenID *big.Int) ([]*meshdb.Order, error) {
+func (w *Watcher) findOrders(makerAddress, tokenAddress common.Address, tokenID *big.Int) ([]*meshdb.Order, error) {
 	orders, err := w.meshDB.FindOrdersByMakerAddressTokenAddressAndTokenID(makerAddress, tokenAddress, tokenID)
 	if err != nil {
 		logger.WithFields(logger.Fields{


### PR DESCRIPTION
Fixes: #190 

Currently, we aren't updating an orders `fillableTakerAssetAmount` nor it's `lastUpdated` timestamp in the DB when processing a contract event impacting it _unless_ it is being unwatched or re-watched. This PR makes it such that we always update an order's DB entry, no matter what the event so that the `lastUpdated` and `fillableTakerAssetAmount` in the DB is always accurate.