### PR TITLE
core: Fix issue where GetLatestBlock can sometimes return nil

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -683,9 +683,12 @@ func (app *App) GetStats() (*rpc.GetStatsResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	latestBlock := rpc.LatestBlock{
-		Number: int(latestBlockHeader.Number.Int64()),
-		Hash:   latestBlockHeader.Hash,
+	var latestBlock rpc.LatestBlock
+	if latestBlockHeader != nil {
+		latestBlock = rpc.LatestBlock{
+			Number: int(latestBlockHeader.Number.Int64()),
+			Hash:   latestBlockHeader.Hash,
+		}
 	}
 	notRemovedFilter := app.db.Orders.IsRemovedIndex.ValueFilter([]byte{0})
 	numOrders, err := app.db.Orders.NewQuery(notRemovedFilter).Count()


### PR DESCRIPTION
There is a bug where Mesh can crash with a nil pointer exception if `GetStats` is called before we have pulled any block header data from Ethereum. I only observed this happening when I reduced `logStatsInterval` locally for debugging purposes, but hypothetically this could happen in a real Mesh node too.