### PR TITLE
Move docs/development.md to CONTRIBUTING.md and update it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,33 @@
-[![Version](https://img.shields.io/badge/version-development-orange.svg)](https://github.com/0xProject/0x-mesh/releases)
-
-# 0x Mesh Development Guide
-
-Welcome to the [0x Mesh](https://github.com/0xProject/0x-mesh) Development
-Guide! This guide will help you get started with contributing to the 0x Mesh
-codebase.
+# 0x Mesh Development and Contribution Guide
 
 ## Directory Location
 
 If you are working on 0x-mesh, the root directory for the project must be at
-**\$GOPATH/src/github.com/0xProject/0x-mesh**. 0x Mesh uses [Dep](https://golang.github.io/dep/docs/installation.html) for dependency
+**\$GOPATH/src/github.com/0xProject/0x-mesh**. 0x Mesh uses
+[Dep](https://golang.github.io/dep/docs/installation.html) for dependency
 management and does not support Go modules.
+
+## Cloning the Repository and Opening PRs
+
+0x Mesh uses two main branches:
+
+1. The `development` branch contains the latest (possibly unreleased) changes
+	and is not guaranteed to be stable.
+2. The `master` branch contains the latest stable release.
+
+If you intend to fork 0x Mesh and open a PR, you should work off of the
+`development` branch. Make sure you check out the `development` branch and pull
+the latest changes.
+
+```
+git checkout development
+git pull
+```
+
+All PRs should use `development` as the base branch. When opening a new PR, use
+the dropdown menu in the GitHub UI to select `development`.
+
+![Selecting a branch](https://user-images.githubusercontent.com/800857/64901012-00272480-d64a-11e9-86f7-a2450ba8d0d9.png)
 
 ## Prerequisites
 
@@ -39,25 +56,26 @@ docker pull 0xorg/ganache-cli
 docker run -ti -p 8545:8545 -e VERSION=4.3.0 0xorg/ganache-cli
 ```
 
-Run tests in a vanilla Go environment:
+There are various Make targets for running tests:
 
-```
+```bash
+# Run tests in pure Go
 make test-go
-```
 
-Run tests in a Node.js/WebAssembly environment:
+# Compile to WebAssembly and run tests in Node.js
+make test-wasm-node
 
-```
-make test-wasm
-```
+# Compile to WebAssembly and run tests in a headless Chrome browser
+make test-wasm-browser
 
-Run tests in both environments:
-
-```
+# Run tests in all available environments
 make test-all
 ```
 
-## Running the linter
+## Running the Linters
+
+0x Mesh is configured to use linters for both Go and TypeScript code. To run all
+available linters, run:
 
 ```
 make lint
@@ -84,5 +102,25 @@ For VS Code, the following editor configuration is recommended:
   "go.vetOnSave": "off"
 
   // ...
+}
+```
+
+When working on code with the build tag `js,wasm`, you might need to add the
+following to your editor config:
+
+```javascript
+{
+	// ...
+
+  "go.toolsEnvVars": {
+    "GOARCH": "wasm",
+    "GOOS": "js"
+  },
+  "go.testEnvVars": {
+    "GOARCH": "wasm",
+    "GOOS": "js"
+	}
+
+	// ...
 }
 ```

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -20,5 +20,5 @@
 
 ## Contributing
 
-* [Development guide](development.md)
+* [Development and contribution guide](../CONTRIBUTING.md)
 * [CHANGELOG](../CHANGELOG.md)


### PR DESCRIPTION
This move will make the guide show up in the GitHub UI when opening a new pull request. I also updated the guide to specify when to use the `development` branch.