### PR TITLE
zeroex,core: Consolidate RejectedOrderStatuses

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/0xProject/0x-mesh/db"
 	"github.com/0xProject/0x-mesh/ethereum"
-	"github.com/0xProject/0x-mesh/ethereum/dbstack"
 	"github.com/0xProject/0x-mesh/ethereum/blockwatch"
+	"github.com/0xProject/0x-mesh/ethereum/dbstack"
 	"github.com/0xProject/0x-mesh/expirationwatch"
 	"github.com/0xProject/0x-mesh/keys"
 	"github.com/0xProject/0x-mesh/loghooks"
@@ -138,8 +138,8 @@ func New(config Config) (*App, error) {
 	}
 	log.AddHook(loghooks.NewPeerIDHook(peerID))
 
-	if config.EthereumRPCMaxContentLength < maxOrderSizeInBytes {
-		return nil, fmt.Errorf("Cannot set `EthereumRPCMaxContentLength` to be less then maxOrderSizeInBytes: %d", maxOrderSizeInBytes)
+	if config.EthereumRPCMaxContentLength < zeroex.MaxOrderSizeInBytes {
+		return nil, fmt.Errorf("Cannot set `EthereumRPCMaxContentLength` to be less then MaxOrderSizeInBytes: %d", zeroex.MaxOrderSizeInBytes)
 	}
 	config = unquoteConfig(config)
 
@@ -575,7 +575,7 @@ func (app *App) AddOrders(signedOrdersRaw []*json.RawMessage) (*zeroex.Validatio
 				SignedOrder: signedOrder,
 				Kind:        zeroex.MeshValidation,
 				Status: zeroex.RejectedOrderStatus{
-					Code:    ROInvalidSchemaCode,
+					Code:    zeroex.ROInvalidSchemaCode,
 					Message: "order did not pass JSON-schema validation: Malformed JSON or empty payload",
 				},
 			})
@@ -584,7 +584,7 @@ func (app *App) AddOrders(signedOrdersRaw []*json.RawMessage) (*zeroex.Validatio
 		if !result.Valid() {
 			log.WithField("signedOrderRaw", string(signedOrderBytes)).Info("Order failed schema validation")
 			status := zeroex.RejectedOrderStatus{
-				Code:    ROInvalidSchemaCode,
+				Code:    zeroex.ROInvalidSchemaCode,
 				Message: fmt.Sprintf("order did not pass JSON-schema validation: %s", result.Errors()),
 			}
 			signedOrder := &zeroex.SignedOrder{}

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -76,7 +76,7 @@ func (app *App) HandleMessages(messages []*p2p.Message) error {
 			log.WithFields(map[string]interface{}{
 				"error":               err,
 				"from":                msg.From,
-				"maxOrderSizeInBytes": maxOrderSizeInBytes,
+				"maxOrderSizeInBytes": zeroex.MaxOrderSizeInBytes,
 				"actualSizeInBytes":   len(msg.Data),
 			}).Trace("received message that exceeds maximum size")
 			app.handlePeerScoreEvent(msg.From, psInvalidMessage)
@@ -168,7 +168,7 @@ func (app *App) HandleMessages(messages []*p2p.Message) error {
 			"from":              msg.From.String(),
 		}).Trace("not storing rejected order received from peer")
 		switch rejectedOrderInfo.Status {
-		case ROInternalError, zeroex.ROEthRPCRequestFailed, zeroex.ROCoordinatorRequestFailed:
+		case zeroex.ROInternalError, zeroex.ROEthRPCRequestFailed, zeroex.ROCoordinatorRequestFailed:
 			// Don't incur a negative score for these status types (it might not be
 			// their fault).
 		default:

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -97,6 +97,10 @@ type RejectedOrderStatus struct {
 	Message string `json:"message"`
 }
 
+// MaxOrderSizeInBytes is the maximum number of bytes allowed for encoded orders. It
+// is more than 10x the size of a typical ERC20 order to account for multiAsset orders.
+const MaxOrderSizeInBytes = 8192
+
 // RejectedOrderStatus values
 var (
 	ROEthRPCRequestFailed = RejectedOrderStatus{
@@ -155,7 +159,30 @@ var (
 		Code:    "OrderMaxExpirationExceeded",
 		Message: "order expiration too far in the future",
 	}
+	ROInternalError = RejectedOrderStatus{
+		Code:    "InternalError",
+		Message: "an unexpected internal error has occurred",
+	}
+	ROMaxOrderSizeExceeded = RejectedOrderStatus{
+		Code:    "MaxOrderSizeExceeded",
+		Message: fmt.Sprintf("order exceeds the maximum encoded size of %d bytes", MaxOrderSizeInBytes),
+	}
+	ROOrderAlreadyStoredAndUnfillable = RejectedOrderStatus{
+		Code:    "OrderAlreadyStoredAndUnfillable",
+		Message: "order is already stored and is unfillable. Mesh keeps unfillable orders in storage for a little while incase a block re-org makes them fillable again",
+	}
+	ROIncorrectNetwork = RejectedOrderStatus{
+		Code:    "OrderForIncorrectNetwork",
+		Message: "order was created for a different network than the one this Mesh node is configured to support",
+	}
+	ROSenderAddressNotAllowed = RejectedOrderStatus{
+		Code:    "SenderAddressNotAllowed",
+		Message: "orders with a senderAddress are not currently supported",
+	}
 )
+
+// ROInvalidSchemaCode is the RejectedOrderStatus emitted if an order doesn't conform to the order schema
+const ROInvalidSchemaCode = "InvalidSchema"
 
 // ConvertRejectOrderCodeToOrderEventKind converts an RejectOrderCode to an OrderEventKind type
 func ConvertRejectOrderCodeToOrderEventKind(rejectedOrderStatus RejectedOrderStatus) (OrderEventKind, bool) {

--- a/zeroex/order_validator.go
+++ b/zeroex/order_validator.go
@@ -25,12 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// MainnetOrderValidatorAddress is the mainnet OrderValidator contract address
-var MainnetOrderValidatorAddress = common.HexToAddress("0x9463e518dea6810309563c81d5266c1b1d149138")
-
-// GanacheOrderValidatorAddress is the ganache snapshot OrderValidator contract address
-var GanacheOrderValidatorAddress = common.HexToAddress("0x32eecaf51dfea9618e9bc94e9fbfddb1bbdcba15")
-
 // The context timeout length to use for requests to getOrderRelevantStateTimeout
 const getOrderRelevantStateTimeout = 15 * time.Second
 
@@ -40,16 +34,6 @@ const getCoordinatorEndpointTimeout = 10 * time.Second
 // Specifies the max number of eth_call requests we want to make concurrently.
 // Additional requests will block until an ongoing request has completed.
 const concurrencyLimit = 5
-
-// OrderInfo represents the order information emitted from Mesh
-type OrderInfo struct {
-	OrderHash                common.Hash
-	SignedOrder              *SignedOrder
-	FillableTakerAssetAmount *big.Int
-	OrderStatus              OrderStatus
-	// The hash of the Ethereum transaction that caused the order status to change
-	TxHash common.Hash
-}
 
 // RejectedOrderInfo encapsulates all the needed information to understand _why_ a 0x order
 // was rejected (i.e. did not pass) order validation. Since there are many potential reasons, some

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -220,18 +220,12 @@ func (w *Watcher) handleExpiration(expiredOrders []expirationwatch.ExpiredItem) 
 			}).Trace("Order expired that was no longer in DB")
 			continue
 		}
-		orderInfo := &zeroex.OrderInfo{
-			OrderHash:                common.HexToHash(expiredOrder.ID),
-			SignedOrder:              order.SignedOrder,
-			FillableTakerAssetAmount: big.NewInt(0),
-			OrderStatus:              zeroex.OSExpired,
-		}
 		w.unwatchOrder(w.meshDB.Orders, order, order.FillableTakerAssetAmount)
 
 		orderEvent := &zeroex.OrderEvent{
-			OrderHash:                orderInfo.OrderHash,
-			SignedOrder:              orderInfo.SignedOrder,
-			FillableTakerAssetAmount: orderInfo.FillableTakerAssetAmount,
+			OrderHash:                common.HexToHash(expiredOrder.ID),
+			SignedOrder:              order.SignedOrder,
+			FillableTakerAssetAmount: big.NewInt(0),
 			Kind:                     zeroex.EKOrderExpired,
 		}
 		orderEvents = append(orderEvents, orderEvent)


### PR DESCRIPTION
This PR:
- Removes some unused/unnecessary vars/types from `zeroex`
- Consolidates the RejectedOrderStatuses in `zeroex` so that developers wanting to know all the rejection statuses they need to handle can look at one authoritative place.

I considered moving the RejectedOrderStatuses to a separate module but they are _mostly_ used in `zeroex` and make up part of the interface of the `OrderValidator` method `BatchValidate`. It didn't seem like the best solution.