### PR TITLE
Add support for custom network ID/custom contract addresses

### DIFF
--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -120,6 +120,9 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 	if ethereumRPCMaxContentLength := jsConfig.Get("ethereumRPCMaxContentLength"); !isNullOrUndefined(ethereumRPCMaxContentLength) {
 		config.EthereumRPCMaxContentLength = ethereumRPCMaxContentLength.Int()
 	}
+	if customContractAddresses := jsConfig.Get("customContractAddresses"); !isNullOrUndefined(customContractAddresses) {
+		config.CustomContractAddresses = customContractAddresses.String()
+	}
 
 	return config, nil
 }

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -66,36 +66,30 @@ export interface Config {
     // Parity, feel free to double the default max in order to reduce the number
     // of RPC calls made by Mesh. Defaults to 524288 bytes.
     ethereumRPCMaxContentLength?: number;
-    // customContractAddresses is a mapping of
-    // network ID to contract addresses for that network ID. The contract
-    // addresses for most common networks are already included by default, so this
-    // is typically only needed for testing on custom networks. The given
-    // addresses are added to the default list of addresses for known networks and
-    // overriding any known contract addresses is not allowed. The addresses for
-    // exchange, devUtils, erc20Proxy, and erc721Proxy are required for each
-    // network. For example:
+    // customContractAddresses is set of custom addresses to use for the
+    // configured network ID. The contract addresses for most common networks
+    // are already included by default, so this is typically only needed for
+    // testing on custom networks. The given addresses are added to the default
+    // list of addresses for known networks and overriding any contract
+    // addresses for known networks is not allowed. The addresses for exchange,
+    // devUtils, erc20Proxy, and erc721Proxy are required for each network. For
+    // example:
     //
     //    {
-    //        "999": {
-    //            "exchange":"0x48bacb9266a570d521063ef5dd96e61686dbe788",
-    //            "devUtils": "0x38ef19fdf8e8415f18c307ed71967e19aac28ba1",
-    //            "erc20Proxy": "0x1dc4c1cefef38a777b15aa20260a54e584b16c48",
-    //            "erc721Proxy": "0x1d7022f5b17d2f8b695918fb48fa1089c9f85401"
-    //         }
+    //        exchange: "0x48bacb9266a570d521063ef5dd96e61686dbe788",
+    //        devUtils: "0x38ef19fdf8e8415f18c307ed71967e19aac28ba1",
+    //        erc20Proxy: "0x1dc4c1cefef38a777b15aa20260a54e584b16c48",
+    //        erc721Proxy: "0x1d7022f5b17d2f8b695918fb48fa1089c9f85401"
     //    }
     //
-    customContractAddresses?: NetworkIDToContractAddresses;
-}
-
-export interface NetworkIDToContractAddresses {
-    [networkID: string]: ContractAddresses;
+    customContractAddresses?: ContractAddresses;
 }
 
 export interface ContractAddresses {
-    erc20Proxy: string;
-    erc721Proxy: string;
     exchange: string;
     devUtils: string;
+    erc20Proxy: string;
+    erc721Proxy: string;
     coordinator?: string;
     coordinatorRegistry?: string;
     weth9?: string;

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -66,6 +66,40 @@ export interface Config {
     // Parity, feel free to double the default max in order to reduce the number
     // of RPC calls made by Mesh. Defaults to 524288 bytes.
     ethereumRPCMaxContentLength?: number;
+    // customContractAddresses is a mapping of
+    // network ID to contract addresses for that network ID. The contract
+    // addresses for most common networks are already included by default, so this
+    // is typically only needed for testing on custom networks. The given
+    // addresses are added to the default list of addresses for known networks and
+    // overriding any known contract addresses is not allowed. The addresses for
+    // exchange, devUtils, erc20Proxy, and erc721Proxy are required for each
+    // network. For example:
+    //
+    //    {
+    //        "999": {
+    //            "exchange":"0x48bacb9266a570d521063ef5dd96e61686dbe788",
+    //            "devUtils": "0x38ef19fdf8e8415f18c307ed71967e19aac28ba1",
+    //            "erc20Proxy": "0x1dc4c1cefef38a777b15aa20260a54e584b16c48",
+    //            "erc721Proxy": "0x1d7022f5b17d2f8b695918fb48fa1089c9f85401"
+    //         }
+    //    }
+    //
+    customContractAddresses?: NetworkIDToContractAddresses;
+}
+
+export interface NetworkIDToContractAddresses {
+    [networkID: string]: ContractAddresses;
+}
+
+export interface ContractAddresses {
+    erc20Proxy: string;
+    erc721Proxy: string;
+    exchange: string;
+    devUtils: string;
+    coordinator?: string;
+    coordinatorRegistry?: string;
+    weth9?: string;
+    zrxToken?: string;
 }
 
 export enum Verbosity {
@@ -103,6 +137,7 @@ interface WrapperConfig {
     orderExpirationBufferSeconds?: number;
     blockPollingIntervalSeconds?: number;
     ethereumRPCMaxContentLength?: number;
+    customContractAddresses?: string; // json-encoded instead of Object.
 }
 
 // The type for signed orders exposed by MeshWrapper. Unlike other types, the
@@ -260,9 +295,29 @@ enum ContractEventKind {
     WethWithdrawalEvent = 'WethWithdrawalEvent',
 }
 
-type WrapperContractEventParameters =  WrapperERC20TransferEvent | WrapperERC20ApprovalEvent | WrapperERC721TransferEvent | WrapperERC721ApprovalEvent | WrapperExchangeFillEvent | WrapperExchangeCancelUpToEvent | WrapperWethWithdrawalEvent | WrapperWethDepositEvent | ERC721ApprovalForAllEvent | ExchangeCancelEvent;
+type WrapperContractEventParameters =
+    | WrapperERC20TransferEvent
+    | WrapperERC20ApprovalEvent
+    | WrapperERC721TransferEvent
+    | WrapperERC721ApprovalEvent
+    | WrapperExchangeFillEvent
+    | WrapperExchangeCancelUpToEvent
+    | WrapperWethWithdrawalEvent
+    | WrapperWethDepositEvent
+    | ERC721ApprovalForAllEvent
+    | ExchangeCancelEvent;
 
-type ContractEventParameters =  ERC20TransferEvent | ERC20ApprovalEvent | ERC721TransferEvent | ERC721ApprovalEvent | ExchangeFillEvent | ExchangeCancelUpToEvent | WethWithdrawalEvent | WethDepositEvent | ERC721ApprovalForAllEvent | ExchangeCancelEvent;
+type ContractEventParameters =
+    | ERC20TransferEvent
+    | ERC20ApprovalEvent
+    | ERC721TransferEvent
+    | ERC721ApprovalEvent
+    | ExchangeFillEvent
+    | ExchangeCancelUpToEvent
+    | WethWithdrawalEvent
+    | WethDepositEvent
+    | ERC721ApprovalForAllEvent
+    | ExchangeCancelEvent;
 
 export interface ContractEvent {
     blockHash: string;
@@ -521,9 +576,12 @@ async function sleepAsync(ms: number): Promise<void> {
 
 function configToWrapperConfig(config: Config): WrapperConfig {
     const bootstrapList = config.bootstrapList == null ? undefined : config.bootstrapList.join(',');
+    const customContractAddresses =
+        config.customContractAddresses == null ? undefined : JSON.stringify(config.customContractAddresses);
     return {
         ...config,
         bootstrapList,
+        customContractAddresses,
     };
 }
 
@@ -540,105 +598,105 @@ function wrapperSignedOrderToSignedOrder(wrapperSignedOrder: WrapperSignedOrder)
 }
 
 function wrapperContractEventsToContractEvents(wrapperContractEvents: WrapperContractEvent[]): ContractEvent[] {
-        const contractEvents: ContractEvent[] = [];
-        if (wrapperContractEvents === null) {
-            return contractEvents;
-        }
-        wrapperContractEvents.forEach(wrapperContractEvent => {
-            const kind = wrapperContractEvent.kind as ContractEventKind;
-            const rawParameters = wrapperContractEvent.parameters;
-            let parameters: ContractEventParameters;
-            switch (kind) {
-                case ContractEventKind.ERC20TransferEvent:
-                    const erc20TransferEvent = rawParameters as WrapperERC20TransferEvent;
-                    parameters = {
-                        from: erc20TransferEvent.from,
-                        to: erc20TransferEvent.to,
-                        value: new BigNumber(erc20TransferEvent.value),
-                    };
-                    break;
-                case ContractEventKind.ERC20ApprovalEvent:
-                    const erc20ApprovalEvent = rawParameters as WrapperERC20ApprovalEvent;
-                    parameters = {
-                        owner: erc20ApprovalEvent.owner,
-                        spender: erc20ApprovalEvent.spender,
-                        value: new BigNumber(erc20ApprovalEvent.value),
-                    };
-                    break;
-                case ContractEventKind.ERC721TransferEvent:
-                    const erc721TransferEvent = rawParameters as WrapperERC721TransferEvent;
-                    parameters = {
-                        from: erc721TransferEvent.from,
-                        to: erc721TransferEvent.to,
-                        tokenId: new BigNumber(erc721TransferEvent.tokenId),
-                    };
-                    break;
-                case ContractEventKind.ERC721ApprovalEvent:
-                    const erc721ApprovalEvent = rawParameters as WrapperERC721ApprovalEvent;
-                    parameters = {
-                        owner: erc721ApprovalEvent.owner,
-                        approved: erc721ApprovalEvent.approved,
-                        tokenId: new BigNumber(erc721ApprovalEvent.tokenId),
-                    };
-                    break;
-                case ContractEventKind.ExchangeFillEvent:
-                    const exchangeFillEvent = rawParameters as WrapperExchangeFillEvent;
-                    parameters = {
-                        makerAddress: exchangeFillEvent.makerAddress,
-                        takerAddress: exchangeFillEvent.takerAddress,
-                        senderAddress: exchangeFillEvent.senderAddress,
-                        feeRecipientAddress: exchangeFillEvent.feeRecipientAddress,
-                        makerAssetFilledAmount: new BigNumber(exchangeFillEvent.makerAssetFilledAmount),
-                        takerAssetFilledAmount: new BigNumber(exchangeFillEvent.takerAssetFilledAmount),
-                        makerFeePaid: new BigNumber(exchangeFillEvent.makerFeePaid),
-                        takerFeePaid: new BigNumber(exchangeFillEvent.takerFeePaid),
-                        orderHash: exchangeFillEvent.orderHash,
-                        makerAssetData: exchangeFillEvent.makerAssetData,
-                        takerAssetData: exchangeFillEvent.takerAssetData,
-                    };
-                    break;
-                case ContractEventKind.ExchangeCancelEvent:
-                    parameters = rawParameters as ExchangeCancelEvent;
-                    break;
-                case ContractEventKind.ExchangeCancelUpToEvent:
-                    const exchangeCancelUpToEvent = rawParameters as WrapperExchangeCancelUpToEvent;
-                    parameters = {
-                        makerAddress: exchangeCancelUpToEvent.makerAddress,
-                        senderAddress: exchangeCancelUpToEvent.senderAddress,
-                        orderEpoch: new BigNumber(exchangeCancelUpToEvent.orderEpoch),
-                    };
-                    break;
-                case ContractEventKind.WethDepositEvent:
-                    const wethDepositEvent = rawParameters as WrapperWethDepositEvent;
-                    parameters = {
-                        owner: wethDepositEvent.owner,
-                        value: new BigNumber(wethDepositEvent.value),
-                    };
-                    break;
-                case ContractEventKind.WethWithdrawalEvent:
-                    const wethWithdrawalEvent = rawParameters as WrapperWethWithdrawalEvent;
-                    parameters = {
-                        owner: wethWithdrawalEvent.owner,
-                        value: new BigNumber(wethWithdrawalEvent.value),
-                    };
-                    break;
-                default:
-                    throw new Error(`Unrecognized ContractEventKind: ${kind}`);
-            }
-            const contractEvent: ContractEvent = {
-                blockHash: wrapperContractEvent.blockHash,
-                txHash:  wrapperContractEvent.txHash,
-                txIndex:  wrapperContractEvent.txIndex,
-                logIndex:  wrapperContractEvent.logIndex,
-                isRemoved:  wrapperContractEvent.isRemoved,
-                address:  wrapperContractEvent.address,
-                kind,
-                parameters,
-            };
-            contractEvents.push(contractEvent);
-        });
+    const contractEvents: ContractEvent[] = [];
+    if (wrapperContractEvents === null) {
         return contractEvents;
     }
+    wrapperContractEvents.forEach(wrapperContractEvent => {
+        const kind = wrapperContractEvent.kind as ContractEventKind;
+        const rawParameters = wrapperContractEvent.parameters;
+        let parameters: ContractEventParameters;
+        switch (kind) {
+            case ContractEventKind.ERC20TransferEvent:
+                const erc20TransferEvent = rawParameters as WrapperERC20TransferEvent;
+                parameters = {
+                    from: erc20TransferEvent.from,
+                    to: erc20TransferEvent.to,
+                    value: new BigNumber(erc20TransferEvent.value),
+                };
+                break;
+            case ContractEventKind.ERC20ApprovalEvent:
+                const erc20ApprovalEvent = rawParameters as WrapperERC20ApprovalEvent;
+                parameters = {
+                    owner: erc20ApprovalEvent.owner,
+                    spender: erc20ApprovalEvent.spender,
+                    value: new BigNumber(erc20ApprovalEvent.value),
+                };
+                break;
+            case ContractEventKind.ERC721TransferEvent:
+                const erc721TransferEvent = rawParameters as WrapperERC721TransferEvent;
+                parameters = {
+                    from: erc721TransferEvent.from,
+                    to: erc721TransferEvent.to,
+                    tokenId: new BigNumber(erc721TransferEvent.tokenId),
+                };
+                break;
+            case ContractEventKind.ERC721ApprovalEvent:
+                const erc721ApprovalEvent = rawParameters as WrapperERC721ApprovalEvent;
+                parameters = {
+                    owner: erc721ApprovalEvent.owner,
+                    approved: erc721ApprovalEvent.approved,
+                    tokenId: new BigNumber(erc721ApprovalEvent.tokenId),
+                };
+                break;
+            case ContractEventKind.ExchangeFillEvent:
+                const exchangeFillEvent = rawParameters as WrapperExchangeFillEvent;
+                parameters = {
+                    makerAddress: exchangeFillEvent.makerAddress,
+                    takerAddress: exchangeFillEvent.takerAddress,
+                    senderAddress: exchangeFillEvent.senderAddress,
+                    feeRecipientAddress: exchangeFillEvent.feeRecipientAddress,
+                    makerAssetFilledAmount: new BigNumber(exchangeFillEvent.makerAssetFilledAmount),
+                    takerAssetFilledAmount: new BigNumber(exchangeFillEvent.takerAssetFilledAmount),
+                    makerFeePaid: new BigNumber(exchangeFillEvent.makerFeePaid),
+                    takerFeePaid: new BigNumber(exchangeFillEvent.takerFeePaid),
+                    orderHash: exchangeFillEvent.orderHash,
+                    makerAssetData: exchangeFillEvent.makerAssetData,
+                    takerAssetData: exchangeFillEvent.takerAssetData,
+                };
+                break;
+            case ContractEventKind.ExchangeCancelEvent:
+                parameters = rawParameters as ExchangeCancelEvent;
+                break;
+            case ContractEventKind.ExchangeCancelUpToEvent:
+                const exchangeCancelUpToEvent = rawParameters as WrapperExchangeCancelUpToEvent;
+                parameters = {
+                    makerAddress: exchangeCancelUpToEvent.makerAddress,
+                    senderAddress: exchangeCancelUpToEvent.senderAddress,
+                    orderEpoch: new BigNumber(exchangeCancelUpToEvent.orderEpoch),
+                };
+                break;
+            case ContractEventKind.WethDepositEvent:
+                const wethDepositEvent = rawParameters as WrapperWethDepositEvent;
+                parameters = {
+                    owner: wethDepositEvent.owner,
+                    value: new BigNumber(wethDepositEvent.value),
+                };
+                break;
+            case ContractEventKind.WethWithdrawalEvent:
+                const wethWithdrawalEvent = rawParameters as WrapperWethWithdrawalEvent;
+                parameters = {
+                    owner: wethWithdrawalEvent.owner,
+                    value: new BigNumber(wethWithdrawalEvent.value),
+                };
+                break;
+            default:
+                throw new Error(`Unrecognized ContractEventKind: ${kind}`);
+        }
+        const contractEvent: ContractEvent = {
+            blockHash: wrapperContractEvent.blockHash,
+            txHash: wrapperContractEvent.txHash,
+            txIndex: wrapperContractEvent.txIndex,
+            logIndex: wrapperContractEvent.logIndex,
+            isRemoved: wrapperContractEvent.isRemoved,
+            address: wrapperContractEvent.address,
+            kind,
+            parameters,
+        };
+        contractEvents.push(contractEvent);
+    });
+    return contractEvents;
+}
 
 function signedOrderToWrapperSignedOrder(signedOrder: SignedOrder): WrapperSignedOrder {
     return {
@@ -697,3 +755,5 @@ function wrapperRejectedOrderInfoToRejectedOrderInfo(
         signedOrder: wrapperSignedOrderToSignedOrder(wrapperRejectedOrderInfo.signedOrder),
     };
 }
+
+// tslint:disable-next-line:max-file-line-count

--- a/core/core.go
+++ b/core/core.go
@@ -97,6 +97,25 @@ type Config struct {
 	// or Infura. If using Alchemy or Parity, feel free to double the default max in order to reduce the
 	// number of RPC calls made by Mesh.
 	EthereumRPCMaxContentLength int `envvar:"ETHEREUM_RPC_MAX_CONTENT_LENGTH" default:"524288"`
+	// CustomContractAddresses is a JSON-encoded string representing a mapping of
+	// network ID to contract addresses for that network ID. The contract
+	// addresses for most common networks are already included by default, so this
+	// is typically only needed for testing on custom networks. The given
+	// addresses are added to the default list of addresses for known networks and
+	// overriding any known contract addresses is not allowed. The addresses for
+	// exchange, devUtils, erc20Proxy, and erc721Proxy are required for each
+	// network. For example:
+	//
+	//    {
+	//        "999": {
+	//            "exchange":"0x48bacb9266a570d521063ef5dd96e61686dbe788",
+	//            "devUtils": "0x38ef19fdf8e8415f18c307ed71967e19aac28ba1",
+	//            "erc20Proxy": "0x1dc4c1cefef38a777b15aa20260a54e584b16c48",
+	//            "erc721Proxy": "0x1d7022f5b17d2f8b695918fb48fa1089c9f85401"
+	//         }
+	//    }
+	//
+	CustomContractAddresses string `envvar:"CUSTOM_CONTRACT_ADDRESSES" default:""`
 }
 
 type snapshotInfo struct {
@@ -128,6 +147,13 @@ func New(config Config) (*App, error) {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetLevel(log.Level(config.Verbosity))
 	log.AddHook(loghooks.NewKeySuffixHook())
+
+	// Add custom contract addresses if needed.
+	if config.CustomContractAddresses != "" {
+		if err := parseAndAddCustomContractAddresses(config.CustomContractAddresses); err != nil {
+			return nil, err
+		}
+	}
 
 	// Load private key and add peer ID hook.
 	privKeyPath := filepath.Join(config.DataDir, "keys", "privkey")
@@ -713,4 +739,21 @@ func (app *App) periodicallyLogStats(ctx context.Context) {
 func (app *App) SubscribeToOrderEvents(sink chan<- []*zeroex.OrderEvent) event.Subscription {
 	subscription := app.orderWatcher.Subscribe(sink)
 	return subscription
+}
+
+func parseAndAddCustomContractAddresses(encodedContractAddresses string) error {
+	customAddresses := map[string]ethereum.ContractAddresses{}
+	if err := json.Unmarshal([]byte(encodedContractAddresses), &customAddresses); err != nil {
+		return fmt.Errorf("config.CustomContractAddresses is invalid: %s", err.Error())
+	}
+	for networkIDString, contractAddresses := range customAddresses {
+		networkID, err := strconv.Atoi(networkIDString)
+		if err != nil {
+			return fmt.Errorf("config.CustomContractAddresses is invalid: could not decode networkID: %s", err.Error())
+		}
+		if err := ethereum.AddContractAddressesForNetworkID(networkID, contractAddresses); err != nil {
+			return fmt.Errorf("config.CustomContractAddresses is invalid: %s", err.Error())
+		}
+	}
+	return nil
 }

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -3,6 +3,7 @@ package ethereum
 import (
 	"fmt"
 
+	"github.com/0xProject/0x-mesh/constants"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -15,16 +16,40 @@ func GetContractAddressesForNetworkID(networkID int) (ContractAddresses, error) 
 	return ContractAddresses{}, fmt.Errorf("invalid network: %d", networkID)
 }
 
+func AddContractAddressesForNetworkID(networkID int, addresses ContractAddresses) error {
+	if _, alreadExists := NetworkIDToContractAddresses[networkID]; alreadExists {
+		return fmt.Errorf("cannot add contract addresses for network ID %d: addresses for this network id are already defined", networkID)
+	}
+	if addresses.Exchange == constants.NullAddress {
+		return fmt.Errorf("cannot add contract addresses for network ID %d: Exchange address is required", networkID)
+	}
+	if addresses.DevUtils == constants.NullAddress {
+		return fmt.Errorf("cannot add contract addresses for network ID %d: DevUtils address is required", networkID)
+	}
+	if addresses.ERC20Proxy == constants.NullAddress {
+		return fmt.Errorf("cannot add contract addresses for network ID %d: ERC20Proxy address is required", networkID)
+	}
+	if addresses.ERC721Proxy == constants.NullAddress {
+		return fmt.Errorf("cannot add contract addresses for network ID %d: ERC721Proxy address is required", networkID)
+	}
+	// TODO(albrow): Uncomment this if we re-add coordinator support.
+	// if addresses.CoordinatorRegistry == constants.NullAddress {
+	// 	return fmt.Errorf("cannot add contract addresses for network ID %d: CoordinatorRegistry address is required", networkID)
+	// }
+	NetworkIDToContractAddresses[networkID] = addresses
+	return nil
+}
+
 // ContractAddresses maps a contract's name to it's Ethereum address
 type ContractAddresses struct {
-	ERC20Proxy          common.Address
-	ERC721Proxy         common.Address
-	Exchange            common.Address
-	Coordinator         common.Address
-	CoordinatorRegistry common.Address
-	DevUtils            common.Address
-	WETH9               common.Address
-	ZRXToken            common.Address
+	ERC20Proxy          common.Address `json:"erc20Proxy"`
+	ERC721Proxy         common.Address `json:"erc721Proxy"`
+	Exchange            common.Address `json:"exchange"`
+	Coordinator         common.Address `json:"coordinator"`
+	CoordinatorRegistry common.Address `json:"coordinatorRegistry"`
+	DevUtils            common.Address `json:"devUtils"`
+	WETH9               common.Address `json:"weth9"`
+	ZRXToken            common.Address `json:"zrxToken"`
 }
 
 // NetworkIDToContractAddresses maps networkId to a mapping of contract name to Ethereum address

--- a/integration-tests/browser/src/index.ts
+++ b/integration-tests/browser/src/index.ts
@@ -45,6 +45,21 @@ provider.start();
         ethereumRPCURL,
         ethereumNetworkID: 50,
         bootstrapList: ['/ip4/127.0.0.1/tcp/60500/ws/ipfs/16Uiu2HAmGd949LwaV4KNvK2WDSiMVy7xEmW983VH75CMmefmMpP7'],
+        // Note(albrow): customContractAddresses is not actually required for
+        // the integration tests. Including them it here to test parsing and
+        // passing custom contract addresses to Go.
+        customContractAddresses: {
+            '999': {
+                erc20Proxy: '0x1dc4c1cefef38a777b15aa20260a54e584b16c48',
+                erc721Proxy: '0x1d7022f5b17d2f8b695918fb48fa1089c9f85401',
+                exchange: '0x48bacb9266a570d521063ef5dd96e61686dbe788',
+                coordinator: '0x0d8b0dd11f5d34ed41d556def5f841900d5b1c6b',
+                coordinatorRegistry: '0x1941ff73d1154774d87521d2d0aaad5d19c8df60',
+                devUtils: '0x38ef19fdf8e8415f18c307ed71967e19aac28ba1',
+                weth9: '0x0b1ba0af832d7c05fd64161e0db78e85978e8082',
+                zrxToken: '0x871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
+            },
+        },
     });
 
     // This handler will be called whenver there is a critical error.

--- a/integration-tests/browser/src/index.ts
+++ b/integration-tests/browser/src/index.ts
@@ -45,21 +45,6 @@ provider.start();
         ethereumRPCURL,
         ethereumNetworkID: 50,
         bootstrapList: ['/ip4/127.0.0.1/tcp/60500/ws/ipfs/16Uiu2HAmGd949LwaV4KNvK2WDSiMVy7xEmW983VH75CMmefmMpP7'],
-        // Note(albrow): customContractAddresses is not actually required for
-        // the integration tests. Including them it here to test parsing and
-        // passing custom contract addresses to Go.
-        customContractAddresses: {
-            '999': {
-                erc20Proxy: '0x1dc4c1cefef38a777b15aa20260a54e584b16c48',
-                erc721Proxy: '0x1d7022f5b17d2f8b695918fb48fa1089c9f85401',
-                exchange: '0x48bacb9266a570d521063ef5dd96e61686dbe788',
-                coordinator: '0x0d8b0dd11f5d34ed41d556def5f841900d5b1c6b',
-                coordinatorRegistry: '0x1941ff73d1154774d87521d2d0aaad5d19c8df60',
-                devUtils: '0x38ef19fdf8e8415f18c307ed71967e19aac28ba1',
-                weth9: '0x0b1ba0af832d7c05fd64161e0db78e85978e8082',
-                zrxToken: '0x871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
-            },
-        },
     });
 
     // This handler will be called whenver there is a critical error.


### PR DESCRIPTION
This PR adds support for declaring a custom network ID and custom contract addresses. This is primarily intended for testing purposes and allows Mesh to be used with local Ethereum networks other than Ganache.