### PR TITLE
Add workaround for BandwidthChecker issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 - Implemented a new strategy for limiting the amount of database storage used by Mesh and removing orders when the database is full. This strategy involves a dynamically adjusting maximum expiration time. When the database is full, Mesh will enforce a maximum expiration time for all incoming orders and remove any existing orders with an expiration time too far in the future. If conditions change and there is enough space in the database again, the max expiration time will slowly increase. This is a short term solution which solves the immediate issue of finite storage capacities and does a decent job of protecting against spam. We expect to improve and possibly replace it in the future. See [#450](https://github.com/0xProject/0x-mesh/pull/450) for more details.
 - Added support for a new feature called "order pinning" ([#474](https://github.com/0xProject/0x-mesh/pull/474)). Pinned orders will not be affected by any DDoS prevention or incentive mechanisms (including the new dynamic max expiration time feature) and will always stay in storage until they are no longer fillable. By default, all orders which are submitted via either the JSON-RPC API or the `addOrdersAsync` function in the TypeScript bindings will be pinned.
+- Re-enabled bandwidth-based peer banning with a workaround to deal with erroneous spikes [#478](https://github.com/0xProject/0x-mesh/pull/478).
 
 ### Bug fixes 🐞 
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:8dfbaa09c5bb2df7ba84be3bb47d045f10a75502e708a1c15fec690dbe2e46fc"
+  name = "github.com/ReneKroon/ttlcache"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e9e37b599534bbeb6ec45a6215cda104ff212b69"
+  version = "v1.6.0"
+
+[[projects]]
   digest = "1:a8a7b3ab27d90a3c63b5d2fe6e23c80a79d2b68708490b90bb160ccc7836c831"
   name = "github.com/albrow/stringset"
   packages = ["."]
@@ -429,6 +437,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:9642c35dd8d4b8981d58327a917f178898baf9b331373748dd50439aec5c2628"
+  name = "github.com/karlseguin/ccache"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ec06cd93a07565b373789b0078ba88fe697fddd9"
+  version = "v2.0.3"
+
+[[projects]]
   branch = "master"
   digest = "1:8cb15b21828b36ad568850d0ecb9340e22b148c8c6755f4a3d7918021bfc38a2"
   name = "github.com/knq/sysutil"
@@ -467,14 +483,6 @@
   pruneopts = "UT"
   revision = "c4a5988a1e475884367015e1a2d0bd5fa4c491f4"
   version = "v0.0.2"
-
-[[projects]]
-  digest = "1:6a443af5bfbc3cd231972c06ce15d8e396486bf57a9115fac6c1bc76eb68bcc5"
-  name = "github.com/libp2p/go-conn-security"
-  packages = ["insecure"]
-  pruneopts = "UT"
-  revision = "5f8143019e00897f3f6776723f2ca9230904458b"
-  version = "v0.1.0"
 
 [[projects]]
   digest = "1:041a5219e2f0c1fa2af5d25aee6970600ba2ac055ba386c18cfe960d392df3db"
@@ -720,14 +728,6 @@
   pruneopts = "UT"
   revision = "221d8d5e05a0252049203c8f74d4f38b64da9963"
   version = "v0.2.0"
-
-[[projects]]
-  digest = "1:f55b1d675b33c91230c833c99b7aa1a03f9eda84ab775d2ecddd8136cb2d2faa"
-  name = "github.com/libp2p/go-libp2p-transport"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "2406e91c260757c7cf63c70ad20073f5a7b29af4"
-  version = "v0.1.0"
 
 [[projects]]
   digest = "1:2fcb80000123d80148ce210a053a226d52dc891419905d7ff076c164825da50d"
@@ -1343,6 +1343,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/ReneKroon/ttlcache",
     "github.com/albrow/stringset",
     "github.com/chromedp/cdproto/runtime",
     "github.com/chromedp/chromedp",
@@ -1362,23 +1363,19 @@
     "github.com/google/uuid",
     "github.com/hashicorp/golang-lru",
     "github.com/ipfs/go-ds-leveldb",
-    "github.com/ipfs/go-log",
     "github.com/jpillora/backoff",
-    "github.com/libp2p/go-conn-security-multistream",
-    "github.com/libp2p/go-conn-security/insecure",
+    "github.com/karlseguin/ccache",
     "github.com/libp2p/go-libp2p",
     "github.com/libp2p/go-libp2p-autonat-svc",
     "github.com/libp2p/go-libp2p-circuit",
     "github.com/libp2p/go-libp2p-connmgr",
     "github.com/libp2p/go-libp2p-core/crypto",
     "github.com/libp2p/go-libp2p-core/host",
-    "github.com/libp2p/go-libp2p-core/mux",
+    "github.com/libp2p/go-libp2p-core/metrics",
     "github.com/libp2p/go-libp2p-core/network",
     "github.com/libp2p/go-libp2p-core/peer",
-    "github.com/libp2p/go-libp2p-core/pnet",
     "github.com/libp2p/go-libp2p-core/protocol",
     "github.com/libp2p/go-libp2p-core/routing",
-    "github.com/libp2p/go-libp2p-core/sec",
     "github.com/libp2p/go-libp2p-crypto",
     "github.com/libp2p/go-libp2p-discovery",
     "github.com/libp2p/go-libp2p-kad-dht",
@@ -1388,14 +1385,8 @@
     "github.com/libp2p/go-libp2p-peerstore/pstoreds",
     "github.com/libp2p/go-libp2p-pubsub",
     "github.com/libp2p/go-libp2p-swarm",
-    "github.com/libp2p/go-libp2p-transport",
-    "github.com/libp2p/go-libp2p-transport-upgrader",
-    "github.com/libp2p/go-libp2p/config",
-    "github.com/libp2p/go-libp2p/p2p/host/basic",
     "github.com/libp2p/go-libp2p/p2p/host/relay",
-    "github.com/libp2p/go-libp2p/p2p/host/routed",
     "github.com/libp2p/go-maddr-filter",
-    "github.com/libp2p/go-stream-muxer-multistream",
     "github.com/libp2p/go-ws-transport",
     "github.com/multiformats/go-multiaddr",
     "github.com/multiformats/go-multiaddr-dns",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -125,3 +125,7 @@
 [[constraint]]
   name = "github.com/libp2p/go-maddr-filter"
   version = "0.0.5"
+
+[[constraint]]
+  name = "github.com/karlseguin/ccache"
+  version = "2.0.3"

--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/karlseguin/ccache"
 	"github.com/libp2p/go-libp2p-core/metrics"
+	"github.com/libp2p/go-libp2p-core/peer"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -16,12 +18,57 @@ const (
 	defaultMaxBytesPerSecond = 104857600 // 100 MiB.
 	// logBandwidthUsageInterval is how often to log bandwidth usage data.
 	logBandwidthUsageInterval = 5 * time.Minute
+	// violationsCacheSize is the size of the cache (number of entries) used for
+	// tracking bandwidth violations over time.
+	violationsCacheSize = 100
+	// violationsBeforeBan is the number of times a peer is allowed to violate the
+	// bandwidth limits before being banned.
+	violationsBeforeBan = 4
+	// violationsTTL is the TTL for bandwidth violations. If a peer does not have
+	// any violations during this timespan, their violation count will be reset.
+	violationsTTL = 6 * time.Hour
 )
 
 type bandwidthChecker struct {
 	node              *Node
 	counter           *metrics.BandwidthCounter
 	maxBytesPerSecond float64
+	violations        *violationsTracker
+}
+
+// violationsTracker is used to count how many times each peer has violated the
+// bandwidth limit. It is a workaround for a bug in libp2p's BandwidthCounter.
+// See: https://github.com/libp2p/go-libp2p-core/issues/65.
+//
+// TODO(albrow): Could potentially remove this if the issue is resolved.
+type violationsTracker struct {
+	cache *ccache.Cache
+}
+
+func newViolationsTracker(ctx context.Context) *violationsTracker {
+	cache := ccache.New(ccache.Configure().MaxSize(violationsCacheSize).ItemsToPrune(violationsCacheSize / 10))
+	go func() {
+		// Stop the cache when the context is done. This prevents goroutine leaks
+		// since ccache spawns a new goroutine as part of its implementation.
+		select {
+		case <-ctx.Done():
+			cache.Stop()
+		}
+	}()
+	return &violationsTracker{
+		cache: cache,
+	}
+}
+
+// add increments the number of bandwidth violations by the given peer. It
+// returns the new count.
+func (v *violationsTracker) add(peerID peer.ID) int {
+	newCount := 1
+	if item := v.cache.Get(peerID.String()); item != nil {
+		newCount = item.Value().(int) + 1
+	}
+	v.cache.Set(peerID.String(), newCount, violationsTTL)
+	return newCount
 }
 
 func newBandwidthChecker(node *Node, counter *metrics.BandwidthCounter) *bandwidthChecker {
@@ -29,6 +76,7 @@ func newBandwidthChecker(node *Node, counter *metrics.BandwidthCounter) *bandwid
 		node:              node,
 		counter:           counter,
 		maxBytesPerSecond: defaultMaxBytesPerSecond,
+		violations:        newViolationsTracker(node.ctx),
 	}
 }
 
@@ -73,38 +121,48 @@ func (checker *bandwidthChecker) checkUsage() {
 		// If the peer is sending data at a higher rate than is allowed, ban
 		// them.
 		if stats.RateIn > checker.maxBytesPerSecond {
-			log.WithFields(log.Fields{
-				"remotePeerID":      remotePeerID.String(),
-				"bytesPerSecondIn":  stats.RateIn,
-				"maxBytesPerSecond": checker.maxBytesPerSecond,
-			}).Warn("would ban peer due to high bandwidth usage")
-			// There are possibly multiple connections to each peer. We ban the IP
-			// address associated with each connection.
-			for _, conn := range checker.node.host.Network().ConnsToPeer(remotePeerID) {
-				// TODO(albrow): We don't actually ban for now due to an apparent bug in
-				// libp2p's BandwidthCounter. Uncomment this once the issue is resolved.
-				// See: https://github.com/libp2p/go-libp2p-core/issues/65
-				//
-				// if err := checker.node.BanIP(conn.RemoteMultiaddr()); err != nil {
-				// 	if err == errProtectedIP {
-				// 		continue
-				// 	}
-				// 	log.WithFields(log.Fields{
-				// 		"remotePeerID":    remotePeerID.String(),
-				// 		"remoteMultiaddr": conn.RemoteMultiaddr().String(),
-				// 		"error":           err.Error(),
-				// 	}).Error("could not ban peer")
-				// }
+			numViolations := checker.violations.add(remotePeerID)
+
+			// Check if the number of violations exceeds violationsBeforeBan.
+			if numViolations >= violationsBeforeBan {
 				log.WithFields(log.Fields{
 					"remotePeerID":      remotePeerID.String(),
-					"remoteMultiaddr":   conn.RemoteMultiaddr().String(),
-					"rateIn":            stats.RateIn,
+					"bytesPerSecondIn":  stats.RateIn,
 					"maxBytesPerSecond": checker.maxBytesPerSecond,
-				}).Trace("would ban IP/multiaddress due to high bandwidth usage")
+					"numViolations":     numViolations,
+				}).Warn("banning peer due to high bandwidth usage")
+				// There are possibly multiple connections to each peer. We ban the IP
+				// address associated with each connection.
+				for _, conn := range checker.node.host.Network().ConnsToPeer(remotePeerID) {
+					if err := checker.node.BanIP(conn.RemoteMultiaddr()); err != nil {
+						if err == errProtectedIP {
+							continue
+						}
+						log.WithFields(log.Fields{
+							"remotePeerID":    remotePeerID.String(),
+							"remoteMultiaddr": conn.RemoteMultiaddr().String(),
+							"error":           err.Error(),
+						}).Error("could not ban peer")
+					}
+					log.WithFields(log.Fields{
+						"remotePeerID":      remotePeerID.String(),
+						"remoteMultiaddr":   conn.RemoteMultiaddr().String(),
+						"rateIn":            stats.RateIn,
+						"maxBytesPerSecond": checker.maxBytesPerSecond,
+					}).Trace("would ban IP/multiaddress due to high bandwidth usage")
+				}
+				// Banning the IP doesn't close the connection, so we do that
+				// separately. ClosePeer closes all connections to the given peer.
+				_ = checker.node.host.Network().ClosePeer(remotePeerID)
+			} else {
+				// Log that high bandwidth usage occurred but don't yet ban the peer.
+				log.WithFields(log.Fields{
+					"remotePeerID":      remotePeerID.String(),
+					"bytesPerSecondIn":  stats.RateIn,
+					"maxBytesPerSecond": checker.maxBytesPerSecond,
+					"numViolations":     numViolations,
+				}).Warn("detected high bandwidth usage")
 			}
-			// Banning the IP doesn't close the connection, so we do that
-			// separately. ClosePeer closes all connections to the given peer.
-			_ = checker.node.host.Network().ClosePeer(remotePeerID)
 		}
 	}
 }

--- a/p2p/bandwidth_checker.go
+++ b/p2p/bandwidth_checker.go
@@ -20,7 +20,7 @@ const (
 	logBandwidthUsageInterval = 5 * time.Minute
 	// violationsCacheSize is the size of the cache (number of entries) used for
 	// tracking bandwidth violations over time.
-	violationsCacheSize = 100
+	violationsCacheSize = peerCountHigh
 	// violationsBeforeBan is the number of times a peer is allowed to violate the
 	// bandwidth limits before being banned.
 	violationsBeforeBan = 4


### PR DESCRIPTION
Fixes #475.

The current implementation will ban peers if they violate bandwidth limits 4 times over the course of 6 hours. Each violation resets the TTL to 6 hours. If there are no violations over a time span of 6 hours, their count of violations is reset.

This workaround does slightly reduce the resiliency of the Mesh network in the face of spamming attacks, but the impact is minimal and it is much better than having no bandwidth limits in place at all.