### PR TITLE
p2p: Segregate V3 Mesh network from V2 network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
-## v5.0.1-beta-0xv3.1
+## v5.0.2-beta-0xv3
 
 ### Bug fixes 🐞 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 - Updated DevUtils.sol contract address for the Kovan network to one including a bug fix for validating orders with nulled out `feeAssetData` fields. ([#446](https://github.com/0xProject/0x-mesh/pull/446)])
 - Added back Ropsten and Rinkeby support and fixed `exchange` address on Kovan ([#451](https://github.com/0xProject/0x-mesh/pull/451))
+- Segregate V3 Mesh network from V2 network ([#455](https://github.com/0xProject/0x-mesh/pull/455))
 
 ## v5.0.0-beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
-## v5.0.1-beta-0xv3
+## v5.0.1-beta-0xv3.1
 
 ### Bug fixes 🐞 
 

--- a/core/core.go
+++ b/core/core.go
@@ -247,11 +247,11 @@ func unquoteConfig(config Config) Config {
 }
 
 func getPubSubTopic(networkID int) string {
-	return fmt.Sprintf("/0x-orders/network/%d/version/1", networkID)
+	return fmt.Sprintf("/0x-orders/network/%d/version/2", networkID)
 }
 
 func getRendezvous(networkID int) string {
-	return fmt.Sprintf("/0x-mesh/network/%d/version/1", networkID)
+	return fmt.Sprintf("/0x-mesh/network/%d/version/2", networkID)
 }
 
 func initPrivateKey(path string) (p2pcrypto.PrivKey, error) {

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const dhtProtocolID = protocol.ID("/0x-mesh-dht/version/1")
+const dhtProtocolID = protocol.ID("/0x-mesh-dht/version/2")
 
 // DefaultBootstrapList is a list of addresses to use by default for
 // bootstrapping the DHT.

--- a/p2p/bootstrap.go
+++ b/p2p/bootstrap.go
@@ -12,7 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const dhtProtocolID = protocol.ID("/0x-mesh-dht/version/2")
+const dhtProtocolID = protocol.ID("/0x-mesh-dht/version/1")
 
 // DefaultBootstrapList is a list of addresses to use by default for
 // bootstrapping the DHT.


### PR DESCRIPTION
Update pubSubTopic, rendezvous string and DHT ID so that the V3 Mesh network is separate from the V2 network.