### PR TITLE
cut-release: Fix outdated elements of script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,5 +65,5 @@ jobs:
           command: cd rpc/clients/typescript && yarn test
       - run:
           name: Run cut-release script to test it still works
-          command: make cut-release
+          command: VERSION=100.0.0 make cut-release
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,4 +63,7 @@ jobs:
       - run:
           name: Run TS RPC client tests
           command: cd rpc/clients/typescript && yarn test
+      - run:
+          name: Run cut-release script to test it still works
+          command: make cut-release
 

--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -96,7 +96,7 @@ func updateHardCodedVersions(version string) {
 	updateFileWithRegex(changelog, regex, newChangelogSection)
 
 	// Update badge in README.md
-	pathToMDFilesWithBadges := []string{"README.md", "docs/rpc_api.md", "docs/development.md", "docs/deployment.md", "docs/deployment_with_telemetry"}
+	pathToMDFilesWithBadges := []string{"README.md", "docs/rpc_api.md", "docs/deployment.md", "docs/deployment_with_telemetry.md"}
 	doubleDashVersion := strings.Replace(version, "-", "--", -1)
 	newSvgName := fmt.Sprintf("version-%s-orange.svg", doubleDashVersion)
 	regex = `version-(.*)-orange.svg`

--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -25,6 +25,7 @@ func main() {
 	updateHardCodedVersions(env.Version)
 
 	generateTypescriptClientDocs()
+	generateTypescriptBrowserDocs()
 }
 
 func generateTypescriptClientDocs() {
@@ -40,6 +41,26 @@ func generateTypescriptClientDocs() {
 	// Run `yarn docs:md` to generate MD docs
 	cmd = exec.Command("yarn", "docs:md")
 	cmd.Dir = "rpc/clients/typescript"
+	stdoutStderr, err = cmd.CombinedOutput()
+	if err != nil {
+		log.Print(string(stdoutStderr))
+		log.Fatal(err)
+	}
+}
+
+func generateTypescriptBrowserDocs() {
+	// Run `yarn install` to make sure `TypeDoc` dep is installed
+	cmd := exec.Command("yarn", "install", "--frozen-lockfile")
+	cmd.Dir = "browser"
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Print(string(stdoutStderr))
+		log.Fatal(err)
+	}
+
+	// Run `yarn docs:md` to generate MD docs
+	cmd = exec.Command("yarn", "docs:md")
+	cmd.Dir = "browser"
 	stdoutStderr, err = cmd.CombinedOutput()
 	if err != nil {
 		log.Print(string(stdoutStderr))

--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -95,12 +95,6 @@ func updateHardCodedVersions(version string) {
 	regex = `(## Upcoming release)`
 	updateFileWithRegex(changelog, regex, newChangelogSection)
 
-	// Update `beta_telemetry_node/docker-compose.yml`
-	dockerComposePath := "examples/beta_telemetry_node/docker-compose.yml"
-	newVersionString = fmt.Sprintf(`image: 0xorg/mesh:%s`, version)
-	regex = `image: 0xorg/mesh:(.*)`
-	updateFileWithRegex(dockerComposePath, regex, newVersionString)
-
 	// Update badge in README.md
 	pathToMDFilesWithBadges := []string{"README.md", "docs/rpc_api.md", "docs/development.md", "docs/deployment.md", "docs/deployment_with_telemetry"}
 	doubleDashVersion := strings.Replace(version, "-", "--", -1)


### PR DESCRIPTION
The `cut-release` tool had the following issues that this PR fixes:
- Tried to update no longer existent `docker-compose.yml`
- Didn't generate updated doc MD file for Browser package
- `deployment_with_telemetry` file was missing file suffix
- `development.md` file no longer exists