### PR TITLE
core/message-handler: round robin order sharing

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -137,6 +137,11 @@ type App struct {
 	snapshotExpirationWatcher *expirationwatch.Watcher
 	muIdToSnapshotInfo        sync.Mutex
 	idToSnapshotInfo          map[string]snapshotInfo
+	messageHandler            *MessageHandler
+}
+
+type MessageHandler struct {
+	nextOffset int
 }
 
 func New(config Config) (*App, error) {
@@ -234,6 +239,9 @@ func New(config Config) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
+	messageHandler := &MessageHandler{
+		nextOffset: 0,
+	}
 
 	app := &App{
 		config:                    config,
@@ -249,6 +257,7 @@ func New(config Config) (*App, error) {
 		meshMessageJSONSchema:     meshMessageJSONSchema,
 		snapshotExpirationWatcher: snapshotExpirationWatcher,
 		idToSnapshotInfo:          map[string]snapshotInfo{},
+		messageHandler:            messageHandler,
 	}
 
 	log.WithFields(map[string]interface{}{

--- a/core/core.go
+++ b/core/core.go
@@ -140,10 +140,6 @@ type App struct {
 	messageHandler            *MessageHandler
 }
 
-type MessageHandler struct {
-	nextOffset int
-}
-
 func New(config Config) (*App, error) {
 	// Configure logger
 	// TODO(albrow): Don't use global variables for log settings.

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -12,6 +12,10 @@ import (
 // Ensure that App implements p2p.MessageHandler.
 var _ p2p.MessageHandler = &App{}
 
+type MessageHandler struct {
+	nextOffset int
+}
+
 func min(a int, b int) int {
 	if a < b {
 		return a


### PR DESCRIPTION
## Description
The `GetOrdersToShare` function gets a set of orders from the mesh database to share with other peers. The current strategy for selecting orders to share is simply to choose a random segment of the valid orders in the database's snapshot of length `max`. This strategy works well---albeit imperfectly---when `(number of valid orders)` is reasonably close to `max`, but as the number of valid orders climbs, the risk of some orders not being propagated to peers increases. 

A simple strategy to mitigate this issue is to use a `round robin strategy` for selecting orders. This strategy will select orders by starting at the "beginning" of the database's collection of orders and working all the way up to the last orders in the database. Once the top order has been shared, the strategy loops around and starts sharing orders closer to the "beginning" of the order collection again. This strategy has the benefit that it will exhaustively go through a node's orders, so it will necessarily share all of the valid orders. 