### PR TITLE
WIP: Implement ETH JSON-RPC Rate Limiting

### DIFF
--- a/ratelimit/rate_limiter.go
+++ b/ratelimit/rate_limiter.go
@@ -1,0 +1,88 @@
+package ratelimit
+
+import (
+	"context"
+	"time"
+)
+
+// Request represents a request to the RateLimiter
+type Request struct {
+	ResponseChan chan struct{}
+}
+
+// RateLimiter is a rate-limiter for requests
+type RateLimiter struct {
+	maxRequestsPer24Hrs    int
+	periodStart            time.Time
+	lastRequestApprovedAt  time.Time
+	ticker                 *time.Ticker
+	requestsChan           chan *Request
+	whitelistChan          chan struct{}
+	minTimeBetweenRequests time.Duration
+}
+
+// NewRateLimiter instantiates a new RateLimiter
+func NewRateLimiter(maxRequestsPer24Hrs, maxRequestsPerSecond int) *RateLimiter {
+	return &RateLimiter{
+		maxRequestsPer24Hrs:    maxRequestsPer24Hrs,
+		minTimeBetweenRequests: time.Duration(1000/maxRequestsPerSecond) * time.Millisecond,
+		requestsChan:           make(chan *Request, 50000),
+		whitelistChan:          make(chan struct{}, maxRequestsPer24Hrs),
+	}
+}
+
+// Start starts the rate limiter
+func (r *RateLimiter) Start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case request := <-r.requestsChan:
+				select {
+				case <-r.whitelistChan:
+					timePassed := time.Since(r.lastRequestApprovedAt)
+					if timePassed > r.minTimeBetweenRequests {
+						r.lastRequestApprovedAt = time.Now()
+						request.ResponseChan <- struct{}{}
+					} else {
+						timeLeft := r.minTimeBetweenRequests - timePassed
+						time.Sleep(timeLeft)
+						r.lastRequestApprovedAt = time.Now()
+						request.ResponseChan <- struct{}{}
+					}
+				case <-ctx.Done():
+					r.ticker.Stop()
+					request.ResponseChan <- struct{}{}
+					return
+				}
+			case <-ctx.Done():
+				r.ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	r.periodStart = time.Now()
+	regularTimeBetweenRequests := 24 * 60 * 60 * 1000 / r.maxRequestsPer24Hrs
+	r.ticker = time.NewTicker(time.Duration(regularTimeBetweenRequests) * time.Millisecond)
+	for range r.ticker.C {
+		if time.Since(r.periodStart) > 24*time.Hour {
+			// Drain the whitelistChan
+			for {
+				select {
+				case <-r.whitelistChan:
+				default:
+					break
+				}
+			}
+			// Restart the period
+			r.periodStart = time.Now()
+		}
+		// Whitelist a request
+		r.whitelistChan <- struct{}{}
+	}
+}
+
+// Request requests to RateLimiter for permission to send a request
+func (r *RateLimiter) Request(request *Request) {
+	r.requestsChan <- request
+}

--- a/ratelimit/rate_limiter_test.go
+++ b/ratelimit/rate_limiter_test.go
@@ -1,0 +1,111 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	maxRequestsPer24Hrs  = 200000
+	maxRequestsPerSecond = 5
+)
+
+func TestSingleRequest(t *testing.T) {
+	rateLimiter := NewRateLimiter(maxRequestsPer24Hrs, maxRequestsPerSecond)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	go func() {
+		rateLimiter.Start(ctx)
+	}()
+	responseChan := make(chan struct{})
+	r := &Request{
+		ResponseChan: responseChan,
+	}
+	rateLimiter.Request(r)
+	<-r.ResponseChan
+	cancelFunc()
+}
+
+func TestProcessesRequestsImmediatelyIfBufferedRequests(t *testing.T) {
+	rateLimiter := NewRateLimiter(maxRequestsPer24Hrs, maxRequestsPerSecond)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	go func() {
+		rateLimiter.Start(ctx)
+	}()
+
+	minTimeBetweenRequests := time.Duration(1000/maxRequestsPerSecond) * time.Millisecond
+
+	regularTimeBetweenRequests := time.Duration(24*60*60*1000/maxRequestsPer24Hrs) * time.Millisecond
+	// Wait for two request whitelist slots to buffer
+	time.Sleep(regularTimeBetweenRequests * 3)
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			responseChan := make(chan struct{})
+			r := &Request{
+				ResponseChan: responseChan,
+			}
+			rateLimiter.Request(r)
+			start := time.Now()
+			<-r.ResponseChan
+			elapsed := time.Since(start)
+			if i == 0 {
+				// First request should go through immediately
+				assert.Condition(t, func() bool {
+					return elapsed < 5*time.Millisecond
+				})
+			} else {
+				// Subsequent requests should wait at least minTimeBetweenRequests
+				assert.Condition(t, func() bool {
+					return elapsed > minTimeBetweenRequests && elapsed < regularTimeBetweenRequests
+				})
+			}
+		}(i)
+	}
+	wg.Wait()
+	cancelFunc()
+}
+
+func TestTakesRegularIntervalWithoutBufferedRequests(t *testing.T) {
+	rateLimiter := NewRateLimiter(maxRequestsPer24Hrs, maxRequestsPerSecond)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	go func() {
+		rateLimiter.Start(ctx)
+	}()
+
+	regularTimeBetweenRequests := time.Duration(24*60*60*1000/maxRequestsPer24Hrs) * time.Millisecond
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			responseChan := make(chan struct{})
+			r := &Request{
+				ResponseChan: responseChan,
+			}
+			rateLimiter.Request(r)
+			start := time.Now()
+			<-r.ResponseChan
+			elapsed := time.Since(start)
+			expectedElapsed := time.Duration(i+1) * regularTimeBetweenRequests
+			diff := elapsed - expectedElapsed
+			assert.Condition(t, func() bool {
+				return diff < 10*time.Millisecond
+			})
+		}(i)
+	}
+	wg.Wait()
+	cancelFunc()
+}
+
+// TODO:
+// - Test resetting after the 24hr period ends, and starts new period
+// - Test cancelling the context while requests are pending
+// - Add step of requesting permission before every ETH JSON RPC request


### PR DESCRIPTION
This PR currently implements a suggested rate limiter for ETH RPC calls. It is modeled after the Infura API limits but will work well for other Ethereum nodes as well (and will be configurable!). It will let the node operator specify the max number of requests to allow per 24hrs as well as a max per second limit. The former avoids the issue of sending more than X requests within a 24hr period (100k on Infura free tier) while the latter prevents Mesh from triggering any rate-limits (max 30 requests per second for Infura Free tier).

If Mesh does not use up all the requests, they accumulate and can be used at a later time with only the per second rate limit in effect. Once 24hrs elapses, any left over request credits are cleared and the next 24hr period starts.