### PR TITLE
Move some deps to devDependencies for TS RPC client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,11 @@ jobs:
           name: Install yarn
           command: npm i -g yarn@^1.15
       - run:
+        # HACK(albrow): Workaround for the "Incorrect integrity when fetching
+        # from the cache" error on CircleCI.
+          name: Clean yarn cache
+          command: yarn cache clean
+      - run:
           name: Install dependencies
           command: make deps-no-lockfile
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,7 @@ jobs:
       - run: node --version
       - run:
           name: Install yarn
-          command: npm i -g yarn@^1.15
-      - run:
-        # HACK(albrow): Workaround for the "Incorrect integrity when fetching
-        # from the cache" error on CircleCI.
-          name: Clean yarn cache
-          command: yarn cache clean
+          command: npm i -g yarn@1.17
       - run:
           name: Install dependencies
           command: make deps-no-lockfile

--- a/rpc/clients/typescript/package.json
+++ b/rpc/clients/typescript/package.json
@@ -5,14 +5,7 @@
         "node": ">=6.12"
     },
     "description": "A Javascript library for interacting with the Mesh JSON RPC API over WebSockets",
-    "keywords": [
-        "p2p",
-        "mesh",
-        "0xproject",
-        "ethereum",
-        "tokens",
-        "exchange"
-    ],
+    "keywords": ["p2p", "mesh", "0xproject", "ethereum", "tokens", "exchange"],
     "main": "lib/src/index.js",
     "types": "lib/src/index.d.ts",
     "scripts": {
@@ -37,8 +30,6 @@
     },
     "homepage": "https://github.com/0xProject/0x-mesh/rpc/clients/typescript/README.md",
     "dependencies": {
-        "@0x/assert": "^2.1.2",
-        "@0x/dev-utils": "^2.2.6",
         "@0x/order-utils": "^8.2.4",
         "@0x/types": "^2.4.1",
         "@0x/typescript-typings": "^4.2.4",
@@ -48,6 +39,8 @@
         "websocket": "^1.0.29"
     },
     "devDependencies": {
+        "@0x/assert": "^2.1.2",
+        "@0x/dev-utils": "^2.2.6",
         "@0x/ts-doc-gen": "^0.0.13",
         "@0x/tslint-config": "^3.0.1",
         "@types/mocha": "^2.2.42",

--- a/rpc/clients/typescript/package.json
+++ b/rpc/clients/typescript/package.json
@@ -30,6 +30,7 @@
     },
     "homepage": "https://github.com/0xProject/0x-mesh/rpc/clients/typescript/README.md",
     "dependencies": {
+        "@0x/assert": "^2.1.2",
         "@0x/order-utils": "^8.2.4",
         "@0x/types": "^2.4.1",
         "@0x/typescript-typings": "^4.2.4",
@@ -39,7 +40,6 @@
         "websocket": "^1.0.29"
     },
     "devDependencies": {
-        "@0x/assert": "^2.1.2",
         "@0x/dev-utils": "^2.2.6",
         "@0x/ts-doc-gen": "^0.0.13",
         "@0x/tslint-config": "^3.0.1",


### PR DESCRIPTION
Related to #428. We can take even more steps if needed; this is just the low-hanging fruit.