### PR TITLE
Implement low-level rate-limiting

### DIFF
--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -98,10 +98,10 @@ func (checker *bandwidthChecker) checkUsage() {
 					"remoteMultiaddr": conn.RemoteMultiaddr().String(),
 					"rateIn":          stats.RateIn,
 				}).Trace("banning IP/multiaddress due to high bandwidth usage")
-				// Banning the IP doesn't close the connection, so we do that
-				// separately.
-				_ = conn.Close()
 			}
+			// Banning the IP doesn't close the connection, so we do that
+			// separately. ClosePeer closes all connections to the given peer.
+			_ = checker.node.host.Network().ClosePeer(remotePeerID)
 		}
 	}
 }

--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -45,16 +45,22 @@ func (checker *bandwidthChecker) logBandwidthUsage(ctx context.Context) {
 		for _, remotePeerID := range checker.node.host.Network().Peers() {
 			stats := checker.counter.GetBandwidthForPeer(remotePeerID)
 			log.WithFields(log.Fields{
-				"remotePeerID": remotePeerID.String(),
-				"rateIn":       stats.RateIn,
+				"remotePeerID":      remotePeerID.String(),
+				"bytesPerSecondIn":  stats.RateIn,
+				"totalBytesIn":      stats.TotalIn,
+				"bytesPerSecondOut": stats.RateOut,
+				"totalBytesOut":     stats.TotalOut,
 			}).Debug("bandwidth used by peer")
 		}
 
 		// Log the bandwidth used by each protocol.
 		for protocolID, stats := range checker.counter.GetBandwidthByProtocol() {
 			log.WithFields(log.Fields{
-				"protocolID": protocolID,
-				"rateIn":     stats.RateIn,
+				"protocolID":        protocolID,
+				"bytesPerSecondIn":  stats.RateIn,
+				"totalBytesIn":      stats.TotalIn,
+				"bytesPerSecondOut": stats.RateOut,
+				"totalBytesOut":     stats.TotalOut,
 			}).Debug("bandwidth used by protocol")
 		}
 
@@ -71,8 +77,8 @@ func (checker *bandwidthChecker) checkUsage() {
 		// them.
 		if stats.RateIn > checker.maxBytesPerSecond {
 			log.WithFields(log.Fields{
-				"remotePeerID": remotePeerID.String(),
-				"rateIn":       stats.RateIn,
+				"remotePeerID":     remotePeerID.String(),
+				"bytesPerSecondIn": stats.RateIn,
 			}).Warn("banning peer due to high bandwidth usage")
 			// There are possibly multiple connections to each peer. We ban the IP
 			// address associated with each connection.

--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -12,7 +12,7 @@ const (
 	// defaultMaxBytesPerSecond is the maximum number of bytes per second that a
 	// peer is allowed to send before failing the bandwidth check.
 	// TODO(albrow): Reduce this limit once we have a better picture of what
-	// real-world bandwidth should be.
+	// real world bandwidth should be.
 	defaultMaxBytesPerSecond = 104857600 // 100 MiB.
 )
 
@@ -20,9 +20,6 @@ type bandwidthChecker struct {
 	node              *Node
 	counter           *metrics.BandwidthCounter
 	maxBytesPerSecond float64
-	// TODO(albrow): We'll use these later.
-	// lastSnapshot     map[peer.ID]metrics.Stats
-	// lastSnapshotTime time.Time
 }
 
 func newBandwidthChecker(node *Node, counter *metrics.BandwidthCounter) *bandwidthChecker {

--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -1,0 +1,99 @@
+package p2p
+
+import (
+	"context"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/metrics"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// peerBandwidthLimit is the maximum number of bytes per second that a peer is
+	// allowed to send before failing the bandwidth check.
+	// TODO(albrow): Reduce this limit once we have a better picture of what
+	// real-world bandwidth should be.
+	peerBandwidthLimit = 104857600 // 100 MiB.
+)
+
+type bandwidthChecker struct {
+	node    *Node
+	counter *metrics.BandwidthCounter
+	// TODO(albrow): We'll use these later.
+	// lastSnapshot     map[peer.ID]metrics.Stats
+	// lastSnapshotTime time.Time
+}
+
+func newBandwidthChecker(node *Node, counter *metrics.BandwidthCounter) *bandwidthChecker {
+	return &bandwidthChecker{
+		node:    node,
+		counter: counter,
+	}
+}
+
+func (checker *bandwidthChecker) logBandwidthUsage(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// Log the bandwidth used by each peer.
+		for _, remotePeerID := range checker.node.host.Network().Peers() {
+			stats := checker.counter.GetBandwidthForPeer(remotePeerID)
+			log.WithFields(log.Fields{
+				"remotePeerID": remotePeerID.String(),
+				"rateIn":       stats.RateIn,
+			}).Debug("bandwidth used by peer")
+		}
+
+		// Log the bandwidth used by each protocol.
+		for protocolID, stats := range checker.counter.GetBandwidthByProtocol() {
+			log.WithFields(log.Fields{
+				"protocolID": protocolID,
+				"rateIn":     stats.RateIn,
+			}).Debug("bandwidth used by protocol")
+		}
+
+		time.Sleep(logBandwidthUsageInterval)
+	}
+}
+
+// checkUsage checks the amount of data sent by each connected peer and bans
+// (via IP address) any peers which have exceeded the bandwidth limit.
+func (checker *bandwidthChecker) checkUsage() {
+	for _, remotePeerID := range checker.node.host.Network().Peers() {
+		stats := checker.counter.GetBandwidthForPeer(remotePeerID)
+		// If the peer is sending is data at a higher rate than is allowed, ban
+		// them.
+		if stats.RateIn > peerBandwidthLimit {
+			log.WithFields(log.Fields{
+				"remotePeerID": remotePeerID.String(),
+				"rateIn":       stats.RateIn,
+			}).Warn("banning peer due to high bandwidth usage")
+			// There are possibly multiple connections to each peer. We ban the IP
+			// address associated with each connection.
+			for _, conn := range checker.node.host.Network().ConnsToPeer(remotePeerID) {
+				if err := checker.node.BanIP(conn.RemoteMultiaddr()); err != nil {
+					if err == errProtectedIP {
+						continue
+					}
+					log.WithFields(log.Fields{
+						"remotePeerID":    remotePeerID.String(),
+						"remoteMultiaddr": conn.RemoteMultiaddr().String(),
+						"error":           err.Error(),
+					}).Error("could not ban peer")
+				}
+				log.WithFields(log.Fields{
+					"remotePeerID":    remotePeerID.String(),
+					"remoteMultiaddr": conn.RemoteMultiaddr().String(),
+					"rateIn":          stats.RateIn,
+				}).Trace("banning IP/multiaddress due to high bandwidth usage")
+				// Banning the IP doesn't close the connection, so we do that
+				// separately.
+				_ = conn.Close()
+			}
+		}
+	}
+}

--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -70,7 +70,7 @@ func (checker *bandwidthChecker) continuouslyLogBandwidthUsage(ctx context.Conte
 func (checker *bandwidthChecker) checkUsage() {
 	for _, remotePeerID := range checker.node.host.Network().Peers() {
 		stats := checker.counter.GetBandwidthForPeer(remotePeerID)
-		// If the peer is sending is data at a higher rate than is allowed, ban
+		// If the peer is sending data at a higher rate than is allowed, ban
 		// them.
 		if stats.RateIn > checker.maxBytesPerSecond {
 			log.WithFields(log.Fields{

--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -74,8 +74,9 @@ func (checker *bandwidthChecker) checkUsage() {
 		// them.
 		if stats.RateIn > checker.maxBytesPerSecond {
 			log.WithFields(log.Fields{
-				"remotePeerID":     remotePeerID.String(),
-				"bytesPerSecondIn": stats.RateIn,
+				"remotePeerID":      remotePeerID.String(),
+				"bytesPerSecondIn":  stats.RateIn,
+				"maxBytesPerSecond": checker.maxBytesPerSecond,
 			}).Warn("banning peer due to high bandwidth usage")
 			// There are possibly multiple connections to each peer. We ban the IP
 			// address associated with each connection.
@@ -91,9 +92,10 @@ func (checker *bandwidthChecker) checkUsage() {
 					}).Error("could not ban peer")
 				}
 				log.WithFields(log.Fields{
-					"remotePeerID":    remotePeerID.String(),
-					"remoteMultiaddr": conn.RemoteMultiaddr().String(),
-					"rateIn":          stats.RateIn,
+					"remotePeerID":      remotePeerID.String(),
+					"remoteMultiaddr":   conn.RemoteMultiaddr().String(),
+					"rateIn":            stats.RateIn,
+					"maxBytesPerSecond": checker.maxBytesPerSecond,
 				}).Trace("banning IP/multiaddress due to high bandwidth usage")
 			}
 			// Banning the IP doesn't close the connection, so we do that

--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -14,6 +14,8 @@ const (
 	// TODO(albrow): Reduce this limit once we have a better picture of what
 	// real world bandwidth should be.
 	defaultMaxBytesPerSecond = 104857600 // 100 MiB.
+	// logBandwidthUsageInterval is how often to log bandwidth usage data.
+	logBandwidthUsageInterval = 5 * time.Minute
 )
 
 type bandwidthChecker struct {

--- a/p2p/bandwidth_checker_test.go
+++ b/p2p/bandwidth_checker_test.go
@@ -1,0 +1,111 @@
+// +build !js
+
+package p2p
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBandwidthChecker(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	node0 := newTestNode(t, ctx, nil)
+	node1 := newTestNode(t, ctx, nil)
+
+	// For the purposes of this test, we use only the first multiaddress for each
+	// peer.
+	node0AddrInfo := peer.AddrInfo{
+		ID:    node0.ID(),
+		Addrs: node0.Multiaddrs()[0:1],
+	}
+	node1AddrInfo := peer.AddrInfo{
+		ID:    node1.ID(),
+		Addrs: node1.Multiaddrs()[0:1],
+	}
+
+	// At first, each node should be able to connect to the other.
+	require.NoError(t, node0.Connect(node1AddrInfo, testConnectionTimeout))
+	require.NoError(t, node1.Connect(node0AddrInfo, testConnectionTimeout))
+
+	// Manually send a message from node0 to node1 that would exceed the bandwidth
+	// limit.
+	newMaxBytesPerSecond := float64(1)
+	message := make([]byte, int(newMaxBytesPerSecond*100))
+	require.NoError(t, node0.send(message))
+
+	// Wait for node1 to receive the message.
+	expectedMessage := &Message{
+		From: node0.ID(),
+		Data: message,
+	}
+	expectMessage(t, node1, expectedMessage, 15*time.Second)
+
+	// Manually change the bandwidth limit for node1.
+	node1.bandwidthChecker.maxBytesPerSecond = newMaxBytesPerSecond
+
+	// Wait for node1 to block node0 and for the connection to close.
+	waitForNodeToBlockAddr(t, node1, node0AddrInfo.Addrs[0], 5*time.Second)
+	waitForNodesToDisconect(t, node0, node1, 5*time.Second)
+}
+
+func waitForNodeToBlockAddr(t *testing.T, blocker *Node, addressToBlock ma.Multiaddr, timeout time.Duration) {
+	blockedCheckTimeout := time.After(timeout)
+	blockedCheckInterval := 250 * time.Millisecond
+
+	for {
+		select {
+		case <-blockedCheckTimeout:
+			t.Fatal("timed out waiting for node to block the given address")
+			return
+		default:
+		}
+
+		blocker.bandwidthChecker.checkUsage()
+		isBlocked := blocker.filters.AddrBlocked(addressToBlock)
+		if isBlocked {
+			// This is what we want. Return and continue the test.
+			return
+		}
+
+		// Otherwise wait a bit and then check again.
+		time.Sleep(blockedCheckInterval)
+		continue
+	}
+}
+
+func waitForNodesToDisconect(t *testing.T, node0 *Node, node1 *Node, timeout time.Duration) {
+	disconnectTimeout := time.After(timeout)
+	disconnectCheckInterval := 250 * time.Millisecond
+
+	for {
+		select {
+		case <-disconnectTimeout:
+			t.Fatal("timed out waiting for node0 and node1 to disconnect")
+			return
+		default:
+		}
+
+		// Check if node0 is connected to node1
+		if node0.host.Network().Connectedness(node1.ID()) != network.NotConnected {
+			time.Sleep(disconnectCheckInterval)
+			continue
+		}
+
+		// Check if node1 is connected to node0
+		if node1.host.Network().Connectedness(node0.ID()) != network.NotConnected {
+			time.Sleep(disconnectCheckInterval)
+			continue
+		}
+
+		// If neither node is connected to the other, we're done.
+		return
+	}
+}

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -286,7 +286,7 @@ func (n *Node) Start() error {
 	discovery.Advertise(n.ctx, n.routingDiscovery, n.config.RendezvousString, discovery.TTL(advertiseTTL))
 
 	// Start logging bandwidth in the background.
-	go n.bandwidthChecker.logBandwidthUsage(n.ctx)
+	go n.bandwidthChecker.continuouslyLogBandwidthUsage(n.ctx)
 
 	return n.mainLoop()
 }

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -430,7 +430,7 @@ func (n *Node) runOnce() error {
 	}
 
 	// Check bandwidth usage non-deterministically
-	if mathrand.Float64() <= chanceToCheckBandiwdthUsage {
+	if mathrand.Float64() <= chanceToCheckBandwidthUsage {
 		n.bandwidthChecker.checkUsage()
 	}
 

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -58,7 +58,9 @@ const (
 	chanceToCheckBandiwdthUsage = 0.1
 	// peerBandwidthLimit is the maximum number of bytes per second that a peer is
 	// allowed to send before failing the bandwidth check.
-	peerBandwidthLimit = 104857600 // 100 MiB. Set extremely high for now.
+	// TODO(albrow): Reduce this limit once we have a better picture of what
+	// real-world bandwidth should be.
+	peerBandwidthLimit = 104857600 // 100 MiB.
 	// logBandwidthUsageInterval is how often to log bandwidth usage data.
 	logBandwidthUsageInterval = 5 * time.Minute
 )
@@ -353,9 +355,9 @@ func (n *Node) ProtectIP(maddr ma.Multiaddr) error {
 
 // BanIP adds the IP address of the given Multiaddr to the blacklist. The
 // node will no longer dial or accept connections from this IP address. However,
-// if the IP address is protected, calling BanIP is a no-op. BanIP does not
-// automatically disconnect from the given multiaddress if there is currently an
-// open connection.
+// if the IP address is protected, calling BanIP will not ban the IP address and
+// will instead return errProtectedIP. BanIP does not automatically disconnect
+// from the given multiaddress if there is currently an open connection.
 func (n *Node) BanIP(maddr ma.Multiaddr) error {
 	ipNet, err := ipNetFromMaddr(maddr)
 	if err != nil {

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -55,7 +55,7 @@ const (
 	// bandwidth usage. So on each iteration of the main loop we generate a number
 	// between 0 and 1. If its less than chanceToCheckBandiwdthUsage, we perform
 	// a bandwidth check.
-	chanceToCheckBandiwdthUsage = 0.1
+	chanceToCheckBandwidthUsage = 0.1
 )
 
 var errProtectedIP = errors.New("cannot ban protected IP address")

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -56,8 +56,6 @@ const (
 	// between 0 and 1. If its less than chanceToCheckBandiwdthUsage, we perform
 	// a bandwidth check.
 	chanceToCheckBandiwdthUsage = 0.1
-	// logBandwidthUsageInterval is how often to log bandwidth usage data.
-	logBandwidthUsageInterval = 5 * time.Minute
 )
 
 var errProtectedIP = errors.New("cannot ban protected IP address")

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -231,7 +231,7 @@ loop:
 	// opened on both sides, the ping message might *still* not be received by the
 	// other peer. Waiting for 1 second gives each peer enough time to finish
 	// setting up GossipSub. I couldn't find any way to avoid this hack :(
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	// Send ping from node0 to node1
 	pingMessage := &Message{From: node0.host.ID(), Data: []byte("ping\n")}

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -502,7 +502,7 @@ func TestProtectIP(t *testing.T) {
 	// Ban all node1 IP addresses (this should have no effect since the IP
 	// addresses are protected).
 	for _, maddr := range node1.Multiaddrs() {
-		require.NoError(t, node0.BanIP(maddr))
+		require.EqualError(t, node0.BanIP(maddr), errProtectedIP.Error())
 	}
 
 	// Each node should now be able to connect to the other.


### PR DESCRIPTION
Fixes https://github.com/0xProject/0x-mesh/issues/119.

This PR implements low-level rate-limiting and bans offending peers by their IP address. Currently, the limit on bandwidth usage is set conservatively high at 100 MiB/s. We can lower this limit over time as we get a better sense for what real world usage looks like.

This PR also will cause Mesh to log bandwidth statistics every 5 minutes, which will help us understand how much bandwidth is being used by each peer and each protocol over time. Technically, it would probably be better to report these statistics via Prometheus. However, since we already have the proxy and authentication infra set up for logging+EFK, I think it is okay to log them for now.

Also note that in order for this rate-limiting strategy to be effective we need to implement https://github.com/0xProject/0x-mesh/issues/390. In this PR, relay hosts are immune from being banned, so a spammer could simply use a relayed connection to circumvent the bandwidth limits. Once well-behaving relay hosts implement their own rate-limiting, we can safely differentiate misbehaving relay hosts from well-behaving ones and ban them.