### PR TITLE
Increase transactionExclusionTestTimeout

### DIFF
--- a/db/transaction_test.go
+++ b/db/transaction_test.go
@@ -13,7 +13,7 @@ import (
 
 // transactionExclusionTestTimeout is used in transaction exclusion tests to
 // timeout while waiting for one transaction to open.
-const transactionExclusionTestTimeout = 100 * time.Millisecond
+const transactionExclusionTestTimeout = 500 * time.Millisecond
 
 func TestTransaction(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
We were still seeing occasional issues with the transaction exclusion tests. This PR increases the timeout used throughout the tests from 100ms to 500ms.

Since #388, we (mostly) no longer use `time.Sleep` in the tests so increasing `transactionExclusionTestTimeout` will not substantially slow down the tests in the passing case. It does slow down the tests slightly in the failure/timeout case, but I think that's a tradeoff we have to make at this point.

