### PR TITLE
Remove sleep from transaction exclusion tests

### DIFF
--- a/db/global_transaction_test.go
+++ b/db/global_transaction_test.go
@@ -97,9 +97,9 @@ func TestGlobalTransaction(t *testing.T) {
 	// is committed/discarded. We use two channels to determine the order in which
 	// the two events occurred.
 	// commitSignal is fired right before the transaction is committed.
-	commitSignal := make(chan struct{}, 1)
+	commitSignal := make(chan struct{})
 	// newCollectionSignal is fired after the new collection has been created.
-	newCollectionSignal := make(chan struct{}, 1)
+	newCollectionSignal := make(chan struct{})
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -120,7 +120,7 @@ func TestGlobalTransaction(t *testing.T) {
 		_, err := db.NewCollection("people2", &testModel{})
 		require.NoError(t, err)
 		// Signal that the new collection was created.
-		newCollectionSignal <- struct{}{}
+		close(newCollectionSignal)
 	}()
 
 	// Make sure that col0 only contains models that were created before the
@@ -141,10 +141,10 @@ func TestGlobalTransaction(t *testing.T) {
 	// that the mutexes are the thing enforcing that no new collections are
 	// created and no new writes are made to the db state until after the global
 	// transaction is committed.
-	time.Sleep(transactionTestSleepDuration)
+	time.Sleep(50 * time.Millisecond)
 
 	// Signal that we are about to commit the transaction, then commit it.
-	commitSignal <- struct{}{}
+	close(commitSignal)
 	require.NoError(t, txn.Commit())
 
 	// Wait for any goroutines to finish.
@@ -281,50 +281,19 @@ func TestGlobalTransactionExclusion(t *testing.T) {
 		_ = txn.Discard()
 	}()
 
-	// discardSignal is fired right before the original global transaction is
-	// discarded.
-	discardSignal := make(chan struct{}, 1)
 	// newGlobalTxnOpenSignal is fired when a new global transaction is opened.
-	newGlobalTxnOpenSignal := make(chan struct{}, 1)
+	newGlobalTxnOpenSignal := make(chan struct{})
 	// col0TxnOpenSignal is fired when a transaction on col0 is opened.
-	col0TxnOpenSignal := make(chan struct{}, 1)
+	col0TxnOpenSignal := make(chan struct{})
 	// col1TxnOpenSignal is fired when a transaction on col1 is opened.
-	col1TxnOpenSignal := make(chan struct{}, 1)
+	col1TxnOpenSignal := make(chan struct{})
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		for {
-			select {
-			case <-discardSignal:
-				// Expected outcome. Return from the goroutine.
-				return
-			case <-newGlobalTxnOpenSignal:
-				t.Error("a new global transaction was opened before the first was committed/discarded")
-			case <-col0TxnOpenSignal:
-				t.Error("a new transaction was opened on col0 before the global transaction was committed/discarded")
-			case <-col1TxnOpenSignal:
-				t.Error("a new transaction was opened on col1 before the global transaction was committed/discarded")
-			}
-		}
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		txn := db.OpenGlobalTransaction()
-		newGlobalTxnOpenSignal <- struct{}{}
-		defer func() {
-			_ = txn.Discard()
-		}()
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
 		txn := col0.OpenTransaction()
-		col0TxnOpenSignal <- struct{}{}
+		close(col0TxnOpenSignal)
 		defer func() {
 			_ = txn.Discard()
 		}()
@@ -334,15 +303,59 @@ func TestGlobalTransactionExclusion(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		txn := col1.OpenTransaction()
-		col1TxnOpenSignal <- struct{}{}
+		close(col1TxnOpenSignal)
 		defer func() {
 			_ = txn.Discard()
 		}()
 	}()
 
-	time.Sleep(transactionTestSleepDuration)
-	discardSignal <- struct{}{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		txn := db.OpenGlobalTransaction()
+		close(newGlobalTxnOpenSignal)
+		defer func() {
+			_ = txn.Discard()
+		}()
+	}()
+
+	select {
+	case <-time.After(transactionExclusionTestTimeout):
+		// Expected outcome. Return from the goroutine.
+		return
+	case <-newGlobalTxnOpenSignal:
+		t.Error("a new global transaction was opened before the first was committed/discarded")
+	case <-col0TxnOpenSignal:
+		t.Error("a new transaction was opened on col0 before the global transaction was committed/discarded")
+	case <-col1TxnOpenSignal:
+		t.Error("a new transaction was opened on col1 before the global transaction was committed/discarded")
+	}
+
+	// Discard the first global transaction.
 	require.NoError(t, txn.Discard())
 
+	// Check that col0 and col1 transactions are opened.
+	wasCol0TxnOpened := false
+	wasCol1TxnOpened := false
+	wasNewGlobalTxnOpened := false
+	txnOpenTimeout := time.After(transactionExclusionTestTimeout)
+	for {
+		if wasCol0TxnOpened && wasCol1TxnOpened && wasNewGlobalTxnOpened {
+			// All three transactions were opened. Break the for loop.
+			break
+		}
+		select {
+		case <-txnOpenTimeout:
+			t.Fatalf("timed out waiting for one or more transactions to open (tx0: %t, txn1: %t, global: %t)", wasCol0TxnOpened, wasCol1TxnOpened, wasNewGlobalTxnOpened)
+		case <-col0TxnOpenSignal:
+			wasCol0TxnOpened = true
+		case <-col1TxnOpenSignal:
+			wasCol1TxnOpened = true
+		case <-newGlobalTxnOpenSignal:
+			wasNewGlobalTxnOpened = true
+		}
+	}
+
+	// Wait for all goroutines to exit.
 	wg.Wait()
 }


### PR DESCRIPTION
This PR rewrites the transaction exclusion tests to avoid using `time.Sleep` when possible. Hopefully this will help reduce the rate of sporadic failures on CI.

Fundamentally, these tests are hard to write because in some cases we are checking that events _do not_ to occur over a certain time frame. Another complication is that CI performs differently (especially when running the tests in the browser) and has a different timing for certain events.

The tests are still not perfect and there are some cases where a difference in timing can lead to a false positive, but this PR should still make things a lot better.