### PR TITLE
Immediately share orders after they are received via JSON-RPC

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -676,11 +676,20 @@ func (app *App) AddOrders(signedOrdersRaw []*json.RawMessage) (*ordervalidator.V
 			return nil, err
 		}
 		// Share the order with our peers.
-		if err := app.ShareOrder(acceptedOrderInfo.SignedOrder); err != nil {
+		if err := app.shareOrder(acceptedOrderInfo.SignedOrder); err != nil {
 			return nil, err
 		}
 	}
 	return allValidationResults, nil
+}
+
+// shareOrder immediately shares the given order on the GossipSub network.
+func (app *App) shareOrder(order *zeroex.SignedOrder) error {
+	encoded, err := encodeOrder(order)
+	if err != nil {
+		return err
+	}
+	return app.node.Send(encoded)
 }
 
 // AddPeer can be used to manually connect to a new peer.

--- a/core/core.go
+++ b/core/core.go
@@ -669,8 +669,14 @@ func (app *App) AddOrders(signedOrdersRaw []*json.RawMessage) (*ordervalidator.V
 	}
 
 	for _, acceptedOrderInfo := range allValidationResults.Accepted {
+		// Add the order to the OrderWatcher. This also saves the order in the
+		// database.
 		err = app.orderWatcher.Add(acceptedOrderInfo)
 		if err != nil {
+			return nil, err
+		}
+		// Share the order with our peers.
+		if err := app.ShareOrder(acceptedOrderInfo.SignedOrder); err != nil {
 			return nil, err
 		}
 	}

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -207,12 +207,3 @@ func (app *App) HandleMessages(messages []*p2p.Message) error {
 	}
 	return nil
 }
-
-// Share order immediately shares the given order on the GossipSub network.
-func (app *App) ShareOrder(order *zeroex.SignedOrder) error {
-	encoded, err := encodeOrder(order)
-	if err != nil {
-		return err
-	}
-	return app.node.Send(encoded)
-}

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -207,3 +207,12 @@ func (app *App) HandleMessages(messages []*p2p.Message) error {
 	}
 	return nil
 }
+
+// Share order immediately shares the given order on the GossipSub network.
+func (app *App) ShareOrder(order *zeroex.SignedOrder) error {
+	encoded, err := encodeOrder(order)
+	if err != nil {
+		return err
+	}
+	return app.node.Send(encoded)
+}

--- a/p2p/bandwidth_checker_test.go
+++ b/p2p/bandwidth_checker_test.go
@@ -42,7 +42,7 @@ func TestBandwidthChecker(t *testing.T) {
 	// limit.
 	newMaxBytesPerSecond := float64(1)
 	message := make([]byte, int(newMaxBytesPerSecond*100))
-	require.NoError(t, node0.send(message))
+	require.NoError(t, node0.Send(message))
 
 	// Wait for node1 to receive the message.
 	expectedMessage := &Message{

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -540,15 +540,15 @@ func (n *Node) shareBatch() error {
 		return err
 	}
 	for _, data := range outgoing {
-		if err := n.send(data); err != nil {
+		if err := n.Send(data); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// send sends a message continaing the given data to all connected peers.
-func (n *Node) send(data []byte) error {
+// Send sends a message continaing the given data to all connected peers.
+func (n *Node) Send(data []byte) error {
 	return n.pubsub.Publish(n.config.Topic, data)
 }
 

--- a/p2p/node_test.go
+++ b/p2p/node_test.go
@@ -235,13 +235,13 @@ loop:
 
 	// Send ping from node0 to node1
 	pingMessage := &Message{From: node0.host.ID(), Data: []byte("ping\n")}
-	require.NoError(t, node0.send(pingMessage.Data))
+	require.NoError(t, node0.Send(pingMessage.Data))
 	const pingPongTimeout = 15 * time.Second
 	expectMessage(t, node1, pingMessage, pingPongTimeout)
 
 	// Send pong from node1 to node0
 	pongMessage := &Message{From: node1.host.ID(), Data: []byte("pong\n")}
-	require.NoError(t, node1.send(pongMessage.Data))
+	require.NoError(t, node1.Send(pongMessage.Data))
 	expectMessage(t, node0, pongMessage, pingPongTimeout)
 }
 


### PR DESCRIPTION
In the current version of Mesh, we do not immediately share orders that are received via JSON-RPC and validated. Instead, we are currently storing them and then relying on the round-robin sharing process for sharing existing orders in the database.

That approach is really inefficient and possibly explains the discrepancy we are seeing in the number of orders held by each Mesh node. This PR addresses the issue by immediately sharing orders received via JSON-RPC (after validation).