### PR TITLE
orderwatch: Fix fillableTakerAssetAmount DB update bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 ### Bug fixes 🐞 
 
+- Fixed bug where we weren't updating an orders `fillableTakerAssetAmount` in the DB when orders were being partially filled or when their fillability increased due to a block re-org. ([#439](https://github.com/0xProject/0x-mesh/pull/439))
 - Made `verbosity` field optional in the TypeScript `Config` type. ([#410](https://github.com/0xProject/0x-mesh/pull/410))
 - Fixed issue where we weren't re-validating orders potentially impacted by the balance increase of the recipient of an ERC20 or ERC721 transfer. ([#416](https://github.com/0xProject/0x-mesh/pull/416))
 

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -532,7 +532,7 @@ func (w *Watcher) Add(orderInfo *ordervalidator.AcceptedOrderInfo) error {
 		OrderHash:                orderInfo.OrderHash,
 		SignedOrder:              orderInfo.SignedOrder,
 		FillableTakerAssetAmount: orderInfo.FillableTakerAssetAmount,
-		EndState:                     zeroex.ESOrderAdded,
+		EndState:                 zeroex.ESOrderAdded,
 	}
 	w.orderFeed.Send([]*zeroex.OrderEvent{orderEvent})
 
@@ -638,6 +638,7 @@ func (w *Watcher) generateOrderEventsIfChanged(ordersColTxn *db.Transaction, ord
 			w.updateOrderDBEntry(ordersColTxn, order)
 		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && oldAmountIsMoreThenNewAmount {
 			// Order was filled, emit  event and update order in DB
+			order.FillableTakerAssetAmount = newFillableAmount
 			w.updateOrderDBEntry(ordersColTxn, order)
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,
@@ -650,6 +651,7 @@ func (w *Watcher) generateOrderEventsIfChanged(ordersColTxn *db.Transaction, ord
 		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && !oldAmountIsMoreThenNewAmount {
 			// The order is now fillable for more then it was before. E.g.: A fill txn reverted (block-reorg)
 			// Update order in DB and emit event
+			order.FillableTakerAssetAmount = newFillableAmount
 			w.updateOrderDBEntry(ordersColTxn, order)
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -629,7 +629,7 @@ func (w *Watcher) generateOrderEventsIfChanged(ordersColTxn *db.Transaction, ord
 				OrderHash:                acceptedOrderInfo.OrderHash,
 				SignedOrder:              order.SignedOrder,
 				FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
-				EndState:                     zeroex.ESOrderAdded,
+				EndState:                 zeroex.ESOrderAdded,
 				ContractEvents:           orderHashToEvents[order.Hash],
 			}
 			orderEvents = append(orderEvents, orderEvent)
@@ -642,7 +642,7 @@ func (w *Watcher) generateOrderEventsIfChanged(ordersColTxn *db.Transaction, ord
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,
 				SignedOrder:              order.SignedOrder,
-				EndState:                     zeroex.ESOrderFilled,
+				EndState:                 zeroex.ESOrderFilled,
 				FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
 				ContractEvents:           orderHashToEvents[order.Hash],
 			}
@@ -654,7 +654,7 @@ func (w *Watcher) generateOrderEventsIfChanged(ordersColTxn *db.Transaction, ord
 			orderEvent := &zeroex.OrderEvent{
 				OrderHash:                acceptedOrderInfo.OrderHash,
 				SignedOrder:              order.SignedOrder,
-				EndState:                     zeroex.ESOrderFillabilityIncreased,
+				EndState:                 zeroex.ESOrderFillabilityIncreased,
 				FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
 				ContractEvents:           orderHashToEvents[order.Hash],
 			}
@@ -685,7 +685,7 @@ func (w *Watcher) generateOrderEventsIfChanged(ordersColTxn *db.Transaction, ord
 					OrderHash:                rejectedOrderInfo.OrderHash,
 					SignedOrder:              rejectedOrderInfo.SignedOrder,
 					FillableTakerAssetAmount: big.NewInt(0),
-					EndState:                     endState,
+					EndState:                 endState,
 					ContractEvents:           orderHashToEvents[order.Hash],
 				}
 				orderEvents = append(orderEvents, orderEvent)


### PR DESCRIPTION
This PR fixes a bug in OrderWatcher where we were not updating an order's fillableTakerAssetAmount in the DB if an order was _partially_ filled, or if it's fillability increased due to a block re-org.