### PR TITLE
Temporarily disable bandwidth-based rate-limiting

### DIFF
--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -77,26 +77,30 @@ func (checker *bandwidthChecker) checkUsage() {
 				"remotePeerID":      remotePeerID.String(),
 				"bytesPerSecondIn":  stats.RateIn,
 				"maxBytesPerSecond": checker.maxBytesPerSecond,
-			}).Warn("banning peer due to high bandwidth usage")
+			}).Warn("would ban peer due to high bandwidth usage")
 			// There are possibly multiple connections to each peer. We ban the IP
 			// address associated with each connection.
 			for _, conn := range checker.node.host.Network().ConnsToPeer(remotePeerID) {
-				if err := checker.node.BanIP(conn.RemoteMultiaddr()); err != nil {
-					if err == errProtectedIP {
-						continue
-					}
-					log.WithFields(log.Fields{
-						"remotePeerID":    remotePeerID.String(),
-						"remoteMultiaddr": conn.RemoteMultiaddr().String(),
-						"error":           err.Error(),
-					}).Error("could not ban peer")
-				}
+				// TODO(albrow): We don't actually ban for now due to an apparent bug in
+				// libp2p's BandwidthCounter. Uncomment this once the issue is resolved.
+				// See: https://github.com/libp2p/go-libp2p-core/issues/65
+				//
+				// if err := checker.node.BanIP(conn.RemoteMultiaddr()); err != nil {
+				// 	if err == errProtectedIP {
+				// 		continue
+				// 	}
+				// 	log.WithFields(log.Fields{
+				// 		"remotePeerID":    remotePeerID.String(),
+				// 		"remoteMultiaddr": conn.RemoteMultiaddr().String(),
+				// 		"error":           err.Error(),
+				// 	}).Error("could not ban peer")
+				// }
 				log.WithFields(log.Fields{
 					"remotePeerID":      remotePeerID.String(),
 					"remoteMultiaddr":   conn.RemoteMultiaddr().String(),
 					"rateIn":            stats.RateIn,
 					"maxBytesPerSecond": checker.maxBytesPerSecond,
-				}).Trace("banning IP/multiaddress due to high bandwidth usage")
+				}).Trace("would ban IP/multiaddress due to high bandwidth usage")
 			}
 			// Banning the IP doesn't close the connection, so we do that
 			// separately. ClosePeer closes all connections to the given peer.

--- a/p2p/bandwidth_checker_test.go
+++ b/p2p/bandwidth_checker_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestBandwidthChecker(t *testing.T) {
+	// TODO(albrow): Unskip this test.
+	t.Skip("Skipping due to apparent bug in libp2p's BandwidthCounter")
+
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
See https://github.com/libp2p/go-libp2p-core/issues/65. We're still checking bandwidth and logging in cases where we *would have* banned a peer.