### PR TITLE
core, orderwatch, meshdb: Implement a dynamically decreasing max expiration time for orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v5.2.0-beta
+
+### Features ✅ 
+
+- Implemented a new strategy for limiting the amount of database storage used by Mesh and removing orders when the database is full. This strategy involves a dynamically adjusting maximum expiration time. When the database is full, Mesh will enforce a maximum expiration time for all incoming orders and remove any existing orders with an expiration time too far in the future. If conditions change and there is enough space in the database again, the max expiration time will slowly increase. This is a short term solution which solves the immediate issue of finite storage capacities and does a decent job of protecting against spam. We expect to improve and possibly replace it in the future. See [#450](https://github.com/0xProject/0x-mesh/pull/450) for more details.
+
 ## v5.1.0-beta
 
 ### Features ✅ 

--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -87,6 +87,7 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 		UseBootstrapList:            true,
 		BlockPollingInterval:        5 * time.Second,
 		EthereumRPCMaxContentLength: 524288,
+		MaxOrdersInStorage:          100000,
 	}
 
 	// Required config options

--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -123,6 +123,9 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 	if customContractAddresses := jsConfig.Get("customContractAddresses"); !isNullOrUndefined(customContractAddresses) {
 		config.CustomContractAddresses = customContractAddresses.String()
 	}
+	if maxOrdersInStorage := jsConfig.Get("maxOrdersInStorage"); !isNullOrUndefined(maxOrdersInStorage) {
+		config.MaxOrdersInStorage = maxOrdersInStorage.Int()
+	}
 
 	return config, nil
 }

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -85,7 +85,7 @@ export interface Config {
     // The maximum number of orders that Mesh will keep in storage. As the
     // number of orders in storage grows, Mesh will begin enforcing a limit on
     // maximum expiration time for incoming orders and remove any orders with an
-    // expiration time too far in the future.
+    // expiration time too far in the future. Defaults to 100,000.
     maxOrdersInStorage?: number;
 }
 

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -66,14 +66,13 @@ export interface Config {
     // Parity, feel free to double the default max in order to reduce the number
     // of RPC calls made by Mesh. Defaults to 524288 bytes.
     ethereumRPCMaxContentLength?: number;
-    // customContractAddresses is set of custom addresses to use for the
-    // configured network ID. The contract addresses for most common networks
-    // are already included by default, so this is typically only needed for
-    // testing on custom networks. The given addresses are added to the default
-    // list of addresses for known networks and overriding any contract
-    // addresses for known networks is not allowed. The addresses for exchange,
-    // devUtils, erc20Proxy, and erc721Proxy are required for each network. For
-    // example:
+    // A set of custom addresses to use for the configured network ID. The
+    // contract addresses for most common networks are already included by
+    // default, so this is typically only needed for testing on custom networks.
+    // The given addresses are added to the default list of addresses for known
+    // networks and overriding any contract addresses for known networks is not
+    // allowed. The addresses for exchange, devUtils, erc20Proxy, and
+    // erc721Proxy are required for each network. For example:
     //
     //    {
     //        exchange: "0x48bacb9266a570d521063ef5dd96e61686dbe788",
@@ -83,6 +82,11 @@ export interface Config {
     //    }
     //
     customContractAddresses?: ContractAddresses;
+    // The maximum number of orders that Mesh will keep in storage. As the
+    // number of orders in storage grows, Mesh will begin enforcing a limit on
+    // maximum expiration time for incoming orders and remove any orders with an
+    // expiration time too far in the future.
+    maxOrdersInStorage?: number;
 }
 
 export interface ContractAddresses {
@@ -133,6 +137,7 @@ interface WrapperConfig {
     blockPollingIntervalSeconds?: number;
     ethereumRPCMaxContentLength?: number;
     customContractAddresses?: string; // json-encoded instead of Object.
+    maxOrdersInStorage?: number;
 }
 
 // The type for signed orders exposed by MeshWrapper. Unlike other types, the

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -399,6 +399,7 @@ export enum OrderEventEndState {
     Expired = 'EXPIRED',
     Unfunded = 'UNFUNDED',
     FillabilityIncreased = 'FILLABILITY_INCREASED',
+    StoppedWatching = 'STOPPED_WATCHING',
 }
 
 interface WrapperOrderEvent {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -2,6 +2,7 @@ package constants
 
 import (
 	"errors"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -60,3 +61,11 @@ var ErrInternal = errors.New("internal error")
 
 // TestMaxContentLength is the max Ethereum RPC Content-Length used in tests
 var TestMaxContentLength = 1024 * 512
+
+// UnlimitedExpirationTime is the maximum value for uint256, which mens there is
+// effectively no limit on the maximum expiration time for orders.
+var UnlimitedExpirationTime *big.Int
+
+func init() {
+	UnlimitedExpirationTime, _ = big.NewInt(2).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
+}

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -62,10 +62,11 @@ var ErrInternal = errors.New("internal error")
 // TestMaxContentLength is the max Ethereum RPC Content-Length used in tests
 var TestMaxContentLength = 1024 * 512
 
-// UnlimitedExpirationTime is the maximum value for uint256, which means there is
-// effectively no limit on the maximum expiration time for orders.
+// UnlimitedExpirationTime is the maximum value for uint256 (2^256-1), which
+// means there is effectively no limit on the maximum expiration time for
+// orders.
 var UnlimitedExpirationTime *big.Int
 
 func init() {
-	UnlimitedExpirationTime, _ = big.NewInt(2).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
+	UnlimitedExpirationTime, _ = big.NewInt(0).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
 }

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -62,7 +62,7 @@ var ErrInternal = errors.New("internal error")
 // TestMaxContentLength is the max Ethereum RPC Content-Length used in tests
 var TestMaxContentLength = 1024 * 512
 
-// UnlimitedExpirationTime is the maximum value for uint256, which mens there is
+// UnlimitedExpirationTime is the maximum value for uint256, which means there is
 // effectively no limit on the maximum expiration time for orders.
 var UnlimitedExpirationTime *big.Int
 

--- a/core/core.go
+++ b/core/core.go
@@ -218,6 +218,7 @@ func New(config Config) (*App, error) {
 	}
 
 	// Initialize order watcher (but don't start it yet).
+	// TODO(albrow): Load previous max expiration time from the database.
 	orderWatcher, err := orderwatch.New(orderwatch.Config{
 		MeshDB:           meshDB,
 		BlockWatcher:     blockWatcher,

--- a/core/core.go
+++ b/core/core.go
@@ -118,7 +118,7 @@ type Config struct {
 	// storage. As the number of orders in storage grows, Mesh will begin
 	// enforcing a limit on maximum expiration time for incoming orders and remove
 	// any orders with an expiration time too far in the future.
-	MaxOrdersInStorage int `envvar:"MAX_ORDERS_IN_STORAGE" default:"10000"`
+	MaxOrdersInStorage int `envvar:"MAX_ORDERS_IN_STORAGE" default:"100000"`
 }
 
 type snapshotInfo struct {

--- a/core/core.go
+++ b/core/core.go
@@ -748,6 +748,7 @@ func (app *App) GetStats() (*rpc.GetStatsResponse, error) {
 		NumOrders:                 numOrders,
 		NumPeers:                  app.node.GetNumPeers(),
 		NumOrdersIncludingRemoved: numOrdersIncludingRemoved,
+		MaxExpirationTime:         app.orderWatcher.MaxExpirationTime().String(),
 	}
 	return response, nil
 }
@@ -776,6 +777,7 @@ func (app *App) periodicallyLogStats(ctx context.Context) {
 			"numOrders":                 stats.NumOrders,
 			"numOrdersIncludingRemoved": stats.NumOrdersIncludingRemoved,
 			"numPeers":                  stats.NumPeers,
+			"maxExpirationTime":         stats.MaxExpirationTime,
 		}).Info("current stats")
 	}
 }

--- a/core/core.go
+++ b/core/core.go
@@ -114,6 +114,7 @@ type Config struct {
 	//    }
 	//
 	CustomContractAddresses string `envvar:"CUSTOM_CONTRACT_ADDRESSES" default:""`
+	// TODO(albrow): Add max orders as an env var.
 }
 
 type snapshotInfo struct {
@@ -213,7 +214,13 @@ func New(config Config) (*App, error) {
 	}
 
 	// Initialize order watcher (but don't start it yet).
-	orderWatcher, err := orderwatch.New(meshDB, blockWatcher, orderValidator, config.EthereumNetworkID, config.OrderExpirationBuffer)
+	orderWatcher, err := orderwatch.New(orderwatch.Config{
+		MeshDB:           meshDB,
+		BlockWatcher:     blockWatcher,
+		OrderValidator:   orderValidator,
+		NetworkID:        config.EthereumNetworkID,
+		ExpirationBuffer: config.OrderExpirationBuffer,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -114,7 +114,11 @@ type Config struct {
 	//    }
 	//
 	CustomContractAddresses string `envvar:"CUSTOM_CONTRACT_ADDRESSES" default:""`
-	// TODO(albrow): Add max orders as an env var.
+	// MaxOrdersInStorage is the maximum number of orders that Mesh will keep in
+	// storage. As the number of orders in storage grows, Mesh will begin
+	// enforcing a limit on maximum expiration time for incoming orders and remove
+	// any orders with an expiration time too far in the future.
+	MaxOrdersInStorage int `envvar:"MAX_ORDERS_IN_STORAGE" default:"10000"`
 }
 
 type snapshotInfo struct {
@@ -220,6 +224,7 @@ func New(config Config) (*App, error) {
 		OrderValidator:   orderValidator,
 		NetworkID:        config.EthereumNetworkID,
 		ExpirationBuffer: config.OrderExpirationBuffer,
+		MaxOrders:        config.MaxOrdersInStorage,
 	})
 	if err != nil {
 		return nil, err

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -17,14 +17,14 @@ func TestEthereumNetworkDetection(t *testing.T) {
 	defer meshDB.Close()
 
 	// simulate starting up on mainnet
-	err = initNetworkID(1, meshDB)
+	_, err = initMetadata(1, meshDB)
 	require.NoError(t, err)
 
 	// simulate restart on same network
-	err = initNetworkID(1, meshDB)
+	_, err = initMetadata(1, meshDB)
 	require.NoError(t, err)
 
 	// should error when attempting to start on different network
-	err = initNetworkID(2, meshDB)
+	_, err = initMetadata(2, meshDB)
 	assert.Error(t, err)
 }

--- a/core/validation.go
+++ b/core/validation.go
@@ -115,6 +115,15 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*ordervalidator.Va
 			})
 			continue
 		}
+		if order.ExpirationTimeSeconds.Cmp(app.orderWatcher.MaxExpirationTime()) == 1 {
+			results.Rejected = append(results.Rejected, &ordervalidator.RejectedOrderInfo{
+				OrderHash:   orderHash,
+				SignedOrder: order,
+				Kind:        ordervalidator.MeshValidation,
+				Status:      ordervalidator.ROMaxExpirationExceeded,
+			})
+			continue
+		}
 		// Note(albrow): Orders with a sender address can be canceled or invalidated
 		// off-chain which is difficult to support since we need to prune
 		// canceled/invalidated orders from the database. We can special-case some

--- a/docs/rpc_api.md
+++ b/docs/rpc_api.md
@@ -204,7 +204,8 @@ Gets certain configurations and stats about a Mesh node.
         },
         "numPeers": 18,
         "numOrders": 1095,
-        "numOrdersIncludingRemoved": 1134
+        "numOrdersIncludingRemoved": 1134,
+        "maxExpirationTime": "717784680"
     },
     "id": 1
 }

--- a/meshdb/meshdb.go
+++ b/meshdb/meshdb.go
@@ -5,20 +5,13 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/db"
 	"github.com/0xProject/0x-mesh/ethereum/miniheader"
 	"github.com/0xProject/0x-mesh/zeroex"
 	"github.com/ethereum/go-ethereum/common"
 	log "github.com/sirupsen/logrus"
 )
-
-// unlimitedExpirationTime is the maximum value for uint256, which mens there is
-// effectively no limit on the maximum expiration time for orders.
-var unlimitedExpirationTime *big.Int
-
-func init() {
-	unlimitedExpirationTime, _ = big.NewInt(2).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
-}
 
 // Order is the database representation a 0x order along with some relevant metadata
 type Order struct {
@@ -391,8 +384,8 @@ func (m *MeshDB) TrimOrdersByExpirationTime(targetMaxOrders int) (newMaxExpirati
 	}
 	if numOrders <= targetMaxOrders {
 		// If the number of orders is less than the target, we don't need to remove
-		// any orders. Return the unlimitedExpirationTime.
-		return unlimitedExpirationTime, nil, nil
+		// any orders. Return UnlimitedExpirationTime.
+		return constants.UnlimitedExpirationTime, nil, nil
 	}
 
 	// Find the orders which we need to remove.

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -85,6 +85,7 @@ type GetStatsResponse struct {
 	NumPeers                  int         `json:"numPeers"`
 	NumOrders                 int         `json:"numOrders"`
 	NumOrdersIncludingRemoved int         `json:"numOrdersIncludingRemoved"`
+	MaxExpirationTime         string      `json:"maxExpirationTime"`
 }
 
 // GetStats retrieves stats about the Mesh node

--- a/rpc/clients/typescript/src/types.ts
+++ b/rpc/clients/typescript/src/types.ts
@@ -419,4 +419,5 @@ export interface GetStatsResponse {
     numPeers: number;
     numOrders: number;
     numOrdersIncludingRemoved: number;
+    maxExpirationTime: string;
 }

--- a/scenario/scenario.go
+++ b/scenario/scenario.go
@@ -97,6 +97,32 @@ func CreateZRXForWETHSignedTestOrder(t *testing.T, ethClient *ethclient.Client, 
 	return signedTestOrder
 }
 
+// CreateSignedTestOrderWithExpirationTime creates a valid 0x orders where the maker wishes to trade ZRX for WETH
+func CreateSignedTestOrderWithExpirationTime(t *testing.T, ethClient *ethclient.Client, makerAddress, takerAddress common.Address, expirationTime time.Time) *zeroex.SignedOrder {
+	// Create order
+	testOrder := &zeroex.Order{
+		MakerAddress:          makerAddress,
+		TakerAddress:          constants.NullAddress,
+		SenderAddress:         constants.NullAddress,
+		FeeRecipientAddress:   common.HexToAddress("0xa258b39954cef5cb142fd567a46cddb31a670124"),
+		MakerAssetData:        common.Hex2Bytes("f47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c"),
+		TakerAssetData:        common.Hex2Bytes("f47261b00000000000000000000000000b1ba0af832d7c05fd64161e0db78e85978e8082"),
+		Salt:                  big.NewInt(1548619145450),
+		MakerFee:              big.NewInt(0),
+		TakerFee:              big.NewInt(0),
+		MakerAssetAmount:      big.NewInt(0),
+		TakerAssetAmount:      big.NewInt(0),
+		ExpirationTimeSeconds: big.NewInt(expirationTime.Unix()),
+		ExchangeAddress:       ethereum.NetworkIDToContractAddresses[constants.TestNetworkID].Exchange,
+	}
+
+	// Sign Order
+	signedTestOrder, err := zeroex.SignTestOrder(testOrder)
+	require.NoError(t, err, "could not sign order")
+
+	return signedTestOrder
+}
+
 // CreateWETHForZRXSignedTestOrder creates a valid 0x orders where the maker wishes to trade WETH for ZRX
 func CreateWETHForZRXSignedTestOrder(t *testing.T, ethClient *ethclient.Client, makerAddress, takerAddress common.Address, wethAmount *big.Int, zrxAmount *big.Int) *zeroex.SignedOrder {
 	// Create order

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -183,7 +183,7 @@ const (
 	// (e.g. the database is full or the peer that sent the order was
 	// misbehaving). The order will no longer be watched and no further events for
 	// this order will be emitted. In some cases, the order may be re-added in the
-	// future.
+	// future. TOOD(albrow): Rename this.
 	ESOrderRemoved = OrderEventEndState("REMOVED")
 )
 

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -183,8 +183,8 @@ const (
 	// (e.g. the database is full or the peer that sent the order was
 	// misbehaving). The order will no longer be watched and no further events for
 	// this order will be emitted. In some cases, the order may be re-added in the
-	// future. TOOD(albrow): Rename this.
-	ESOrderRemoved = OrderEventEndState("REMOVED")
+	// future.
+	ESStoppedWatching = OrderEventEndState("STOPPED_WATCHING")
 )
 
 var eip712OrderTypes = signer.Types{

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -179,6 +179,12 @@ const (
 	// Fillability for an order can increase if a previously processed fill event
 	// gets reverted, or if a maker tops up their balance/allowance backing an order
 	ESOrderFillabilityIncreased = OrderEventEndState("FILLABILITY_INCREASED")
+	// Order is potentially still valid but was removed for a different reason
+	// (e.g. the database is full or the peer that sent the order was
+	// misbehaving). The order will no longer be watched and no further events for
+	// this order will be emitted. In some cases, the order may be re-added in the
+	// future.
+	ESOrderRemoved = OrderEventEndState("REMOVED")
 )
 
 var eip712OrderTypes = signer.Types{

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -97,14 +97,13 @@ func New(config Config) (*Watcher, error) {
 	}
 
 	// Configure a SlowCounter to be used for increasing max expiration time.
+	// This configuration means the first increment will increase the max
+	// expiration time by 10 seconds. Each subsequent increment will double the
+	// amount by which we increase the max expiration time (by 20 seconds, 40
+	// seconds, 80 seconds, etc.).
 	slowCounterConfig := slowcounter.Config{
-		// TODO(albrow): the way rate works makes it difficult to tune. Ideally we
-		// would like to increase by one hour, then two, then four, etc. But the
-		// fact that we are dealing with a time means the magnitude of the number is
-		// quite high. So if we wanted to increase by one hour, the next iteration
-		// would only increase by slightly more than an hour. Could improve by using
-		// a more complicated exponential growth formula.
-		Rate:               1.125,
+		StartingOffset:     big.NewInt(5),
+		Rate:               2,
 		MinDelayBeforeIncr: 5 * time.Minute,
 		MinTicksBeforeIncr: 10,
 		MaxCount:           constants.UnlimitedExpirationTime,

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -693,7 +693,7 @@ func (w *Watcher) Add(orderInfo *ordervalidator.AcceptedOrderInfo) error {
 		// differently depending on whether the order was received via RPC or from a
 		// peer. In the former case, we should return an RPC error response
 		// indicating that the order was not in fact added. In the latter case, we
-		// should effectively no-op, nether penalizing the peer or emitting any
+		// should effectively no-op, neither penalizing the peer or emitting any
 		// order events. For now, we respond by emitting an ADDED event immediately
 		// followed by a STOPPED_WATCHING event. If this order was submitted via
 		// RPC, the RPC client will see a response that indicates the order was

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -109,12 +109,12 @@ func New(config Config) (*Watcher, error) {
 		return nil, err
 	}
 
-	// Apply defaults to config.
+	// Validate config.
 	if config.MaxOrders == 0 {
-		config.MaxOrders = defaultMaxOrders
+		return nil, errors.New("config.MaxOrders is required and cannot be zero")
 	}
 	if config.MaxExpirationTime == nil {
-		config.MaxExpirationTime = constants.UnlimitedExpirationTime
+		return nil, errors.New("config.MaxExpirationTime is required and cannot be nil")
 	} else if big.NewInt(time.Now().Unix()).Cmp(config.MaxExpirationTime) == 1 {
 		// MaxExpirationTime should never be in the past.
 		config.MaxExpirationTime = big.NewInt(time.Now().Unix())

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -41,7 +41,7 @@ var permanentlyDeleteAfter = 4 * time.Minute
 // orders
 var expirationPollingInterval = 50 * time.Millisecond
 
-// maxOrdersTrimRatio affects how many orders are trimmed whenver we reach the
+// maxOrdersTrimRatio affects how many orders are trimmed whenever we reach the
 // maximum number of orders. When order storage is full, Watcher will remove
 // orders until the total number of remaining orders is equal to
 // maxOrdersTrimRatio * maxOrders.

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -147,7 +147,7 @@ func New(config Config) (*Watcher, error) {
 		maxOrders:                  config.MaxOrders,
 	}
 
-	// Check if any orders need to be rmoved right away due to high expiration
+	// Check if any orders need to be removed right away due to high expiration
 	// times.
 	if err := w.decreaseMaxExpirationTimeIfNeeded(); err != nil {
 		return nil, err

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -47,7 +47,7 @@ var expirationPollingInterval = 50 * time.Millisecond
 // maxOrdersTrimRatio * maxOrders.
 const maxOrdersTrimRatio = 0.9
 
-const defaultMaxOrders = 10000
+const defaultMaxOrders = 100000
 
 // Watcher watches all order-relevant state and handles the state transitions
 type Watcher struct {

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -676,6 +676,7 @@ func (w *Watcher) trimOrdersAndFireEvents() error {
 			EndState:                 zeroex.ESOrderRemoved,
 		}
 		w.orderFeed.Send([]*zeroex.OrderEvent{orderEvent})
+		// TODO(albrow): remove order from in-memory state.
 	}
 	if newMaxExpirationTime.Cmp(w.maxExpirationTime) == -1 {
 		// Decrease the max expiration time to account for the fact that orders were

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -301,7 +301,7 @@ func (w *Watcher) maxExpirationTimeLoop(ctx context.Context) error {
 			ticker.Stop()
 			return nil
 		case <-ticker.C:
-			if err := w.checkIncreaseMaxExpirationTime(); err != nil {
+			if err := w.increaseMaxExpirationTimeIfPossible(); err != nil {
 				return err
 			}
 		}
@@ -1170,7 +1170,7 @@ func (w *Watcher) decreaseMaxExpirationTimeIfNeeded() error {
 	return nil
 }
 
-func (w *Watcher) checkIncreaseMaxExpirationTime() error {
+func (w *Watcher) increaseMaxExpirationTimeIfPossible() error {
 	if orderCount, err := w.meshDB.Orders.Count(); err != nil {
 		return err
 	} else if orderCount < w.maxOrders {

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -99,6 +99,9 @@ func New(config Config) (*Watcher, error) {
 	}
 	if config.MaxExpirationTime == nil {
 		config.MaxExpirationTime = constants.UnlimitedExpirationTime
+	} else if big.NewInt(time.Now().Unix()).Cmp(config.MaxExpirationTime) == 1 {
+		// MaxExpirationTime should never be in the past.
+		config.MaxExpirationTime = big.NewInt(time.Now().Unix())
 	}
 
 	// Configure a SlowCounter to be used for increasing max expiration time.

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -739,12 +739,12 @@ func (w *Watcher) trimOrdersAndFireEvents() error {
 		}).Debug("removing orders to make space")
 	}
 	for _, removedOrder := range removedOrders {
-		// Fire a "REMOVED" event for each order that was removed.
+		// Fire a "STOPPED_WATCHING" event for each order that was removed.
 		orderEvent := &zeroex.OrderEvent{
 			OrderHash:                removedOrder.Hash,
 			SignedOrder:              removedOrder.SignedOrder,
 			FillableTakerAssetAmount: removedOrder.FillableTakerAssetAmount,
-			EndState:                 zeroex.ESOrderRemoved,
+			EndState:                 zeroex.ESStoppedWatching,
 		}
 		w.orderFeed.Send([]*zeroex.OrderEvent{orderEvent})
 

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1162,7 +1162,7 @@ func (w *Watcher) removeAssetDataAddressFromEventDecoder(assetData []byte) error
 func (w *Watcher) decreaseMaxExpirationTimeIfNeeded() error {
 	if orderCount, err := w.meshDB.Orders.Count(); err != nil {
 		return err
-	} else if orderCount+1 >= w.maxOrders {
+	} else if orderCount+1 > w.maxOrders {
 		if err := w.trimOrdersAndFireEvents(); err != nil {
 			return err
 		}

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -691,6 +691,12 @@ func (w *Watcher) trimOrdersAndFireEvents() error {
 	return nil
 }
 
+// MaxExpirationTime returns the current maximum expiration time for incoming
+// orders.
+func (w *Watcher) MaxExpirationTime() *big.Int {
+	return w.maxExpirationTime
+}
+
 func (w *Watcher) setupInMemoryOrderState(signedOrder *zeroex.SignedOrder) error {
 	orderHash, err := signedOrder.ComputeOrderHash()
 	if err != nil {

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -700,13 +700,13 @@ func TestOrderWatcherDecreaseExpirationTime(t *testing.T) {
 	orderEvents := waitForOrderEvents(t, orderEventsChan, expectedOrderEvents, 4*time.Second)
 	require.Len(t, orderEvents, expectedOrderEvents, "wrong number of order events were fired")
 	for i, orderEvent := range orderEvents {
-		// Last event should be ADDED. The other events should be REMOVED.
+		// Last event should be ADDED. The other events should be STOPPED_WATCHING.
 		if i == expectedOrderEvents-1 {
 			assert.Equal(t, zeroex.ESOrderAdded, orderEvent.EndState, "order event %d had wrong EndState", i)
 		} else {
-			// For REMOVED events, we also make sure that the expiration time is after
+			// For STOPPED_WATCHING events, we also make sure that the expiration time is after
 			// the current max expiration time.
-			assert.Equal(t, zeroex.ESOrderRemoved, orderEvent.EndState, "order event %d had wrong EndState", i)
+			assert.Equal(t, zeroex.ESStoppedWatching, orderEvent.EndState, "order event %d had wrong EndState", i)
 			orderExpirationTime := orderEvent.SignedOrder.ExpirationTimeSeconds
 			assert.True(t, orderExpirationTime.Cmp(orderWatcher.MaxExpirationTime()) != -1, "remaining order has an expiration time of %s which is *less than* the maximum of %s", orderExpirationTime, orderWatcher.MaxExpirationTime())
 		}

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -767,11 +767,13 @@ func setupOrderWatcher(ctx context.Context, t *testing.T, ethClient *ethclient.C
 	orderValidator, err := ordervalidator.New(ethClient, constants.TestNetworkID, ethereumRPCMaxContentLength, 0)
 	require.NoError(t, err)
 	orderWatcher, err := New(Config{
-		MeshDB:           meshDB,
-		BlockWatcher:     blockWatcher,
-		OrderValidator:   orderValidator,
-		NetworkID:        constants.TestNetworkID,
-		ExpirationBuffer: 0,
+		MeshDB:            meshDB,
+		BlockWatcher:      blockWatcher,
+		OrderValidator:    orderValidator,
+		NetworkID:         constants.TestNetworkID,
+		ExpirationBuffer:  0,
+		MaxExpirationTime: constants.UnlimitedExpirationTime,
+		MaxOrders:         1000,
 	})
 	require.NoError(t, err)
 

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -699,7 +699,13 @@ func setupOrderWatcher(ctx context.Context, t *testing.T, ethClient *ethclient.C
 	blockWatcher := blockwatch.New(blockWatcherConfig)
 	orderValidator, err := ordervalidator.New(ethClient, constants.TestNetworkID, ethereumRPCMaxContentLength, 0)
 	require.NoError(t, err)
-	orderWatcher, err := New(meshDB, blockWatcher, orderValidator, constants.TestNetworkID, 0)
+	orderWatcher, err := New(Config{
+		MeshDB:           meshDB,
+		BlockWatcher:     blockWatcher,
+		OrderValidator:   orderValidator,
+		NetworkID:        constants.TestNetworkID,
+		ExpirationBuffer: 0,
+	})
 	require.NoError(t, err)
 
 	// Start the block watcher.

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -5,7 +5,6 @@ package orderwatch
 import (
 	"context"
 	"flag"
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -35,13 +34,26 @@ const (
 	ethereumRPCMaxContentLength = 524288
 )
 
-var makerAddress = constants.GanacheAccount1
-var takerAddress = constants.GanacheAccount2
-var eighteenDecimalsInBaseUnits = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
-var wethAmount = new(big.Int).Mul(big.NewInt(50), eighteenDecimalsInBaseUnits)
-var zrxAmount = new(big.Int).Mul(big.NewInt(100), eighteenDecimalsInBaseUnits)
-var erc1155FungibleAmount = big.NewInt(100)
-var tokenID = big.NewInt(1)
+var (
+	makerAddress                = constants.GanacheAccount1
+	takerAddress                = constants.GanacheAccount2
+	eighteenDecimalsInBaseUnits = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	wethAmount                  = new(big.Int).Mul(big.NewInt(50), eighteenDecimalsInBaseUnits)
+	zrxAmount                   = new(big.Int).Mul(big.NewInt(100), eighteenDecimalsInBaseUnits)
+	erc1155FungibleAmount       = big.NewInt(100)
+	tokenID                     = big.NewInt(1)
+)
+
+var (
+	rpcClient           *ethrpc.Client
+	ethClient           *ethclient.Client
+	zrx                 *wrappers.ZRXToken
+	dummyERC721Token    *wrappers.DummyERC721Token
+	erc1155Mintable     *wrappers.ERC1155Mintable
+	exchange            *wrappers.Exchange
+	weth                *wrappers.WETH9
+	blockchainLifecycle *ethereum.BlockchainLifecycle
+)
 
 // Since these tests must be run sequentially, we don't want them to run as part of
 // the normal testing process. They will only be run if the "--serial" flag is used.
@@ -51,14 +63,6 @@ func init() {
 	flag.BoolVar(&serialTestsEnabled, "serial", false, "enable serial tests")
 	flag.Parse()
 }
-
-var rpcClient *ethrpc.Client
-var ethClient *ethclient.Client
-var zrx *wrappers.ZRXToken
-var dummyERC721Token *wrappers.DummyERC721Token
-var erc1155Mintable *wrappers.ERC1155Mintable
-var exchange *wrappers.Exchange
-var weth *wrappers.WETH9
 
 func init() {
 	var err error
@@ -119,7 +123,7 @@ func TestOrderWatcherUnfundedInsufficientERC20Balance(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderBecameUnfunded, orderEvent.EndState)
@@ -158,7 +162,7 @@ func TestOrderWatcherUnfundedInsufficientERC721Balance(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderBecameUnfunded, orderEvent.EndState)
@@ -198,7 +202,7 @@ func TestOrderWatcherUnfundedInsufficientERC721Allowance(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderBecameUnfunded, orderEvent.EndState)
@@ -238,7 +242,7 @@ func TestOrderWatcherUnfundedInsufficientERC1155Allowance(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderBecameUnfunded, orderEvent.EndState)
@@ -277,7 +281,7 @@ func TestOrderWatcherUnfundedInsufficientERC1155Balance(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderBecameUnfunded, orderEvent.EndState)
@@ -317,7 +321,7 @@ func TestOrderWatcherUnfundedInsufficientERC20Allowance(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderBecameUnfunded, orderEvent.EndState)
@@ -356,7 +360,7 @@ func TestOrderWatcherUnfundedThenFundedAgain(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderBecameUnfunded, orderEvent.EndState)
@@ -464,7 +468,7 @@ func TestOrderWatcherWETHWithdrawAndDeposit(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderBecameUnfunded, orderEvent.EndState)
@@ -525,7 +529,7 @@ func TestOrderWatcherCanceled(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderCancelled, orderEvent.EndState)
@@ -565,7 +569,7 @@ func TestOrderWatcherCancelUpTo(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderCancelled, orderEvent.EndState)
@@ -605,7 +609,7 @@ func TestOrderWatcherERC20Filled(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderFullyFilled, orderEvent.EndState)
@@ -646,7 +650,7 @@ func TestOrderWatcherERC20PartiallyFilled(t *testing.T) {
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, ethClient, txn)
 
-	orderEvents := waitForOrderEvents(t, orderEventsChan, 4*time.Second)
+	orderEvents := waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent := orderEvents[0]
 	assert.Equal(t, zeroex.ESOrderFilled, orderEvent.EndState)
@@ -660,10 +664,79 @@ func TestOrderWatcherERC20PartiallyFilled(t *testing.T) {
 	assert.Equal(t, halfAmount, orders[0].FillableTakerAssetAmount)
 }
 
+func TestOrderWatcherDecreaseExpirationTime(t *testing.T) {
+	if !serialTestsEnabled {
+		t.Skip("Serial tests (tests which cannot run in parallel) are disabled. You can enable them with the --serial flag")
+	}
+
+	// Set up test and orderWatcher. Manually change maxOrders.
+	teardownSubTest := setupSubTest(t)
+	defer teardownSubTest(t)
+	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer func() {
+		cancel()
+	}()
+	orderWatcher := setupOrderWatcher(ctx, t, ethClient, meshDB)
+	orderWatcher.maxOrders = 20
+
+	// create and watch maxOrders orders
+	for i := 0; i < orderWatcher.maxOrders; i++ {
+		signedOrder := scenario.CreateSignedTestOrderWithExpirationTime(t, ethClient, makerAddress, takerAddress, time.Now().Add(10*time.Minute+time.Duration(i)*time.Minute))
+		watchOrder(t, orderWatcher, signedOrder)
+	}
+
+	// We don't care about the order events above for the purposes of this test,
+	// so we only subscribe now.
+	orderEventsChan := make(chan []*zeroex.OrderEvent, 2*orderWatcher.maxOrders)
+	orderWatcher.Subscribe(orderEventsChan)
+
+	// The next order should cause some orders to be removed and the appropriate
+	// events to fire.
+	signedOrder := scenario.CreateSignedTestOrderWithExpirationTime(t, ethClient, makerAddress, takerAddress, time.Now().Add(10*time.Minute+1*time.Second))
+	watchOrder(t, orderWatcher, signedOrder)
+	expectedOrderEvents := int(float64(orderWatcher.maxOrders)*(1-maxOrdersTrimRatio)) + 1
+	orderEvents := waitForOrderEvents(t, orderEventsChan, expectedOrderEvents, 4*time.Second)
+	require.Len(t, orderEvents, expectedOrderEvents, "wrong number of order events were fired")
+	for i, orderEvent := range orderEvents {
+		// Last event should be ADDED. The other events should be REMOVED.
+		if i == expectedOrderEvents-1 {
+			assert.Equal(t, zeroex.ESOrderAdded, orderEvent.EndState, "order event %d had wrong EndState", i)
+		} else {
+			// For REMOVED events, we also make sure that the expiration time is after
+			// the current max expiration time.
+			assert.Equal(t, zeroex.ESOrderRemoved, orderEvent.EndState, "order event %d had wrong EndState", i)
+			orderExpirationTime := orderEvent.SignedOrder.ExpirationTimeSeconds
+			assert.True(t, orderExpirationTime.Cmp(orderWatcher.MaxExpirationTime()) != -1, "remaining order has an expiration time of %s which is *less than* the maximum of %s", orderExpirationTime, orderWatcher.MaxExpirationTime())
+		}
+	}
+
+	// Now we check that the correct number of orders remain and that all
+	// remaining orders have an expiration time less than the current max.
+	expectedRemainingOrders := int(float64(orderWatcher.maxOrders)*maxOrdersTrimRatio) + 1
+	var remainingOrders []*meshdb.Order
+	require.NoError(t, meshDB.Orders.FindAll(&remainingOrders))
+	require.Len(t, remainingOrders, expectedRemainingOrders)
+	for _, order := range remainingOrders {
+		assert.True(t, order.SignedOrder.ExpirationTimeSeconds.Cmp(orderWatcher.MaxExpirationTime()) == -1, "remaining order has an expiration time of %s which is *greater than* the maximum of %s", order.SignedOrder.ExpirationTimeSeconds, orderWatcher.MaxExpirationTime())
+	}
+}
+
 func setupOrderWatcherScenario(ctx context.Context, t *testing.T, ethClient *ethclient.Client, meshDB *meshdb.MeshDB, signedOrder *zeroex.SignedOrder) chan []*zeroex.OrderEvent {
 	orderWatcher := setupOrderWatcher(ctx, t, ethClient, meshDB)
 
 	// Start watching an order
+	watchOrder(t, orderWatcher, signedOrder)
+
+	// Subscribe to OrderWatcher
+	orderEventsChan := make(chan []*zeroex.OrderEvent, 10)
+	orderWatcher.Subscribe(orderEventsChan)
+
+	return orderEventsChan
+}
+
+func watchOrder(t *testing.T, orderWatcher *Watcher, signedOrder *zeroex.SignedOrder) {
 	orderHash, err := signedOrder.ComputeOrderHash()
 	require.NoError(t, err)
 	orderInfo := &ordervalidator.AcceptedOrderInfo{
@@ -674,12 +747,6 @@ func setupOrderWatcherScenario(ctx context.Context, t *testing.T, ethClient *eth
 	}
 	err = orderWatcher.Add(orderInfo)
 	require.NoError(t, err)
-
-	// Subscribe to OrderWatcher
-	orderEventsChan := make(chan []*zeroex.OrderEvent, 10)
-	orderWatcher.Subscribe(orderEventsChan)
-
-	return orderEventsChan
 }
 
 func setupOrderWatcher(ctx context.Context, t *testing.T, ethClient *ethclient.Client, meshDB *meshdb.MeshDB) *Watcher {
@@ -723,8 +790,6 @@ func setupOrderWatcher(ctx context.Context, t *testing.T, ethClient *ethclient.C
 	return orderWatcher
 }
 
-var blockchainLifecycle *ethereum.BlockchainLifecycle
-
 func setupSubTest(t *testing.T) func(t *testing.T) {
 	blockchainLifecycle.Start(t)
 	return func(t *testing.T) {
@@ -732,19 +797,20 @@ func setupSubTest(t *testing.T) func(t *testing.T) {
 	}
 }
 
-func waitForOrderEvents(t *testing.T, orderEventsChan <-chan []*zeroex.OrderEvent, timeout time.Duration) []*zeroex.OrderEvent {
-	start := time.Now()
-	select {
-	case orderEvents := <-orderEventsChan:
-		fmt.Println("orderEvents!", orderEvents)
-		return orderEvents
-	case <-time.After(timeout):
-		elapsed := time.Since(start)
-		fmt.Println("elapsed", elapsed)
-		fmt.Println("timeout!")
-		t.Fatal("timed out waiting for order events")
+func waitForOrderEvents(t *testing.T, orderEventsChan <-chan []*zeroex.OrderEvent, expectedNumberOfEvents int, timeout time.Duration) []*zeroex.OrderEvent {
+	allOrderEvents := []*zeroex.OrderEvent{}
+	for {
+		select {
+		case orderEvents := <-orderEventsChan:
+			allOrderEvents = append(allOrderEvents, orderEvents...)
+			if len(allOrderEvents) >= expectedNumberOfEvents {
+				return allOrderEvents
+			}
+			continue
+		case <-time.After(timeout):
+			t.Fatalf("timed out waiting for %d order events (received %d events)", expectedNumberOfEvents, len(allOrderEvents))
+		}
 	}
-	return []*zeroex.OrderEvent{}
 }
 
 func waitTxnSuccessfullyMined(t *testing.T, ethClient *ethclient.Client, txn *types.Transaction) {

--- a/zeroex/orderwatch/slowcounter/slow_counter.go
+++ b/zeroex/orderwatch/slowcounter/slow_counter.go
@@ -1,0 +1,108 @@
+package slowcounter
+
+import (
+	"errors"
+	"math/big"
+	"sync"
+	"time"
+)
+
+// SlowCounter is an exponentially increasing counter that is only incremented
+// after a certain number of "ticks" and/or a minimum time duration. It has a
+// few configuration  options to control the rate of increase.
+type SlowCounter struct {
+	mut                sync.Mutex
+	config             Config
+	rateRat            *big.Rat
+	lastIncr           time.Time
+	ticksSinceLastIncr int
+	interval           float64
+	currentCount       *big.Rat
+	// placeholder to minimize memory allocations.
+	nextCount *big.Rat
+}
+
+// Config is a set of configuration options for SlowCounter.
+type Config struct {
+	// Rate controls how much each increment increases the current count.
+	// SlowCounter uses the exponential growth formula:
+	//
+	//     nextCount = currentCount * rate
+	//
+	Rate *big.Rat
+	// MinDelayBeforeIncr is the minum amount of time to wait before the counter
+	// is incremented. Both MinDelayBeforeIncr and MinTicksBeforeIncr conditions
+	// must be satisfied in order for the counter to be incremented.
+	MinDelayBeforeIncr time.Duration
+	// MinTicksBeforeIncr is the minimum number of ticks befer the counter is
+	// incremented. Both MinDelayBeforeIncr and MinTicksBeforeIncr conditions
+	// must be satisfied in order for the counter to be incremented.
+	MinTicksBeforeIncr int
+	// MaxCount is the maximum value for the counter. After reaching MaxCount, the
+	// counter will stop incrementing.
+	MaxCount *big.Rat
+}
+
+// New returns a new SlowCounter with the given start count.
+func New(config Config, start *big.Rat) (*SlowCounter, error) {
+	if config.MaxCount == nil {
+		return nil, errors.New("config.MaxCount cannot be nil")
+	}
+	return &SlowCounter{
+		config:       config,
+		lastIncr:     time.Now(),
+		currentCount: start,
+		nextCount:    big.NewRat(1, 1),
+	}, nil
+}
+
+// Tick processes a single tick and may increment the counter if the required
+// conditions are met.
+func (sc *SlowCounter) Tick() {
+	sc.mut.Lock()
+	defer sc.mut.Unlock()
+
+	if sc.currentCount.Cmp(sc.config.MaxCount) == 0 {
+		// Count is already at maximum. Don't need to do anything.
+		return
+	}
+
+	sc.ticksSinceLastIncr += 1
+	minTicksHaveOccurred := sc.ticksSinceLastIncr >= sc.config.MinTicksBeforeIncr
+	minTimeHasPassed := time.Now().After(sc.lastIncr.Add(sc.config.MinDelayBeforeIncr))
+	if minTicksHaveOccurred && minTimeHasPassed {
+		sc.incr()
+	}
+}
+
+// incr increments the counter.
+func (sc *SlowCounter) incr() {
+	sc.lastIncr = time.Now()
+	sc.ticksSinceLastIncr = 0
+
+	// Use the exponential growth forumula to determine nextCount. The following
+	// is written to minimize new memory allocations.
+	sc.currentCount = sc.currentCount.Mul(sc.currentCount, sc.config.Rate)
+
+	// If currentCount is greater than MaxCount, set it to MaxCount.
+	if sc.currentCount.Cmp(sc.config.MaxCount) == 1 {
+		sc.currentCount.Set(sc.config.MaxCount)
+	}
+}
+
+// Count returns the current count.
+func (sc *SlowCounter) Count() *big.Rat {
+	return sc.currentCount
+}
+
+// Reset resets the counter to the given count. This also resets the conditions
+// for MinDelayBeforeIncr and MinTicksBeforeIncr.
+func (sc *SlowCounter) Reset(count *big.Rat) {
+	sc.mut.Lock()
+	defer sc.mut.Unlock()
+
+	sc.lastIncr = time.Now()
+	sc.ticksSinceLastIncr = 0
+	sc.interval = 0
+	sc.currentCount.Set(count)
+}

--- a/zeroex/orderwatch/slowcounter/slow_counter.go
+++ b/zeroex/orderwatch/slowcounter/slow_counter.go
@@ -57,14 +57,14 @@ func New(config Config, start *big.Rat) (*SlowCounter, error) {
 }
 
 // Tick processes a single tick and may increment the counter if the required
-// conditions are met.
-func (sc *SlowCounter) Tick() {
+// conditions are met. Returns true if the counter was incremented.
+func (sc *SlowCounter) Tick() bool {
 	sc.mut.Lock()
 	defer sc.mut.Unlock()
 
 	if sc.currentCount.Cmp(sc.config.MaxCount) == 0 {
 		// Count is already at maximum. Don't need to do anything.
-		return
+		return false
 	}
 
 	sc.ticksSinceLastIncr += 1
@@ -72,7 +72,10 @@ func (sc *SlowCounter) Tick() {
 	minTimeHasPassed := time.Now().After(sc.lastIncr.Add(sc.config.MinDelayBeforeIncr))
 	if minTicksHaveOccurred && minTimeHasPassed {
 		sc.incr()
+		return true
 	}
+
+	return false
 }
 
 // incr increments the counter.

--- a/zeroex/orderwatch/slowcounter/slow_counter_test.go
+++ b/zeroex/orderwatch/slowcounter/slow_counter_test.go
@@ -9,123 +9,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSlowCounterWithNoDelay(t *testing.T) {
+func TestSlowCounter(t *testing.T) {
 	t.Parallel()
 
 	config := Config{
-		StartingOffset:     big.NewInt(10),
-		Rate:               2,
-		MinDelayBeforeIncr: 0,
-		MinTicksBeforeIncr: 3,
-		MaxCount:           big.NewInt(1000),
-	}
-
-	testCases := []struct {
-		startingCount *big.Int
-		ticks         int
-		expectedCount *big.Int
-	}{
-		{
-			startingCount: big.NewInt(0),
-			ticks:         0,
-			expectedCount: big.NewInt(0),
-		},
-		{
-			startingCount: big.NewInt(10),
-			ticks:         0,
-			expectedCount: big.NewInt(10),
-		},
-		{
-			startingCount: big.NewInt(0),
-			ticks:         2,
-			expectedCount: big.NewInt(0),
-		},
-		{
-			startingCount: big.NewInt(10),
-			ticks:         2,
-			expectedCount: big.NewInt(10),
-		},
-		{
-			startingCount: big.NewInt(0),
-			ticks:         3,
-			expectedCount: big.NewInt(20),
-		},
-		{
-			startingCount: big.NewInt(10),
-			ticks:         3,
-			expectedCount: big.NewInt(30),
-		},
-		{
-			startingCount: big.NewInt(0),
-			ticks:         6,
-			expectedCount: big.NewInt(40),
-		},
-		{
-			startingCount: big.NewInt(0),
-			ticks:         18,
-			expectedCount: big.NewInt(640),
-		},
-		{
-			startingCount: big.NewInt(0),
-			ticks:         21,
-			expectedCount: big.NewInt(1000), // max count
-		},
-	}
-
-	for _, tc := range testCases {
-		counter, err := New(config, tc.startingCount)
-		require.NoError(t, err)
-
-		for i := 0; i < tc.ticks; i++ {
-			counter.Tick()
-		}
-
-		actualCount := counter.Count()
-		assert.Equal(t, tc.expectedCount.String(), actualCount.String(), "incorrect count (started at %s and did %d ticks)", tc.startingCount, tc.ticks)
-	}
-}
-
-func TestSlowCounterWithDelay(t *testing.T) {
-	t.Parallel()
-
-	config := Config{
-		StartingOffset:     big.NewInt(10),
-		Rate:               2,
-		MinDelayBeforeIncr: 10 * time.Millisecond,
-		MinTicksBeforeIncr: 3,
-		MaxCount:           big.NewInt(1000),
+		StartingOffset: big.NewInt(10),
+		Rate:           2,
+		Interval:       250 * time.Millisecond,
+		MaxCount:       big.NewInt(1000),
 	}
 	counter, err := New(config, big.NewInt(0))
 	require.NoError(t, err)
 
-	for i := 0; i < config.MinTicksBeforeIncr+1; i++ {
-		wasIncremented := counter.Tick()
-		assert.False(t, wasIncremented, "counter should not be incremented before min delay")
+	{
+		expectedCount := big.NewInt(0)
+		actualCount := counter.Count()
+		assert.Equal(t, expectedCount, actualCount, "wrong count before any increments")
 	}
 
-	time.Sleep(config.MinDelayBeforeIncr)
+	time.Sleep(config.Interval)
 
 	{
-		wasIncremented := counter.Tick()
-		assert.True(t, wasIncremented, "counter should be incremented after min delay")
+		expectedCount := big.NewInt(10)
+		actualCount := counter.Count()
+		assert.Equal(t, expectedCount, actualCount, "wrong count after 1 increment")
+	}
+
+	time.Sleep(config.Interval)
+
+	{
 		expectedCount := big.NewInt(20)
 		actualCount := counter.Count()
-		assert.Equal(t, expectedCount, actualCount, "wrong count after counter was incremented")
-	}
-
-	for i := 0; i < config.MinTicksBeforeIncr+1; i++ {
-		wasIncremented := counter.Tick()
-		assert.False(t, wasIncremented, "counter should not be incremented before min delay")
-	}
-
-	time.Sleep(config.MinDelayBeforeIncr)
-
-	{
-		wasIncremented := counter.Tick()
-		assert.True(t, wasIncremented, "counter should be incremented after min delay")
-		expectedCount := big.NewInt(40)
-		actualCount := counter.Count()
-		assert.Equal(t, expectedCount, actualCount, "wrong count after counter was incremented")
+		assert.Equal(t, expectedCount, actualCount, "wrong count after 2 increments")
 	}
 }
 
@@ -133,19 +48,15 @@ func TestSlowCounterReset(t *testing.T) {
 	t.Parallel()
 
 	config := Config{
-		StartingOffset:     big.NewInt(10),
-		Rate:               2,
-		MinDelayBeforeIncr: 0,
-		MinTicksBeforeIncr: 3,
-		MaxCount:           big.NewInt(1000),
+		StartingOffset: big.NewInt(10),
+		Rate:           2,
+		Interval:       250 * time.Millisecond,
+		MaxCount:       big.NewInt(1000),
 	}
 	counter, err := New(config, big.NewInt(20))
 	require.NoError(t, err)
 
-	// Tick enough times to cause the counter to increment 5 times.
-	for i := 0; i < config.MinTicksBeforeIncr*5; i++ {
-		counter.Tick()
-	}
+	time.Sleep(config.Interval)
 
 	// Reset the counter and check that the count was correctly reset.
 	counter.Reset(big.NewInt(30))
@@ -155,15 +66,35 @@ func TestSlowCounterReset(t *testing.T) {
 		assert.Equal(t, expectedCount, actualCount, "wrong count after counter was reset")
 	}
 
-	// Tick enough times to cause the counter to increment once.
-	for i := 0; i < config.MinTicksBeforeIncr; i++ {
-		counter.Tick()
-	}
+	time.Sleep(config.Interval)
 
 	// Check the counter was incremented once from the new value after reset.
 	{
-		expectedCount := big.NewInt(50)
+		expectedCount := big.NewInt(40)
 		actualCount := counter.Count()
 		assert.Equal(t, expectedCount, actualCount, "wrong count after counter was reset and then incremented")
+	}
+}
+
+func TestSlowCounterMaxCount(t *testing.T) {
+	t.Parallel()
+
+	config := Config{
+		StartingOffset: big.NewInt(10),
+		Rate:           2,
+		// Note(albrow): For this test, we're okay with a much faster interval since
+		// we don't need to be precise. We only need to check that *at least* N
+		// increments have occurred. It is okay if more than N have occurred.
+		Interval: 1 * time.Millisecond,
+		MaxCount: big.NewInt(100),
+	}
+
+	counter, err := New(config, big.NewInt(0))
+	require.NoError(t, err)
+
+	for i := 0; i < 10; i++ {
+		time.Sleep(config.Interval)
+		actualCount := counter.Count()
+		assert.False(t, actualCount.Cmp(config.MaxCount) == 1, "count should never exceed max count")
 	}
 }

--- a/zeroex/orderwatch/slowcounter/slow_counter_test.go
+++ b/zeroex/orderwatch/slowcounter/slow_counter_test.go
@@ -98,7 +98,7 @@ func TestSlowCounterWithDelay(t *testing.T) {
 	counter, err := New(config, big.NewInt(0))
 	require.NoError(t, err)
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < config.MinTicksBeforeIncr+1; i++ {
 		wasIncremented := counter.Tick()
 		assert.False(t, wasIncremented, "counter should not be incremented before min delay")
 	}
@@ -113,7 +113,7 @@ func TestSlowCounterWithDelay(t *testing.T) {
 		assert.Equal(t, expectedCount, actualCount, "wrong count after counter was incremented")
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < config.MinTicksBeforeIncr+1; i++ {
 		wasIncremented := counter.Tick()
 		assert.False(t, wasIncremented, "counter should not be incremented before min delay")
 	}
@@ -126,5 +126,44 @@ func TestSlowCounterWithDelay(t *testing.T) {
 		expectedCount := big.NewInt(40)
 		actualCount := counter.Count()
 		assert.Equal(t, expectedCount, actualCount, "wrong count after counter was incremented")
+	}
+}
+
+func TestSlowCounterReset(t *testing.T) {
+	t.Parallel()
+
+	config := Config{
+		StartingOffset:     big.NewInt(10),
+		Rate:               2,
+		MinDelayBeforeIncr: 0,
+		MinTicksBeforeIncr: 3,
+		MaxCount:           big.NewInt(1000),
+	}
+	counter, err := New(config, big.NewInt(20))
+	require.NoError(t, err)
+
+	// Tick enough times to cause the counter to increment 5 times.
+	for i := 0; i < config.MinTicksBeforeIncr*5; i++ {
+		counter.Tick()
+	}
+
+	// Reset the counter and check that the count was correctly reset.
+	counter.Reset(big.NewInt(30))
+	{
+		expectedCount := big.NewInt(30)
+		actualCount := counter.Count()
+		assert.Equal(t, expectedCount, actualCount, "wrong count after counter was reset")
+	}
+
+	// Tick enough times to cause the counter to increment once.
+	for i := 0; i < config.MinTicksBeforeIncr; i++ {
+		counter.Tick()
+	}
+
+	// Check the counter was incremented once from the new value after reset.
+	{
+		expectedCount := big.NewInt(50)
+		actualCount := counter.Count()
+		assert.Equal(t, expectedCount, actualCount, "wrong count after counter was reset and then incremented")
 	}
 }

--- a/zeroex/orderwatch/slowcounter/slow_counter_test.go
+++ b/zeroex/orderwatch/slowcounter/slow_counter_test.go
@@ -12,12 +12,12 @@ import (
 func TestSlowCounter(t *testing.T) {
 	t.Parallel()
 	config := Config{
-		Rate:               big.NewRat(2, 1),
+		Rate:               2.0,
 		MinDelayBeforeIncr: 10 * time.Millisecond,
 		MinTicksBeforeIncr: 3,
-		MaxCount:           big.NewRat(1000, 1),
+		MaxCount:           big.NewInt(1000),
 	}
-	startingCount := big.NewRat(100, 1)
+	startingCount := big.NewInt(100)
 	sc, err := New(config, startingCount)
 	require.NoError(t, err)
 
@@ -36,7 +36,7 @@ func TestSlowCounter(t *testing.T) {
 	time.Sleep(config.MinDelayBeforeIncr + time.Since(sc.lastIncr))
 
 	// On the next tick, the counter should be incremented once.
-	expectedCount := big.NewRat(200, 1)
+	expectedCount := big.NewInt(200)
 	for i := 0; i < config.MinTicksBeforeIncr; i++ {
 		sc.Tick()
 		assert.Equal(t, expectedCount.String(), sc.Count().String(), "after %d ticks, count should be incremented once", i+config.MinTicksBeforeIncr)
@@ -46,12 +46,12 @@ func TestSlowCounter(t *testing.T) {
 	time.Sleep(config.MinDelayBeforeIncr + time.Since(sc.lastIncr))
 
 	// On the next tick, the counter should be incremented *twice* total.
-	expectedCount = big.NewRat(400, 1)
+	expectedCount = big.NewInt(400)
 	sc.Tick()
 	assert.Equal(t, expectedCount.String(), sc.Count().String(), "after %d ticks, count should be incremented twice", config.MinTicksBeforeIncr*2)
 
 	// Reset the counter.
-	newStart := big.NewRat(150, 1)
+	newStart := big.NewInt(150)
 	sc.Reset(newStart)
 	assert.Equal(t, newStart.String(), sc.Count().String(), "after being reset, count should be the new starting value")
 
@@ -64,7 +64,7 @@ func TestSlowCounter(t *testing.T) {
 
 	// On the next tick, the counter should be incremented *once* from its *new*
 	// starting value.
-	expectedCount = big.NewRat(300, 1)
+	expectedCount = big.NewInt(300)
 	sc.Tick()
 	assert.Equal(t, expectedCount.String(), sc.Count().String(), "after being reset, count should be incremented once")
 }

--- a/zeroex/orderwatch/slowcounter/slow_counter_test.go
+++ b/zeroex/orderwatch/slowcounter/slow_counter_test.go
@@ -13,10 +13,10 @@ func TestSlowCounter(t *testing.T) {
 	t.Parallel()
 
 	config := Config{
-		StartingOffset: big.NewInt(10),
-		Rate:           2,
-		Interval:       250 * time.Millisecond,
-		MaxCount:       big.NewInt(1000),
+		Offset:   big.NewInt(10),
+		Rate:     2,
+		Interval: 250 * time.Millisecond,
+		MaxCount: big.NewInt(1000),
 	}
 	counter, err := New(config, big.NewInt(0))
 	require.NoError(t, err)
@@ -48,10 +48,10 @@ func TestSlowCounterReset(t *testing.T) {
 	t.Parallel()
 
 	config := Config{
-		StartingOffset: big.NewInt(10),
-		Rate:           2,
-		Interval:       250 * time.Millisecond,
-		MaxCount:       big.NewInt(1000),
+		Offset:   big.NewInt(10),
+		Rate:     2,
+		Interval: 250 * time.Millisecond,
+		MaxCount: big.NewInt(1000),
 	}
 	counter, err := New(config, big.NewInt(20))
 	require.NoError(t, err)
@@ -80,8 +80,8 @@ func TestSlowCounterMaxCount(t *testing.T) {
 	t.Parallel()
 
 	config := Config{
-		StartingOffset: big.NewInt(10),
-		Rate:           2,
+		Offset: big.NewInt(10),
+		Rate:   2,
 		// Note(albrow): For this test, we're okay with a much faster interval since
 		// we don't need to be precise. We only need to check that *at least* N
 		// increments have occurred. It is okay if more than N have occurred.

--- a/zeroex/orderwatch/slowcounter/slow_counter_test.go
+++ b/zeroex/orderwatch/slowcounter/slow_counter_test.go
@@ -1,0 +1,70 @@
+package slowcounter
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlowCounter(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		Rate:               big.NewRat(2, 1),
+		MinDelayBeforeIncr: 10 * time.Millisecond,
+		MinTicksBeforeIncr: 3,
+		MaxCount:           big.NewRat(1000, 1),
+	}
+	startingCount := big.NewRat(100, 1)
+	sc, err := New(config, startingCount)
+	require.NoError(t, err)
+
+	// Since min ticks has not been met, the counter should not be incremented.
+	for i := 0; i < config.MinTicksBeforeIncr-1; i++ {
+		sc.Tick()
+		assert.Equal(t, startingCount.String(), sc.Count().String(), "after %d ticks, count should not yet be incremented", i+1)
+	}
+
+	// Since the time hasn't elapsed yet, the next tick should *not* increment the
+	// counter.
+	sc.Tick()
+	assert.Equal(t, startingCount.String(), sc.Count().String(), "count should not yet be incremented because MinDelayBeforeIncr has not passed")
+
+	// Sleep until MinDelayBeforeIncr is satisfied.
+	time.Sleep(config.MinDelayBeforeIncr + time.Since(sc.lastIncr))
+
+	// On the next tick, the counter should be incremented once.
+	expectedCount := big.NewRat(200, 1)
+	for i := 0; i < config.MinTicksBeforeIncr; i++ {
+		sc.Tick()
+		assert.Equal(t, expectedCount.String(), sc.Count().String(), "after %d ticks, count should be incremented once", i+config.MinTicksBeforeIncr)
+	}
+
+	// Sleep until MinDelayBeforeIncr is satisfied.
+	time.Sleep(config.MinDelayBeforeIncr + time.Since(sc.lastIncr))
+
+	// On the next tick, the counter should be incremented *twice* total.
+	expectedCount = big.NewRat(400, 1)
+	sc.Tick()
+	assert.Equal(t, expectedCount.String(), sc.Count().String(), "after %d ticks, count should be incremented twice", config.MinTicksBeforeIncr*2)
+
+	// Reset the counter.
+	newStart := big.NewRat(150, 1)
+	sc.Reset(newStart)
+	assert.Equal(t, newStart.String(), sc.Count().String(), "after being reset, count should be the new starting value")
+
+	// Wait for conditions to be met.
+	for i := 0; i < config.MinTicksBeforeIncr-1; i++ {
+		sc.Tick()
+		assert.Equal(t, newStart.String(), sc.Count().String(), "after %d ticks after being reset, count should not yet be incremented", i+1)
+	}
+	time.Sleep(config.MinDelayBeforeIncr + time.Since(sc.lastIncr))
+
+	// On the next tick, the counter should be incremented *once* from its *new*
+	// starting value.
+	expectedCount = big.NewRat(300, 1)
+	sc.Tick()
+	assert.Equal(t, expectedCount.String(), sc.Count().String(), "after being reset, count should be incremented once")
+}


### PR DESCRIPTION
Fixes #431.

This PR is still a WIP but I'm opening it now so we can discuss the progress so far. This is an implementation of the idea we've been discussing on Slack and a solution to the problem of finite database storage. To quickly re-summarize the idea:

When storage space is plentiful, we start without any kind of limit on expiration time. As the database fills up, we enforce a limit on the maximum expiration time. Any orders that expire after that time will be removed. If more orders keep coming in we can lower the expiration time and remove more orders.

So far this PR adds an index on `ExpirationTime` and implements a new method called `TrimOrdersByExpirationTime` which contains the bulk of the core logic for this feature. There are still some challenges around how to use this function and when to call it, but the approach is looking very feasible as of now. We also still need to determine when and how quickly to increase the max expiration time after storage frees up.