### PR TITLE
Make verbosity field optional in TypeScript Config type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 - Removed the max expiration limit for orders. The only remaining expiration constraint is that the unix timestamp does not overflow int64 (i.e., is not larger than 9223372036854775807). ([#400](https://github.com/0xProject/0x-mesh/pull/400))
 
+### Bug fixes 🐞 
+
+- Made `verbosity` field optional in the TypeScript `Config` type. ([#410](https://github.com/0xProject/0x-mesh/pull/410))
+
 ## v4.0.1-beta
 
 ### Bug fixes 🐞 

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -32,7 +32,7 @@ declare global {
 export interface Config {
     // Verbosity is the logging verbosity. Defaults to Verbosity.Error meaning
     // only errors will be logged.
-    verbosity: Verbosity;
+    verbosity?: Verbosity;
     // The URL of an Ethereum node which supports the Ethereum JSON RPC API.
     // Used to validate and watch orders.
     ethereumRPCURL: string;
@@ -68,7 +68,7 @@ export interface Config {
     ethereumRPCMaxContentLength?: number;
 }
 
-enum Verbosity {
+export enum Verbosity {
     Panic = 0,
     Fatal = 1,
     Error = 2,
@@ -95,7 +95,7 @@ interface MeshWrapper {
 
 // The type for configuration exposed by MeshWrapper.
 interface WrapperConfig {
-    verbosity: number;
+    verbosity?: number;
     ethereumRPCURL: string;
     ethereumNetworkID: number;
     useBootstrapList?: boolean;

--- a/integration-tests/browser/src/index.ts
+++ b/integration-tests/browser/src/index.ts
@@ -1,4 +1,4 @@
-import { Mesh, OrderEvent, BigNumber } from '@0x/mesh-browser';
+import { Mesh, OrderEvent, BigNumber, Verbosity } from '@0x/mesh-browser';
 import { Web3ProviderEngine, RPCSubprovider } from '@0x/subproviders';
 import { signatureUtils, Order, orderHashUtils } from '@0x/order-utils';
 
@@ -41,7 +41,7 @@ provider.start();
     // Configure Mesh to use our local Ganache instance and local bootstrap
     // node.
     const mesh = new Mesh({
-        verbosity: 5,
+        verbosity: Verbosity.Debug,
         ethereumRPCURL,
         ethereumNetworkID: 50,
         bootstrapList: ['/ip4/127.0.0.1/tcp/60500/ws/ipfs/16Uiu2HAmGd949LwaV4KNvK2WDSiMVy7xEmW983VH75CMmefmMpP7'],


### PR DESCRIPTION
This was always intended to be an optional field. The fact that it's required in the `Config` type was just an oversight.