### PR TITLE
Log hash for orders added via RPC or browser callback

### DIFF
--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -72,7 +72,10 @@ func (handler *rpcHandler) GetOrders(page, perPage int, snapshotID string) (*rpc
 
 // AddOrders is called when an RPC client calls AddOrders.
 func (handler *rpcHandler) AddOrders(signedOrdersRaw []*json.RawMessage, opts rpc.AddOrdersOpts) (*ordervalidator.ValidationResults, error) {
-	log.WithField("count", len(signedOrdersRaw)).Debug("received AddOrders request via RPC")
+	log.WithFields(log.Fields{
+		"count":  len(signedOrdersRaw),
+		"pinned": opts.Pinned,
+	}).Info("received AddOrders request via RPC")
 	validationResults, err := handler.app.AddOrders(signedOrdersRaw, opts.Pinned)
 	if err != nil {
 		// We don't want to leak internal error details to the RPC client.

--- a/core/core.go
+++ b/core/core.go
@@ -706,6 +706,10 @@ func (app *App) AddOrders(signedOrdersRaw []*json.RawMessage, pinned bool) (*ord
 				return nil, err
 			}
 		}
+		log.WithFields(log.Fields{
+			"orderHash": acceptedOrderInfo.OrderHash.String(),
+		}).Debug("added new valid order via RPC or browser callback")
+
 		// Share the order with our peers.
 		if err := app.shareOrder(acceptedOrderInfo.SignedOrder); err != nil {
 			return nil, err


### PR DESCRIPTION
This is critical for tracking metrics like order spreading ratio and order propagation delay.