### PR TITLE
Add RPCAddr option for the JSON-RPC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 - Renamed env config from `ETHEREUM_NETWORK_ID` to `ETHEREUM_CHAIN_ID` since `network` is a misnomer here and what we actually care about is the `chainID`. Most chains have the same id for their p2p network and chain. From the ones we support, the only outlier is Ganache, for which you will now need to supply `1337` instead of `50` (Learn more: https://medium.com/@pedrouid/chainid-vs-networkid-how-do-they-differ-on-ethereum-eec2ed41635b) ([#485](https://github.com/0xProject/0x-mesh/pull/485))
 - Rejected order code `OrderForIncorrectNetwork` has been changed to `OrderForIncorrectChain` ([#485](https://github.com/0xProject/0x-mesh/pull/485))
+- Removed `RPC_PORT` environment variable. The new `RPC_ADDR` environment variable allows specifying both the interface and port ([487](https://github.com/0xProject/0x-mesh/pull/487)).
 
 ### Features ✅ 
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,14 +2,6 @@
 
 
 [[projects]]
-  digest = "1:8dfbaa09c5bb2df7ba84be3bb47d045f10a75502e708a1c15fec690dbe2e46fc"
-  name = "github.com/ReneKroon/ttlcache"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "e9e37b599534bbeb6ec45a6215cda104ff212b69"
-  version = "v1.6.0"
-
-[[projects]]
   digest = "1:a8a7b3ab27d90a3c63b5d2fe6e23c80a79d2b68708490b90bb160ccc7836c831"
   name = "github.com/albrow/stringset"
   packages = ["."]
@@ -1106,7 +1098,7 @@
 
 [[projects]]
   branch = "full-wasm-support"
-  digest = "1:19a06414eca371f87af481d67abf345eeaf6ff9eeab1a622513f1b6633d9be4f"
+  digest = "1:5471d57ba7550f873e109f28f58bcebc9a9a2a8b33e1496076da6d6cf2bc627a"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -1123,7 +1115,7 @@
     "leveldb/util",
   ]
   pruneopts = "UT"
-  revision = "3142f6b4d3f932dcad713b9b9f62837e2641aae9"
+  revision = "3ff7350ed31b229a705c7466d4260ca52f5cc552"
   source = "github.com/0xProject/goleveldb"
 
 [[projects]]
@@ -1343,7 +1335,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/ReneKroon/ttlcache",
     "github.com/albrow/stringset",
     "github.com/chromedp/cdproto/runtime",
     "github.com/chromedp/chromedp",

--- a/cmd/mesh/main.go
+++ b/cmd/mesh/main.go
@@ -18,9 +18,9 @@ import (
 // standaloneConfig contains configuration options specific to running 0x Mesh
 // in standalone mode (i.e. not in a browser).
 type standaloneConfig struct {
-	// RPCAddr is the interface and port to use for the JSON RPC API over Websockets.
-	// By default, 0x mesh will listen on localhost and will let the OS
-	// select a randomly available port.
+	// RPCAddr is the interface and port to use for the JSON-RPC API over
+	// WebSockets. By default, 0x Mesh will listen on localhost and will let the
+	// OS select a randomly available port.
 	RPCAddr string `envvar:"RPC_ADDR" default:"localhost:0"`
 }
 

--- a/cmd/mesh/main.go
+++ b/cmd/mesh/main.go
@@ -18,9 +18,10 @@ import (
 // standaloneConfig contains configuration options specific to running 0x Mesh
 // in standalone mode (i.e. not in a browser).
 type standaloneConfig struct {
-	// RPCPort is the port to use for the JSON RPC API over WebSockets. By
-	// default, 0x Mesh will let the OS select a randomly available port.
-	RPCPort int `envvar:"RPC_PORT" default:"0"`
+	// RPCAddr is the interface and port to use for the JSON RPC API over Websockets.
+	// By default, 0x mesh will listen on localhost and will let the OS
+	// select a randomly available port.
+	RPCAddr string `envvar:"RPC_ADDR" default:"localhost:0"`
 }
 
 func main() {
@@ -61,7 +62,7 @@ func main() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		log.WithField("rpc_port", config.RPCPort).Info("starting RPC server")
+		log.WithField("rpc_addr", config.RPCAddr).Info("starting RPC server")
 		if err := listenRPC(app, config, ctx); err != nil {
 			rpcErrChan <- err
 		}

--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -24,11 +24,11 @@ type rpcHandler struct {
 	app *core.App
 }
 
-// listenRPC starts the RPC server and listens on config.RPCPort. It blocks
+// listenRPC starts the RPC server and listens on config.RPCAddr. It blocks
 // until there is an error or the RPC server is closed.
 func listenRPC(app *core.App, config standaloneConfig, ctx context.Context) error {
 	// Initialize the JSON RPC WebSocket server (but don't start it yet).
-	rpcAddr := fmt.Sprintf(":%d", config.RPCPort)
+	rpcAddr := fmt.Sprintf("%s", config.RPCAddr)
 	rpcHandler := &rpcHandler{
 		app: app,
 	}

--- a/dockerfiles/mesh/Dockerfile
+++ b/dockerfiles/mesh/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /usr/mesh
 
 COPY --from=mesh-builder /go/src/github.com/0xProject/0x-mesh/mesh /usr/mesh/mesh
 
-ENV RPC_PORT=60557
+ENV RPC_ADDR=localhost:60557
 EXPOSE 60557
 
 ENV P2P_TCP_PORT=60558

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,9 +107,9 @@ Mesh executable](../cmd/mesh/main.go):
 
 ```go
 type standaloneConfig struct {
-	// RPCAddr is the interface and port to use for the JSON RPC API over Websockets.
-	// By default, 0x mesh will listen on localhost and will let the OS
-	// select a randomly available port.
+	// RPCAddr is the interface and port to use for the JSON-RPC API over
+	// WebSockets. By default, 0x Mesh will listen on localhost and will let the
+	// OS select a randomly available port.
 	RPCAddr string `envvar:"RPC_ADDR" default:"localhost:0"`
 }
 ```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,8 +107,9 @@ Mesh executable](../cmd/mesh/main.go):
 
 ```go
 type standaloneConfig struct {
-	// RPCPort is the port to use for the JSON RPC API over WebSockets. By
-	// default, 0x Mesh will let the OS select a randomly available port.
-	RPCPort int `envvar:"RPC_PORT" default:"0"`
+	// RPCAddr is the interface and port to use for the JSON RPC API over Websockets.
+	// By default, 0x mesh will listen on localhost and will let the OS
+	// select a randomly available port.
+	RPCAddr string `envvar:"RPC_ADDR" default:"localhost:0"`
 }
 ```

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -50,7 +50,7 @@ const (
 	standalonePeerID      = "16Uiu2HAmM9j68mgGGSFkXsuzbGJA8ezVHtQ2H9y6mRJAPhx6xtj9"
 	standaloneDataDir     = "./data/standalone-0"
 	standaloneRPCEndpoint = "ws://localhost:60501"
-	standaloneRPCPort     = 60501
+	standaloneRPCAddr     = "localhost:60501"
 )
 
 var makerAddress = constants.GanacheAccount1
@@ -312,7 +312,7 @@ func startStandaloneNode(t *testing.T, ctx context.Context, logMessages chan<- s
 		"BOOTSTRAP_LIST="+bootstrapList,
 		"ETHEREUM_RPC_URL="+ethereumRPCURL,
 		"ETHEREUM_CHAIN_ID="+strconv.Itoa(ethereumChainID),
-		"RPC_PORT="+strconv.Itoa(standaloneRPCPort),
+		"RPC_ADDR="+standaloneRPCAddr,
 	)
 
 	// Pipe messages from stderr through the logMessages channel.


### PR DESCRIPTION
Allows choosing the JSON-RPC API listening interface and port. Remove RPCPort as it is no longer needed.

Big thanks to @nfeignon for implementing this feature 😄