### PR TITLE
p2p: Add ability to ban IP addresses

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,6 +37,72 @@
   revision = "4063feeff79a0da1b08cc857e89d4602e91a294c"
 
 [[projects]]
+  branch = "master"
+  digest = "1:70df0bb21a1a4847f05c0cdfaadc39468f13cdabf0bdfde01bc89b1ae4c074eb"
+  name = "github.com/chromedp/cdproto"
+  packages = [
+    ".",
+    "accessibility",
+    "animation",
+    "applicationcache",
+    "audits",
+    "backgroundservice",
+    "browser",
+    "cachestorage",
+    "cast",
+    "cdp",
+    "css",
+    "database",
+    "debugger",
+    "deviceorientation",
+    "dom",
+    "domdebugger",
+    "domsnapshot",
+    "domstorage",
+    "emulation",
+    "fetch",
+    "headlessexperimental",
+    "heapprofiler",
+    "indexeddb",
+    "input",
+    "inspector",
+    "io",
+    "layertree",
+    "log",
+    "media",
+    "memory",
+    "network",
+    "overlay",
+    "page",
+    "performance",
+    "profiler",
+    "runtime",
+    "security",
+    "serviceworker",
+    "storage",
+    "systeminfo",
+    "target",
+    "tethering",
+    "tracing",
+    "webaudio",
+    "webauthn",
+  ]
+  pruneopts = "UT"
+  revision = "b5ac1e37ce90b05a556d6d6ce1f4beee5e8cd23e"
+
+[[projects]]
+  digest = "1:2e5122f1f956687cbebd5e652857b28a593a26eef899ac14c5c3437b6f640cf6"
+  name = "github.com/chromedp/chromedp"
+  packages = [
+    ".",
+    "device",
+    "kb",
+  ]
+  pruneopts = "UT"
+  revision = "c956994840a529a4f213d4b27346bfeee1beec05"
+  version = "v0.4.0"
+
+[[projects]]
   digest = "1:05ffeeed3f0f05520de0679f6aa3219ffee69cfd6d9fb6c194879d4c818ad670"
   name = "github.com/coreos/go-semver"
   packages = ["semver"]
@@ -143,6 +209,38 @@
   pruneopts = "UT"
   revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
   version = "v1.8.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:368ba96ddacaae2fe265afcac3062a199908f7dc0c6569d6e05a7a13042cccf1"
+  name = "github.com/gobwas/httphead"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2c6c146eadee0b69f856f87e3e9f1d0cd6aad2f5"
+
+[[projects]]
+  digest = "1:bdfe3b97ff03e4f7252c74cfaefb20050a360c8fb760701014ebf99c9540abd1"
+  name = "github.com/gobwas/pool"
+  packages = [
+    ".",
+    "internal/pmath",
+    "pbufio",
+    "pbytes",
+  ]
+  pruneopts = "UT"
+  revision = "fa3125c39d7eca32e1387bb69b1b38dcb31b1e0b"
+  version = "v0.2.0"
+
+[[projects]]
+  digest = "1:aea6697202cefa9365797c4c8ad0a1dbdf15ba21600ddc599a9000629a2ecb6f"
+  name = "github.com/gobwas/ws"
+  packages = [
+    ".",
+    "wsutil",
+  ]
+  pruneopts = "UT"
+  revision = "05baaea2bbcfe8963301c62d9931c882d59595cd"
+  version = "v1.0.2"
 
 [[projects]]
   digest = "1:d0e00c8ccabdfe678667d6be78c9d08a6a4efc36d9fb596f098706728b00ba6b"
@@ -331,6 +429,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:8cb15b21828b36ad568850d0ecb9340e22b148c8c6755f4a3d7918021bfc38a2"
+  name = "github.com/knq/sysutil"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f05b59f0f3075ba1bc5701ef0df4393a05ebd0e7"
+
+[[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -361,6 +467,14 @@
   pruneopts = "UT"
   revision = "c4a5988a1e475884367015e1a2d0bd5fa4c491f4"
   version = "v0.0.2"
+
+[[projects]]
+  digest = "1:6a443af5bfbc3cd231972c06ce15d8e396486bf57a9115fac6c1bc76eb68bcc5"
+  name = "github.com/libp2p/go-conn-security"
+  packages = ["insecure"]
+  pruneopts = "UT"
+  revision = "5f8143019e00897f3f6776723f2ca9230904458b"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:041a5219e2f0c1fa2af5d25aee6970600ba2ac055ba386c18cfe960d392df3db"
@@ -608,6 +722,14 @@
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:f55b1d675b33c91230c833c99b7aa1a03f9eda84ab775d2ecddd8136cb2d2faa"
+  name = "github.com/libp2p/go-libp2p-transport"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2406e91c260757c7cf63c70ad20073f5a7b29af4"
+  version = "v0.1.0"
+
+[[projects]]
   digest = "1:2fcb80000123d80148ce210a053a226d52dc891419905d7ff076c164825da50d"
   name = "github.com/libp2p/go-libp2p-transport-upgrader"
   packages = ["."]
@@ -713,6 +835,19 @@
   pruneopts = "UT"
   revision = "663972181d409e7263040f0b668462f87c85e1bd"
   version = "v1.2.3"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ad157c87bae81a72ca4cc7b5d2da8907eeedf060ac9828833bfa3013982f6f66"
+  name = "github.com/mailru/easyjson"
+  packages = [
+    ".",
+    "buffer",
+    "jlexer",
+    "jwriter",
+  ]
+  pruneopts = "UT"
+  revision = "b2ccc519800e761ac8000b95e5d57c80a897ff9e"
 
 [[projects]]
   digest = "1:7c084e0e780596dd2a7e20d25803909a9a43689c153de953520dfbc0b0e51166"
@@ -825,15 +960,6 @@
   pruneopts = "UT"
   revision = "039807e4901c4b2041f40a0e4aa32d72939608aa"
   version = "v0.1.0"
-
-[[projects]]
-  branch = "support-arrays"
-  digest = "1:0d4c99af326c5aa0cb55940961953f9772cc84e765f3a90110a4501dcccdae90"
-  name = "github.com/norunners/vert"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "32b044758d63e7074e457e97fd1ca54f01448b16"
-  source = "github.com/albrow/vert"
 
 [[projects]]
   branch = "master"
@@ -1218,6 +1344,8 @@
   analyzer-version = 1
   input-imports = [
     "github.com/albrow/stringset",
+    "github.com/chromedp/cdproto/runtime",
+    "github.com/chromedp/chromedp",
     "github.com/ethereum/go-ethereum",
     "github.com/ethereum/go-ethereum/accounts",
     "github.com/ethereum/go-ethereum/accounts/abi",
@@ -1234,17 +1362,23 @@
     "github.com/google/uuid",
     "github.com/hashicorp/golang-lru",
     "github.com/ipfs/go-ds-leveldb",
+    "github.com/ipfs/go-log",
     "github.com/jpillora/backoff",
+    "github.com/libp2p/go-conn-security-multistream",
+    "github.com/libp2p/go-conn-security/insecure",
     "github.com/libp2p/go-libp2p",
     "github.com/libp2p/go-libp2p-autonat-svc",
     "github.com/libp2p/go-libp2p-circuit",
     "github.com/libp2p/go-libp2p-connmgr",
     "github.com/libp2p/go-libp2p-core/crypto",
     "github.com/libp2p/go-libp2p-core/host",
+    "github.com/libp2p/go-libp2p-core/mux",
     "github.com/libp2p/go-libp2p-core/network",
     "github.com/libp2p/go-libp2p-core/peer",
+    "github.com/libp2p/go-libp2p-core/pnet",
     "github.com/libp2p/go-libp2p-core/protocol",
     "github.com/libp2p/go-libp2p-core/routing",
+    "github.com/libp2p/go-libp2p-core/sec",
     "github.com/libp2p/go-libp2p-crypto",
     "github.com/libp2p/go-libp2p-discovery",
     "github.com/libp2p/go-libp2p-kad-dht",
@@ -1254,11 +1388,17 @@
     "github.com/libp2p/go-libp2p-peerstore/pstoreds",
     "github.com/libp2p/go-libp2p-pubsub",
     "github.com/libp2p/go-libp2p-swarm",
+    "github.com/libp2p/go-libp2p-transport",
+    "github.com/libp2p/go-libp2p-transport-upgrader",
+    "github.com/libp2p/go-libp2p/config",
+    "github.com/libp2p/go-libp2p/p2p/host/basic",
     "github.com/libp2p/go-libp2p/p2p/host/relay",
+    "github.com/libp2p/go-libp2p/p2p/host/routed",
+    "github.com/libp2p/go-maddr-filter",
+    "github.com/libp2p/go-stream-muxer-multistream",
     "github.com/libp2p/go-ws-transport",
     "github.com/multiformats/go-multiaddr",
     "github.com/multiformats/go-multiaddr-dns",
-    "github.com/norunners/vert",
     "github.com/ocdogan/rbt",
     "github.com/plaid/go-envvar/envvar",
     "github.com/sirupsen/logrus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,7 +114,14 @@
   source = "github.com/0xProject/go-ws-transport"
   revision = "163cee1e07594cd148a9086cd3cce5f901e4dae9"
 
-[[constraint]]	
-  branch = "support-arrays"	
-  name = "github.com/norunners/vert"	
-  source = "github.com/albrow/vert"
+[[constraint]]
+  name = "github.com/libp2p/go-libp2p-circuit"
+  version = "0.1.1"
+
+[[constraint]]
+  name = "github.com/libp2p/go-libp2p-swarm"
+  version = "0.2.0"
+
+[[constraint]]
+  name = "github.com/libp2p/go-maddr-filter"
+  version = "0.0.5"

--- a/integration-tests/browser/package.json
+++ b/integration-tests/browser/package.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "private": true,
     "scripts": {
-        "build": "node --max_old_space_size=4096 ./node_modules/webpack/bin/webpack.js",
+        "build": "node --max_old_space_size=4096 ./node_modules/webpack/bin/webpack.js --mode=development",
         "postinstall": "yarn rimraf ./node_modules/@0x/mesh-browser/go ./node_modules/@0x/mesh-browser/scripts"
     },
     "devDependencies": {

--- a/p2p/host.go
+++ b/p2p/host.go
@@ -1,0 +1,269 @@
+// Note: the code in this file is largely copied from
+// https://github.com/libp2p/go-libp2p/config with some modifications in order
+// to support configuring the swarm.
+//
+// Copyright (c) 2014 Juan Batiz-Benet
+// Modified work copyright (c) 2019 ZeroEx, Inc.
+//
+// The code in this file falls under the MIT license located at:
+// https://github.com/libp2p/go-libp2p/blob/v0.3.0/LICENSE
+//
+
+package p2p
+
+import (
+	"context"
+	"fmt"
+
+	logging "github.com/ipfs/go-log"
+	csms "github.com/libp2p/go-conn-security-multistream"
+	"github.com/libp2p/go-conn-security/insecure"
+	libp2p "github.com/libp2p/go-libp2p"
+	circuit "github.com/libp2p/go-libp2p-circuit"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/mux"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/pnet"
+	"github.com/libp2p/go-libp2p-core/routing"
+	"github.com/libp2p/go-libp2p-core/sec"
+	discovery "github.com/libp2p/go-libp2p-discovery"
+	swarm "github.com/libp2p/go-libp2p-swarm"
+	transport "github.com/libp2p/go-libp2p-transport"
+	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
+	"github.com/libp2p/go-libp2p/config"
+	bhost "github.com/libp2p/go-libp2p/p2p/host/basic"
+	relay "github.com/libp2p/go-libp2p/p2p/host/relay"
+	routed "github.com/libp2p/go-libp2p/p2p/host/routed"
+	msmux "github.com/libp2p/go-stream-muxer-multistream"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+var p2plog = logging.Logger("p2p-config")
+
+func NewHost(ctx context.Context, opts ...libp2p.Option) (host.Host, *swarm.Swarm, error) {
+	var cfg config.Config
+	if err := cfg.Apply(append(opts, libp2p.FallbackDefaults)...); err != nil {
+		return nil, nil, err
+	}
+
+	// Check this early. Prevents us from even *starting* without verifying this.
+	if pnet.ForcePrivateNetwork && cfg.Protector == nil {
+		p2plog.Error("tried to create a libp2p node with no Private" +
+			" Network Protector but usage of Private Networks" +
+			" is forced by the enviroment")
+		// Note: This is *also* checked the upgrader itself so it'll be
+		// enforced even *if* you don't use the libp2p constructor.
+		return nil, nil, pnet.ErrNotInPrivateNetwork
+	}
+
+	if cfg.PeerKey == nil {
+		return nil, nil, fmt.Errorf("no peer key specified")
+	}
+
+	// Obtain Peer ID from public key
+	pid, err := peer.IDFromPublicKey(cfg.PeerKey.GetPublic())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if cfg.Peerstore == nil {
+		return nil, nil, fmt.Errorf("no peerstore specified")
+	}
+
+	if !cfg.Insecure {
+		if err := cfg.Peerstore.AddPrivKey(pid, cfg.PeerKey); err != nil {
+			return nil, nil, err
+		}
+		if err := cfg.Peerstore.AddPubKey(pid, cfg.PeerKey.GetPublic()); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// TODO: Make the swarm implementation configurable.
+	swrm := swarm.NewSwarm(ctx, pid, cfg.Peerstore, cfg.Reporter)
+	if cfg.Filters != nil {
+		swrm.Filters = cfg.Filters
+	}
+
+	h, err := bhost.NewHost(ctx, swrm, &bhost.HostOpts{
+		ConnManager:  cfg.ConnManager,
+		AddrsFactory: cfg.AddrsFactory,
+		NATManager:   cfg.NATManager,
+		EnablePing:   !cfg.DisablePing,
+	})
+
+	if err != nil {
+		swrm.Close()
+		return nil, nil, err
+	}
+
+	if cfg.Relay {
+		// If we've enabled the relay, we should filter out relay
+		// addresses by default.
+		//
+		// TODO: We shouldn't be doing this here.
+		oldFactory := h.AddrsFactory
+		h.AddrsFactory = func(addrs []ma.Multiaddr) []ma.Multiaddr {
+			return oldFactory(relay.Filter(addrs))
+		}
+	}
+
+	upgrader := new(tptu.Upgrader)
+	upgrader.Protector = cfg.Protector
+	upgrader.Filters = swrm.Filters
+	if cfg.Insecure {
+		upgrader.Secure = makeInsecureTransport(pid)
+	} else {
+		upgrader.Secure, err = makeSecurityTransport(h, cfg.SecurityTransports)
+		if err != nil {
+			h.Close()
+			return nil, nil, err
+		}
+	}
+
+	upgrader.Muxer, err = makeMuxer(h, cfg.Muxers)
+	if err != nil {
+		h.Close()
+		return nil, nil, err
+	}
+
+	tpts, err := makeTransports(h, upgrader, cfg.Transports)
+	if err != nil {
+		h.Close()
+		return nil, nil, err
+	}
+	for _, t := range tpts {
+		err = swrm.AddTransport(t)
+		if err != nil {
+			h.Close()
+			return nil, nil, err
+		}
+	}
+
+	if cfg.Relay {
+		err := circuit.AddRelayTransport(swrm.Context(), h, upgrader, cfg.RelayOpts...)
+		if err != nil {
+			h.Close()
+			return nil, nil, err
+		}
+	}
+
+	// TODO: This method succeeds if listening on one address succeeds. We
+	// should probably fail if listening on *any* addr fails.
+	if err := h.Network().Listen(cfg.ListenAddrs...); err != nil {
+		h.Close()
+		return nil, nil, err
+	}
+
+	// Configure routing and autorelay
+	var router routing.PeerRouting
+	if cfg.Routing != nil {
+		router, err = cfg.Routing(h)
+		if err != nil {
+			h.Close()
+			return nil, nil, err
+		}
+	}
+
+	if cfg.EnableAutoRelay {
+		if !cfg.Relay {
+			h.Close()
+			return nil, nil, fmt.Errorf("cannot enable autorelay; relay is not enabled")
+		}
+
+		if router == nil {
+			h.Close()
+			return nil, nil, fmt.Errorf("cannot enable autorelay; no routing for discovery")
+		}
+
+		crouter, ok := router.(routing.ContentRouting)
+		if !ok {
+			h.Close()
+			return nil, nil, fmt.Errorf("cannot enable autorelay; no suitable routing for discovery")
+		}
+
+		discovery := discovery.NewRoutingDiscovery(crouter)
+
+		hop := false
+		for _, opt := range cfg.RelayOpts {
+			if opt == circuit.OptHop {
+				hop = true
+				break
+			}
+		}
+
+		if hop {
+			// advertise ourselves
+			relay.Advertise(ctx, discovery)
+		} else {
+			_ = relay.NewAutoRelay(swrm.Context(), h, discovery, router)
+		}
+	}
+
+	// start the host background tasks
+	h.Start()
+
+	if router != nil {
+		return routed.Wrap(h, router), swrm, nil
+	}
+	return h, swrm, nil
+}
+
+func makeInsecureTransport(id peer.ID) sec.SecureTransport {
+	secMuxer := new(csms.SSMuxer)
+	secMuxer.AddTransport(insecure.ID, insecure.New(id))
+	return secMuxer
+}
+
+func makeSecurityTransport(h host.Host, tpts []config.MsSecC) (sec.SecureTransport, error) {
+	secMuxer := new(csms.SSMuxer)
+	transportSet := make(map[string]struct{}, len(tpts))
+	for _, tptC := range tpts {
+		if _, ok := transportSet[tptC.ID]; ok {
+			return nil, fmt.Errorf("duplicate security transport: %s", tptC.ID)
+		}
+		transportSet[tptC.ID] = struct{}{}
+	}
+	for _, tptC := range tpts {
+		tpt, err := tptC.SecC(h)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := tpt.(*insecure.Transport); ok {
+			return nil, fmt.Errorf("cannot construct libp2p with an insecure transport, set the Insecure config option instead")
+		}
+		secMuxer.AddTransport(tptC.ID, tpt)
+	}
+	return secMuxer, nil
+}
+
+func makeMuxer(h host.Host, tpts []config.MsMuxC) (mux.Multiplexer, error) {
+	muxMuxer := msmux.NewBlankTransport()
+	transportSet := make(map[string]struct{}, len(tpts))
+	for _, tptC := range tpts {
+		if _, ok := transportSet[tptC.ID]; ok {
+			return nil, fmt.Errorf("duplicate muxer transport: %s", tptC.ID)
+		}
+		transportSet[tptC.ID] = struct{}{}
+	}
+	for _, tptC := range tpts {
+		tpt, err := tptC.MuxC(h)
+		if err != nil {
+			return nil, err
+		}
+		muxMuxer.AddTransport(tptC.ID, tpt)
+	}
+	return muxMuxer, nil
+}
+
+func makeTransports(h host.Host, u *tptu.Upgrader, tpts []config.TptC) ([]transport.Transport, error) {
+	transports := make([]transport.Transport, len(tpts))
+	for i, tC := range tpts {
+		t, err := tC(h, u)
+		if err != nil {
+			return nil, err
+		}
+		transports[i] = t
+	}
+	return transports, nil
+}

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -3,19 +3,17 @@
 package p2p
 
 import (
-	"net"
-	"sync"
-
-	"github.com/albrow/stringset"
-
 	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"path/filepath"
+	"sync"
 	"time"
 
+	"github.com/albrow/stringset"
 	lru "github.com/hashicorp/golang-lru"
 	libp2p "github.com/libp2p/go-libp2p"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -356,7 +356,7 @@ func (n *Node) UnbanIP(maddr ma.Multiaddr) error {
 func (n *Node) unbanIPNet(ipNet net.IPNet) {
 	// There is no guarantee in the public API of the filters package that would
 	// prevent multiple filters being added for the same IPNet (though it
-	// shoudln't happen in practice). We use a for loop here to make sure we
+	// shouldn't happen in practice). We use a for loop here to make sure we
 	// remove all possible filters. RemoveLiteral returns false if no filter was
 	// removed.
 	for n.swarm.Filters.RemoveLiteral(ipNet) {


### PR DESCRIPTION
Fixes #387.

I originally thought we should create our own `ConnectionManager` to implement this feature, but after digging more into the libp2p code, I don't think that will work. `ConnectionManager` is only responsible for pruning existing connections and doesn't really have the ability to prevent connections from being established in the first place. There is also an incentive to do this at the lowest abstraction level possible to minimize the resources that a peer with a banned IP address can use. Luckily, what we need is basically already implemented in the `swarm` package (see [`Swarm.Filters`](https://godoc.org/github.com/libp2p/go-libp2p-swarm#Swarm)).

Unfortunately `libp2p.New` does not currently expose any way to configure or access the underlying swarm. To workaround this issue, I just copied the code from `libp2p.New` and modified to expose the swarm.

This PR also automatically protects the bootstrap nodes from being banned.