### PR TITLE
orderwatch: Check for stale `removed` orders more frequently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 - Implemented a new strategy for limiting the amount of database storage used by Mesh and removing orders when the database is full. This strategy involves a dynamically adjusting maximum expiration time. When the database is full, Mesh will enforce a maximum expiration time for all incoming orders and remove any existing orders with an expiration time too far in the future. If conditions change and there is enough space in the database again, the max expiration time will slowly increase. This is a short term solution which solves the immediate issue of finite storage capacities and does a decent job of protecting against spam. We expect to improve and possibly replace it in the future. See [#450](https://github.com/0xProject/0x-mesh/pull/450) for more details.
 
+### Bug fixes 🐞 
+
+- Improved the aggressiveness at which we permanently delete orders that have been flagged for removal. Previously we would wait for the cleanup job to handle this (once an hour), but that meant many removed orders would accumulate. We now prune them every 5 minutes. ([#471](https://github.com/0xProject/0x-mesh/pull/471))
+
 ## v5.1.0-beta
 
 ### Features ✅ 

--- a/meshdb/meshdb.go
+++ b/meshdb/meshdb.go
@@ -281,6 +281,16 @@ func (m *MeshDB) FindOrdersLastUpdatedBefore(lastUpdated time.Time) ([]*Order, e
 	return orders, nil
 }
 
+// FindRemovedOrders finds all orders that have been flagged for removal
+func (m *MeshDB) FindRemovedOrders() ([]*Order, error) {
+	var removedOrders []*Order
+	isRemovedFilter := m.Orders.IsRemovedIndex.ValueFilter([]byte{1})
+	if err := m.Orders.NewQuery(isRemovedFilter).Run(&removedOrders); err != nil {
+		return nil, err
+	}
+	return removedOrders, nil
+}
+
 // GetMetadata returns the metadata (or a db.NotFoundError if no metadata has been found).
 func (m *MeshDB) GetMetadata() (*Metadata, error) {
 	var metadata Metadata

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -39,9 +39,9 @@ const (
 	lastUpdatedBuffer = 30 * time.Minute
 
 	// permanentlyDeleteAfter specifies how long after an order is marked as IsRemoved and not updated that
-	// it should be considered for permanent deletion. Blocks get mined on avg. every 12 sec, so 4 minutes
-	// corresponds to a block depth of ~20.
-	permanentlyDeleteAfter = 4 * time.Minute
+	// it should be considered for permanent deletion. Blocks get mined on avg. every 12 sec, so 5 minutes
+	// corresponds to a block depth of ~25.
+	permanentlyDeleteAfter = 5 * time.Minute
 
 	// expirationPollingInterval specifies the interval in which the order watcher should check for expired
 	// orders

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -959,8 +959,7 @@ func (w *Watcher) generateOrderEventsIfChanged(ordersColTxn *db.Transaction, ord
 			}
 			orderEvents = append(orderEvents, orderEvent)
 		} else if oldFillableAmount.Cmp(newFillableAmount) == 0 {
-			// No important state-change happened, simply update lastUpdated timestamp in DB
-			w.updateOrderDBEntry(ordersColTxn, order)
+			// No important state-change happened
 		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && oldAmountIsMoreThenNewAmount {
 			// Order was filled, emit  event and update order in DB
 			order.FillableTakerAssetAmount = newFillableAmount
@@ -997,8 +996,6 @@ func (w *Watcher) generateOrderEventsIfChanged(ordersColTxn *db.Transaction, ord
 			oldFillableAmount := order.FillableTakerAssetAmount
 			if oldFillableAmount.Cmp(big.NewInt(0)) == 0 {
 				// If the oldFillableAmount was already 0, this order is already flagged for removal.
-				// Update it's lastUpdated timestamp in DB
-				w.updateOrderDBEntry(ordersColTxn, order)
 			} else {
 				// If oldFillableAmount > 0, it got fullyFilled, cancelled, expired or unfunded, emit event
 				w.unwatchOrder(ordersColTxn, order, big.NewInt(0))

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -703,9 +703,8 @@ func (w *Watcher) cleanup(ctx context.Context) error {
 }
 
 func (w *Watcher) permanentlyDeleteStaleRemovedOrders(ctx context.Context) error {
-	var removedOrders []*meshdb.Order
-	isRemovedFilter := w.meshDB.Orders.IsRemovedIndex.ValueFilter([]byte{1})
-	if err := w.meshDB.Orders.NewQuery(isRemovedFilter).Run(&removedOrders); err != nil {
+	removedOrders, err := w.meshDB.FindRemovedOrders()
+	if err != nil {
 		return err
 	}
 

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -324,23 +324,21 @@ func (w *Watcher) maxExpirationTimeLoop(ctx context.Context) error {
 }
 
 func (w *Watcher) removedCheckerLoop(ctx context.Context) error {
-	start := time.Now()
 	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-		}
-
-		start = time.Now()
+		start := time.Now()
 		if err := w.permanentlyDeleteStaleRemovedOrders(ctx); err != nil {
 			return err
 		}
 
+		select {
+		case <-ctx.Done():
+			return nil
 		// Wait minRemovedCheckInterval before calling permanentlyDeleteStaleRemovedOrders again. Since
-		// we only start sleeping _after_ permanentlyDeleteStaleRemovedOrders completes, we will never
+		// we only start waiting _after_ permanentlyDeleteStaleRemovedOrders completes, we will never
 		// have multiple calls to permanentlyDeleteStaleRemovedOrders running in parallel
-		time.Sleep(minRemovedCheckInterval - time.Since(start))
+		case <-time.After(minRemovedCheckInterval - time.Since(start)):
+			continue
+		}
 	}
 }
 

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1081,8 +1081,8 @@ type orderDeleter interface {
 	Delete(id []byte) error
 }
 
-func (w *Watcher) permanentlyDeleteOrder(ordersColTxn orderDeleter, order *meshdb.Order) error {
-	err := ordersColTxn.Delete(order.Hash.Bytes())
+func (w *Watcher) permanentlyDeleteOrder(deleter orderDeleter, order *meshdb.Order) error {
+	err := deleter.Delete(order.Hash.Bytes())
 	if err != nil {
 		logger.WithFields(logger.Fields{
 			"error": err.Error(),


### PR DESCRIPTION
Fixes: #459

This PR:
- Adds a process to OrderWatcher that checks for orders that have been flagged for removal and should now be permanently deleted every 5 minutes.
- Stops updating an order DB entry's `lastUpdatedTime` when the entry is in-fact not updated (i.e., when we revalidate the order but no change to fillability was found). This could cause an order from a particularly active maker to stick around indefinitely despite being expired/cancelled/fullyFilled, because the changes in the maker's balance would cause this order to constantly be re-validated and it's `lastUpdatedTime` to constantly get bumped up.
- Slightly increases permanentlyDeleteAfter to 25 block depth to account for us flagging an order for removal due to UTC expiry, but it still potentially getting filled/cancelled a few blocks after. This adjustment is out of extreme caution.