### PR TITLE
Remove expiration buffer config and emit expiry events based on block timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@ This changelog is a work in progress and may contain notes for versions which ha
 - Renamed env config from `ETHEREUM_NETWORK_ID` to `ETHEREUM_CHAIN_ID` since `network` is a misnomer here and what we actually care about is the `chainID`. Most chains have the same id for their p2p network and chain. From the ones we support, the only outlier is Ganache, for which you will now need to supply `1337` instead of `50` (Learn more: https://medium.com/@pedrouid/chainid-vs-networkid-how-do-they-differ-on-ethereum-eec2ed41635b) ([#485](https://github.com/0xProject/0x-mesh/pull/485))
 - Rejected order code `OrderForIncorrectNetwork` has been changed to `OrderForIncorrectChain` ([#485](https://github.com/0xProject/0x-mesh/pull/485))
 - Removed `RPC_PORT` environment variable. The new `RPC_ADDR` environment variable allows specifying both the interface and port ([487](https://github.com/0xProject/0x-mesh/pull/487)).
+- Changed the `EXPIRED` event such that it is emitted when an order is expired according to the latest block timestamp, not anymore based on UTC time. ([#490](https://github.com/0xProject/0x-mesh/pull/490))
+- Removed the `EXPIRATION_BUFFER_SECONDS` env config since we no longer compute order expiration using UTC time. ([#490](https://github.com/0xProject/0x-mesh/pull/490))
 
 ### Features ✅ 
 
 - Implemented a new strategy for limiting the amount of database storage used by Mesh and removing orders when the database is full. This strategy involves a dynamically adjusting maximum expiration time. When the database is full, Mesh will enforce a maximum expiration time for all incoming orders and remove any existing orders with an expiration time too far in the future. If conditions change and there is enough space in the database again, the max expiration time will slowly increase. This is a short term solution which solves the immediate issue of finite storage capacities and does a decent job of protecting against spam. We expect to improve and possibly replace it in the future. See [#450](https://github.com/0xProject/0x-mesh/pull/450) for more details.
 - Added support for a new feature called "order pinning" ([#474](https://github.com/0xProject/0x-mesh/pull/474)). Pinned orders will not be affected by any DDoS prevention or incentive mechanisms (including the new dynamic max expiration time feature) and will always stay in storage until they are no longer fillable. By default, all orders which are submitted via either the JSON-RPC API or the `addOrdersAsync` function in the TypeScript bindings will be pinned.
 - Re-enabled bandwidth-based peer banning with a workaround to deal with erroneous spikes [#478](https://github.com/0xProject/0x-mesh/pull/478).
+- Added an `UNEXPIRED` order event kind which is emitted for orders that were previously considered expired but due to a block-reorg causing the latest block timestamp to be earlier than the previous latest block timestamp, are no longer expired. ([#490](https://github.com/0xProject/0x-mesh/pull/490))
 
 ### Bug fixes 🐞 
 

--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -114,9 +114,6 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 	if bootstrapList := jsConfig.Get("bootstrapList"); !isNullOrUndefined(bootstrapList) {
 		config.BootstrapList = bootstrapList.String()
 	}
-	if orderExpirationBufferSeconds := jsConfig.Get("orderExpirationBufferSeconds"); !isNullOrUndefined(orderExpirationBufferSeconds) {
-		config.OrderExpirationBuffer = time.Duration(orderExpirationBufferSeconds.Int()) * time.Second
-	}
 	if blockPollingIntervalSeconds := jsConfig.Get("blockPollingIntervalSeconds"); !isNullOrUndefined(blockPollingIntervalSeconds) {
 		config.BlockPollingInterval = time.Duration(blockPollingIntervalSeconds.Int()) * time.Second
 	}

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -47,10 +47,6 @@ export interface Config {
     // "/ip4/3.214.190.67/tcp/60558/ipfs/16Uiu2HAmGx8Z6gdq5T5AQE54GMtqDhDFhizywTy1o28NJbAMMumF").
     // Defaults to the hard-coded default bootstrap list.
     bootstrapList?: string[];
-    // The amount of time (in seconds) before the order's stipulated expiration
-    // time that it will be considered expired. Higher values will cause orders
-    // to be considered invalid sooner. Defaluts to 10.
-    orderExpirationBufferSeconds?: number;
     // The polling interval (in seconds) to wait before checking for a new
     // Ethereum block that might contain transactions that impact the
     // fillability of orders stored by Mesh. Different chains have different
@@ -143,7 +139,6 @@ interface WrapperConfig {
     ethereumChainID: number;
     useBootstrapList?: boolean;
     bootstrapList?: string; // comma-separated string instead of an array of strings.
-    orderExpirationBufferSeconds?: number;
     blockPollingIntervalSeconds?: number;
     ethereumRPCMaxContentLength?: number;
     EthereumRPCMaxRequestsPer24HrUTC?: number;

--- a/core/core.go
+++ b/core/core.go
@@ -397,8 +397,8 @@ func (app *App) Start(ctx context.Context) error {
 			select {
 			case <-innerCtx.Done():
 				return
-			case <-ticker.C:
-				expiredSnapshots := app.snapshotExpirationWatcher.Prune(time.Now())
+			case now := <-ticker.C:
+				expiredSnapshots := app.snapshotExpirationWatcher.Prune(now)
 				for _, expiredSnapshot := range expiredSnapshots {
 					app.muIdToSnapshotInfo.Lock()
 					delete(app.idToSnapshotInfo, expiredSnapshot.ID)

--- a/core/core.go
+++ b/core/core.go
@@ -239,24 +239,14 @@ func New(config Config) (*App, error) {
 		return nil, err
 	}
 
-	latestHeader, err := meshDB.FindLatestMiniHeader()
-	if err != nil {
-		return nil, err
-	}
-	var latestBlockTimestamp time.Time
-	if latestHeader != nil {
-		latestBlockTimestamp = latestHeader.Timestamp
-	}
-
 	// Initialize order watcher (but don't start it yet).
 	orderWatcher, err := orderwatch.New(orderwatch.Config{
-		MeshDB:               meshDB,
-		BlockWatcher:         blockWatcher,
-		OrderValidator:       orderValidator,
-		ChainID:              config.EthereumChainID,
-		MaxOrders:            config.MaxOrdersInStorage,
-		MaxExpirationTime:    metadata.MaxExpirationTime,
-		LatestBlockTimestamp: latestBlockTimestamp,
+		MeshDB:            meshDB,
+		BlockWatcher:      blockWatcher,
+		OrderValidator:    orderValidator,
+		ChainID:           config.EthereumChainID,
+		MaxOrders:         config.MaxOrdersInStorage,
+		MaxExpirationTime: metadata.MaxExpirationTime,
 	})
 	if err != nil {
 		return nil, err

--- a/core/core.go
+++ b/core/core.go
@@ -243,9 +243,9 @@ func New(config Config) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
-	var latestBlockTimestamp *time.Time
+	var latestBlockTimestamp time.Time
 	if latestHeader != nil {
-		latestBlockTimestamp = &latestHeader.Timestamp
+		latestBlockTimestamp = latestHeader.Timestamp
 	}
 
 	// Initialize order watcher (but don't start it yet).

--- a/core/core.go
+++ b/core/core.go
@@ -85,9 +85,6 @@ type Config struct {
 	// "/ip4/3.214.190.67/tcp/60558/ipfs/16Uiu2HAmGx8Z6gdq5T5AQE54GMtqDhDFhizywTy1o28NJbAMMumF").
 	// If empty, the default bootstrap list will be used.
 	BootstrapList string `envvar:"BOOTSTRAP_LIST" default:""`
-	// OrderExpirationBuffer is the amount of time before the order's stipulated expiration time
-	// that you'd want it pruned from the Mesh node.
-	OrderExpirationBuffer time.Duration `envvar:"ORDER_EXPIRATION_BUFFER" default:"10s"`
 	// BlockPollingInterval is the polling interval to wait before checking for a new Ethereum block
 	// that might contain transactions that impact the fillability of orders stored by Mesh. Different
 	// chains have different block producing intervals: POW chains are typically slower (e.g., Mainnet)
@@ -237,7 +234,6 @@ func New(config Config) (*App, error) {
 		ethClient,
 		config.EthereumChainID,
 		config.EthereumRPCMaxContentLength,
-		config.OrderExpirationBuffer,
 	)
 	if err != nil {
 		return nil, err
@@ -249,7 +245,6 @@ func New(config Config) (*App, error) {
 		BlockWatcher:      blockWatcher,
 		OrderValidator:    orderValidator,
 		ChainID:           config.EthereumChainID,
-		ExpirationBuffer:  config.OrderExpirationBuffer,
 		MaxOrders:         config.MaxOrdersInStorage,
 		MaxExpirationTime: metadata.MaxExpirationTime,
 	})
@@ -257,7 +252,7 @@ func New(config Config) (*App, error) {
 		return nil, err
 	}
 
-	snapshotExpirationWatcher := expirationwatch.New(0 * time.Second)
+	snapshotExpirationWatcher := expirationwatch.New()
 
 	orderJSONSchema, err := setupOrderSchemaValidator()
 	if err != nil {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -84,9 +84,6 @@ type Config struct {
 	// "/ip4/3.214.190.67/tcp/60558/ipfs/16Uiu2HAmGx8Z6gdq5T5AQE54GMtqDhDFhizywTy1o28NJbAMMumF").
 	// If empty, the default bootstrap list will be used.
 	BootstrapList string `envvar:"BOOTSTRAP_LIST" default:""`
-	// OrderExpirationBuffer is the amount of time before the order's stipulated expiration time
-	// that you'd want it pruned from the Mesh node.
-	OrderExpirationBuffer time.Duration `envvar:"ORDER_EXPIRATION_BUFFER" default:"10s"`
 	// BlockPollingInterval is the polling interval to wait before checking for a new Ethereum block
 	// that might contain transactions that impact the fillability of orders stored by Mesh. Different
 	// chains have different block producing intervals: POW chains are typically slower (e.g., Mainnet)

--- a/ethereum/blockchain_lifecycle.go
+++ b/ethereum/blockchain_lifecycle.go
@@ -2,6 +2,7 @@ package ethereum
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/require"
@@ -41,5 +42,15 @@ func (b *BlockchainLifecycle) Revert(t *testing.T) {
 	require.NoError(t, err)
 	if !didRevert {
 		t.Errorf("Failed to revert snapshot with ID: %s", latestSnapshot)
+	}
+}
+
+// Mine force-mines a block with the specified block timestamp
+func (b *BlockchainLifecycle) Mine(t *testing.T, blockTimestamp time.Time) {
+	var didForceMine string
+	err := b.rpcClient.Call(&didForceMine, "evm_mine", blockTimestamp.Unix())
+	require.NoError(t, err)
+	if didForceMine != "0x0" {
+		t.Error("Failed to force mine a block")
 	}
 }

--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -357,13 +357,19 @@ func (w *Watcher) getMissedEventsToBackfill(ctx context.Context) ([]*Event, erro
 		for _, log := range logs {
 			blockHeader, ok := hashToBlockHeader[log.BlockHash]
 			if !ok {
+				blockNumber := big.NewInt(0).SetUint64(log.BlockNumber)
+				header, err := w.client.HeaderByNumber(blockNumber)
+				if err != nil {
+					return events, err
+				}
 				// TODO(fabio): Find a way to include the parent hash for the block as well.
 				// It's currently not an issue to omit it since we don't use the parent hash
 				// when processing block events in OrderWatcher.
 				blockHeader = &miniheader.MiniHeader{
-					Hash:   log.BlockHash,
-					Number: big.NewInt(0).SetUint64(log.BlockNumber),
-					Logs:   []types.Log{},
+					Hash:      log.BlockHash,
+					Number:    blockNumber,
+					Logs:      []types.Log{},
+					Timestamp: header.Timestamp,
 				}
 				hashToBlockHeader[log.BlockHash] = blockHeader
 			}

--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -362,11 +362,9 @@ func (w *Watcher) getMissedEventsToBackfill(ctx context.Context) ([]*Event, erro
 				if err != nil {
 					return events, err
 				}
-				// TODO(fabio): Find a way to include the parent hash for the block as well.
-				// It's currently not an issue to omit it since we don't use the parent hash
-				// when processing block events in OrderWatcher.
 				blockHeader = &miniheader.MiniHeader{
 					Hash:      log.BlockHash,
+					Parent:    header.Parent,
 					Number:    blockNumber,
 					Logs:      []types.Log{},
 					Timestamp: header.Timestamp,

--- a/ethereum/blockwatch/block_watcher_test.go
+++ b/ethereum/blockwatch/block_watcher_test.go
@@ -198,9 +198,10 @@ func TestGetMissedEventsToBackfillSomeMissed(t *testing.T) {
 	require.NoError(t, err)
 	// Add block number 5 as the last block seen by BlockWatcher
 	lastBlockSeen := &miniheader.MiniHeader{
-		Number: big.NewInt(5),
-		Hash:   common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
-		Parent: common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now(),
 	}
 
 	config.Stack = NewSimpleStack(blockRetentionLimit)
@@ -232,9 +233,10 @@ func TestGetMissedEventsToBackfillNoneMissed(t *testing.T) {
 	require.NoError(t, err)
 	// Add block number 5 as the last block seen by BlockWatcher
 	lastBlockSeen := &miniheader.MiniHeader{
-		Number: big.NewInt(5),
-		Hash:   common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
-		Parent: common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now(),
 	}
 
 	config.Stack = NewSimpleStack(blockRetentionLimit)

--- a/ethereum/blockwatch/client.go
+++ b/ethereum/blockwatch/client.go
@@ -97,9 +97,10 @@ func (rc *RpcClient) HeaderByHash(hash common.Hash) (*miniheader.MiniHeader, err
 		return nil, err
 	}
 	miniHeader := &miniheader.MiniHeader{
-		Hash:   header.Hash(),
-		Parent: header.ParentHash,
-		Number: header.Number,
+		Hash:      header.Hash(),
+		Parent:    header.ParentHash,
+		Number:    header.Number,
+		Timestamp: time.Unix(int64(header.Time), 0),
 	}
 	return miniHeader, nil
 }

--- a/ethereum/blockwatch/client.go
+++ b/ethereum/blockwatch/client.go
@@ -45,6 +45,7 @@ type GetBlockByNumberResponse struct {
 	Hash       common.Hash `json:"hash"`
 	ParentHash common.Hash `json:"parentHash"`
 	Number     string      `json:"number"`
+	Timestamp  string      `json:"timestamp"`
 }
 
 // HeaderByNumber fetches a block header by its number. If no `number` is supplied, it will return the latest
@@ -79,10 +80,15 @@ func (rc *RpcClient) HeaderByNumber(number *big.Int) (*miniheader.MiniHeader, er
 	if !ok {
 		return nil, errors.New("Failed to parse big.Int value from hex-encoded block number returned from eth_getBlockByNumber")
 	}
+	unixTimestamp, ok := math.ParseBig256(header.Timestamp)
+	if !ok {
+		return nil, errors.New("Failed to parse big.Int value from hex-encoded block timestamp returned from eth_getBlockByNumber")
+	}
 	miniHeader := &miniheader.MiniHeader{
-		Hash:   header.Hash,
-		Parent: header.ParentHash,
-		Number: blockNum,
+		Hash:      header.Hash,
+		Parent:    header.ParentHash,
+		Number:    blockNum,
+		Timestamp: time.Unix(unixTimestamp.Int64(), 0),
 	}
 	return miniHeader, nil
 }

--- a/ethereum/dbstack/db_stack_test.go
+++ b/ethereum/dbstack/db_stack_test.go
@@ -3,6 +3,7 @@ package dbstack
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/0xProject/0x-mesh/ethereum/miniheader"
 	"github.com/0xProject/0x-mesh/meshdb"
@@ -16,9 +17,10 @@ const limit = 10
 
 var (
 	miniHeaderOne = &miniheader.MiniHeader{
-		Number: big.NewInt(1),
-		Hash:   common.Hash{},
-		Parent: common.Hash{},
+		Number:    big.NewInt(1),
+		Hash:      common.Hash{},
+		Parent:    common.Hash{},
+		Timestamp: time.Now(),
 	}
 )
 

--- a/ethereum/miniheader/miniheader.go
+++ b/ethereum/miniheader/miniheader.go
@@ -2,6 +2,7 @@ package miniheader
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -9,10 +10,11 @@ import (
 
 // MiniHeader is a representation of a succinct Ethereum block headers
 type MiniHeader struct {
-	Hash   common.Hash
-	Parent common.Hash
-	Number *big.Int
-	Logs   []types.Log
+	Hash      common.Hash
+	Parent    common.Hash
+	Number    *big.Int
+	Timestamp time.Time
+	Logs      []types.Log
 }
 
 // ID returns the MiniHeader's ID

--- a/expirationwatch/expiration_watcher.go
+++ b/expirationwatch/expiration_watcher.go
@@ -1,8 +1,6 @@
 package expirationwatch
 
 import (
-	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -19,12 +17,9 @@ type ExpiredItem struct {
 
 // Watcher watches the expiration of items
 type Watcher struct {
-	expiredItems   chan []ExpiredItem
-	rbTreeMu       sync.RWMutex
-	rbTree         *rbt.RbTree
-	ticker         *time.Ticker
-	wasStartedOnce bool
-	mu             sync.Mutex
+	expiredItems chan []ExpiredItem
+	rbTreeMu     sync.RWMutex
+	rbTree       *rbt.RbTree
 }
 
 // New instantiates a new expiration watcher
@@ -77,49 +72,9 @@ func (w *Watcher) Remove(expirationTimestamp time.Time, id string) {
 	}
 }
 
-// Watch starts the expiration watchers poller. It continuously checks all items
-// for expiration until there is an error or the given context is canceled. You
-// usually want to call Watch inside a goroutine.
-func (w *Watcher) Watch(ctx context.Context, pollingInterval time.Duration) error {
-	w.mu.Lock()
-	if w.wasStartedOnce {
-		w.mu.Unlock()
-		return errors.New("Can only start Watcher once per instance")
-	}
-	w.wasStartedOnce = true
-	w.mu.Unlock()
-
-	// TODO(fabio): Optimize this poller. We could keep track of soonestExpirationTime as a property of
-	// Watcher. Whenever a new item is added via Add, we check if the expiration time is sooner
-	// than soonestExpirationTime and if so, we update soonestExpirationTime. Then instead of running the
-	// inner for loop at a constant frequency, we adjust the frequency based on the value of
-	// soonestExpirationTime (probably by using time.After or time.Sleep).
-	ticker := time.NewTicker(pollingInterval)
-	for {
-		select {
-		case <-ctx.Done():
-			ticker.Stop()
-			close(w.expiredItems)
-			return nil
-		case <-ticker.C:
-			expiredItems := w.prune()
-			if len(expiredItems) > 0 {
-				w.expiredItems <- expiredItems
-			}
-		}
-	}
-}
-
-// ExpiredItems returns a read-only channel that can be used to listen for
-// expired items. The channel will be closed if/when the watcher is done
-// watching.
-func (w *Watcher) ExpiredItems() <-chan []ExpiredItem {
-	return w.expiredItems
-}
-
-// prune checks for any expired items, removes them from the expiration watcher and returns them
-// to the caller
-func (w *Watcher) prune() []ExpiredItem {
+// Prune checks for any expired items given the latest blockTimestamp,
+// removes them from the expiration watcher and returns them to the caller
+func (w *Watcher) Prune(blockTimestamp time.Time) []ExpiredItem {
 	pruned := []ExpiredItem{}
 	for {
 		w.rbTreeMu.RLock()
@@ -130,7 +85,7 @@ func (w *Watcher) prune() []ExpiredItem {
 		}
 		expirationTimeSeconds := int64(*key.(*rbt.Int64Key))
 		expirationTime := time.Unix(expirationTimeSeconds, 0)
-		if !time.Now().After(expirationTime) {
+		if !blockTimestamp.After(expirationTime) {
 			break
 		}
 		ids := value.(stringset.Set)

--- a/expirationwatch/expiration_watcher.go
+++ b/expirationwatch/expiration_watcher.go
@@ -72,9 +72,9 @@ func (w *Watcher) Remove(expirationTimestamp time.Time, id string) {
 	}
 }
 
-// Prune checks for any expired items given the latest blockTimestamp,
-// removes them from the expiration watcher and returns them to the caller
-func (w *Watcher) Prune(blockTimestamp time.Time) []ExpiredItem {
+// Prune checks for any expired items given a timestamp and removes any expired 
+// items from the expiration watcher and returns them to the caller
+func (w *Watcher) Prune(timestamp time.Time) []ExpiredItem {
 	pruned := []ExpiredItem{}
 	for {
 		w.rbTreeMu.RLock()
@@ -85,7 +85,7 @@ func (w *Watcher) Prune(blockTimestamp time.Time) []ExpiredItem {
 		}
 		expirationTimeSeconds := int64(*key.(*rbt.Int64Key))
 		expirationTime := time.Unix(expirationTimeSeconds, 0)
-		if !blockTimestamp.After(expirationTime) {
+		if !timestamp.After(expirationTime) {
 			break
 		}
 		ids := value.(stringset.Set)

--- a/expirationwatch/expiration_watcher_test.go
+++ b/expirationwatch/expiration_watcher_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPrunesExpiredItems(t *testing.T) {
-	watcher := New(0)
+	watcher := New()
 
 	current := time.Now().Truncate(time.Second)
 	expiryEntryOne := ExpiredItem{
@@ -34,7 +34,7 @@ func TestPrunesExpiredItems(t *testing.T) {
 }
 
 func TestPrunesTwoExpiredItemsWithSameExpiration(t *testing.T) {
-	watcher := New(0)
+	watcher := New()
 
 	current := time.Now().Truncate(time.Second)
 	expiration := current.Add(-3 * time.Second)
@@ -62,7 +62,7 @@ func TestPrunesTwoExpiredItemsWithSameExpiration(t *testing.T) {
 }
 
 func TestKeepsUnexpiredItem(t *testing.T) {
-	watcher := New(0)
+	watcher := New()
 
 	id := "0x8e209dda7e515025d0c34aa61a0d1156a631248a4318576a2ce0fb408d97385e"
 	current := time.Now().Truncate(time.Second)
@@ -73,14 +73,14 @@ func TestKeepsUnexpiredItem(t *testing.T) {
 }
 
 func TestReturnsEmptyIfNoItems(t *testing.T) {
-	watcher := New(0)
+	watcher := New()
 
 	pruned := watcher.prune()
 	assert.Len(t, pruned, 0, "Returns empty array when no items tracked")
 }
 
 func TestRemoveOnlyItemWithSpecificExpirationTime(t *testing.T) {
-	watcher := New(0)
+	watcher := New()
 
 	current := time.Now().Truncate(time.Second)
 	expiryEntryOne := ExpiredItem{
@@ -102,7 +102,7 @@ func TestRemoveOnlyItemWithSpecificExpirationTime(t *testing.T) {
 	assert.Equal(t, expiryEntryOne, pruned[0])
 }
 func TestRemoveItemWhichSharesExpirationTimeWithOtherItems(t *testing.T) {
-	watcher := New(0)
+	watcher := New()
 
 	current := time.Now().Truncate(time.Second)
 	singleExpirationTimestamp := current.Add(-3 * time.Second)
@@ -126,7 +126,7 @@ func TestRemoveItemWhichSharesExpirationTimeWithOtherItems(t *testing.T) {
 }
 
 func TestStartAndStopPoller(t *testing.T) {
-	watcher := New(0)
+	watcher := New()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/scenario/scenario.go
+++ b/scenario/scenario.go
@@ -111,8 +111,8 @@ func CreateSignedTestOrderWithExpirationTime(t *testing.T, ethClient *ethclient.
 		Salt:                  big.NewInt(1548619145450),
 		MakerFee:              big.NewInt(0),
 		TakerFee:              big.NewInt(0),
-		MakerAssetAmount:      big.NewInt(0),
-		TakerAssetAmount:      big.NewInt(0),
+		MakerAssetAmount:      big.NewInt(1000),
+		TakerAssetAmount:      big.NewInt(1000),
 		ExpirationTimeSeconds: big.NewInt(expirationTime.Unix()),
 		ExchangeAddress:       ethereum.ChainIDToContractAddresses[constants.TestChainID].Exchange,
 	}

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -173,6 +173,7 @@ const (
 	ESOrderFullyFilled = OrderEventEndState("FULLY_FILLED")
 	ESOrderCancelled   = OrderEventEndState("CANCELLED")
 	ESOrderExpired     = OrderEventEndState("EXPIRED")
+	ESOrderUnexpired   = OrderEventEndState("UNEXPIRED")
 	// An order becomes unfunded if the maker transfers the balance / changes their
 	// allowance backing an order
 	ESOrderBecameUnfunded = OrderEventEndState("UNFUNDED")

--- a/zeroex/ordervalidator/order_validator.go
+++ b/zeroex/ordervalidator/order_validator.go
@@ -122,9 +122,9 @@ var (
 		Code:    "OrderHasInvalidTakerAssetAmount",
 		Message: "order takerAssetAmount cannot be 0",
 	}
-	ROUTCExpired = RejectedOrderStatus{
-		Code:    "OrderUTCExpired",
-		Message: "order expired according to current UTC time",
+	ROExpired = RejectedOrderStatus{
+		Code:    "OrderExpired",
+		Message: "order expired according to latest block timestamp",
 	}
 	ROFullyFilled = RejectedOrderStatus{
 		Code:    "OrderFullyFilled",
@@ -186,7 +186,7 @@ const ROInvalidSchemaCode = "InvalidSchema"
 // ConvertRejectOrderCodeToOrderEventEndState converts an RejectOrderCode to an OrderEventEndState type
 func ConvertRejectOrderCodeToOrderEventEndState(rejectedOrderStatus RejectedOrderStatus) (zeroex.OrderEventEndState, bool) {
 	switch rejectedOrderStatus {
-	case ROUTCExpired:
+	case ROExpired:
 		return zeroex.ESOrderExpired, true
 	case ROFullyFilled:
 		return zeroex.ESOrderFullyFilled, true
@@ -382,13 +382,8 @@ func (o *OrderValidator) BatchValidate(ctx context.Context, rawSignedOrders []*z
 					case zeroex.OSExpired, zeroex.OSFullyFilled, zeroex.OSCancelled, zeroex.OSSignatureInvalid:
 						var status RejectedOrderStatus
 						switch orderStatus {
-						// HACK(fabio): This conditional should only hit _iff_ the order was not expired according to
-						// UTC time when the off-chain order validation check were performed, but once the ETH RPC call
-						// was made to validate the order, it had become expired acccording to the block timestamp. Since
-						// the block timestamp can be before or after the current UTC time, we cannot assume that it is 
-						// UTC expired. We must check for this here. 
 						case zeroex.OSExpired:
-							status = ROUTCExpired
+							status = ROExpired
 						case zeroex.OSFullyFilled:
 							status = ROFullyFilled
 						case zeroex.OSCancelled:
@@ -634,16 +629,6 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*zeroex.SignedOr
 				SignedOrder: signedOrder,
 				Kind:        MeshValidation,
 				Status:      ROMaxExpirationExceeded,
-			})
-			continue
-		}
-		expirationTime := time.Unix(signedOrder.ExpirationTimeSeconds.Int64(), 0)
-		if time.Now().After(expirationTime) {
-			rejectedOrderInfos = append(rejectedOrderInfos, &RejectedOrderInfo{
-				OrderHash:   orderHash,
-				SignedOrder: signedOrder,
-				Kind:        ZeroExValidation,
-				Status:      ROUTCExpired,
 			})
 			continue
 		}

--- a/zeroex/ordervalidator/order_validator_test.go
+++ b/zeroex/ordervalidator/order_validator_test.go
@@ -141,7 +141,7 @@ func TestBatchValidateOffChainCases(t *testing.T) {
 		testCase{
 			SignedOrder:                 signedOrderWithCustomExpirationTimeSeconds(t, testSignedOrder, big.NewInt(time.Now().Add(-5*time.Minute).Unix())),
 			IsValid:                     false,
-			ExpectedRejectedOrderStatus: ROExpired,
+			ExpectedRejectedOrderStatus: ROUTCExpired,
 		},
 		testCase{
 			SignedOrder:                 signedOrderWithCustomSignature(t, testSignedOrder, malformedSignature),

--- a/zeroex/ordervalidator/order_validator_test.go
+++ b/zeroex/ordervalidator/order_validator_test.go
@@ -160,7 +160,7 @@ func TestBatchValidateOffChainCases(t *testing.T) {
 			&testCase.SignedOrder,
 		}
 
-		orderValidator, err := New(ethClient, constants.TestChainID, constants.TestMaxContentLength, 0)
+		orderValidator, err := New(ethClient, constants.TestChainID, constants.TestMaxContentLength)
 		require.NoError(t, err)
 
 		offchainValidOrders, rejectedOrderInfos := orderValidator.BatchOffchainValidation(signedOrders)
@@ -191,7 +191,7 @@ func TestBatchValidateAValidOrder(t *testing.T) {
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
-	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength, 0)
+	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -219,7 +219,7 @@ func TestBatchValidateSignatureInvalid(t *testing.T) {
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
-	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength, 0)
+	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -247,7 +247,7 @@ func TestBatchValidateUnregisteredCoordinatorSoftCancels(t *testing.T) {
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
-	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength, 0)
+	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -278,7 +278,7 @@ func TestBatchValidateCoordinatorSoftCancels(t *testing.T) {
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
-	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength, 0)
+	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength)
 	require.NoError(t, err)
 
 	// generate a test server so we can capture and inspect the request
@@ -331,7 +331,7 @@ func TestComputeOptimalChunkSizesMaxContentLengthTooLow(t *testing.T) {
 	require.NoError(t, err)
 
 	maxContentLength := singleOrderPayloadSize - 10
-	orderValidator, err := New(ethRPCClient, constants.TestChainID, maxContentLength, 0)
+	orderValidator, err := New(ethRPCClient, constants.TestChainID, maxContentLength)
 	require.NoError(t, err)
 
 	signedOrders := []*zeroex.SignedOrder{signedOrder}
@@ -349,7 +349,7 @@ func TestComputeOptimalChunkSizes(t *testing.T) {
 	require.NoError(t, err)
 
 	maxContentLength := singleOrderPayloadSize * 3
-	orderValidator, err := New(ethRPCClient, constants.TestChainID, maxContentLength, 0)
+	orderValidator, err := New(ethRPCClient, constants.TestChainID, maxContentLength)
 	require.NoError(t, err)
 
 	signedOrders := []*zeroex.SignedOrder{signedOrder, signedOrder, signedOrder, signedOrder}
@@ -387,7 +387,7 @@ func TestComputeOptimalChunkSizesMultiAssetOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	maxContentLength := singleOrderPayloadSize * 3
-	orderValidator, err := New(ethRPCClient, constants.TestChainID, maxContentLength, 0)
+	orderValidator, err := New(ethRPCClient, constants.TestChainID, maxContentLength)
 	require.NoError(t, err)
 
 	signedOrders := []*zeroex.SignedOrder{signedMultiAssetOrder, signedOrder, signedOrder, signedOrder, signedOrder}

--- a/zeroex/ordervalidator/order_validator_test.go
+++ b/zeroex/ordervalidator/order_validator_test.go
@@ -139,11 +139,6 @@ func TestBatchValidateOffChainCases(t *testing.T) {
 			ExpectedRejectedOrderStatus: ROInvalidTakerAssetData,
 		},
 		testCase{
-			SignedOrder:                 signedOrderWithCustomExpirationTimeSeconds(t, testSignedOrder, big.NewInt(time.Now().Add(-5*time.Minute).Unix())),
-			IsValid:                     false,
-			ExpectedRejectedOrderStatus: ROUTCExpired,
-		},
-		testCase{
 			SignedOrder:                 signedOrderWithCustomSignature(t, testSignedOrder, malformedSignature),
 			IsValid:                     false,
 			ExpectedRejectedOrderStatus: ROInvalidSignature,

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1008,7 +1008,7 @@ func (w *Watcher) generateOrderEventsIfChanged(ctx context.Context, ordersColTxn
 		oldAmountIsMoreThenNewAmount := oldFillableAmount.Cmp(newFillableAmount) == 1
 
 		expirationTime := time.Unix(order.SignedOrder.ExpirationTimeSeconds.Int64(), 0)
-		isExpired := time.Now().After(expirationTime)
+		isExpired := w.latestBlockTimestamp.After(expirationTime)
 		if !isExpired && oldFillableAmount.Cmp(big.NewInt(0)) == 0 {
 			// A previous event caused this order to be removed from DB because it's
 			// fillableAmount became 0, but it has now been revived (e.g., block re-org

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -941,7 +941,7 @@ func (w *Watcher) setupInMemoryOrderState(signedOrder *zeroex.SignedOrder) error
 		return err
 	}
 
-	expirationTimestamp := time.Unix(signedOrder.ExpirationTimeSeconds.Int64(), 0).UTC()
+	expirationTimestamp := time.Unix(signedOrder.ExpirationTimeSeconds.Int64(), 0)
 	w.expirationWatcher.Add(expirationTimestamp, orderHash.Hex())
 
 	return nil

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -92,13 +92,12 @@ type Watcher struct {
 }
 
 type Config struct {
-	MeshDB               *meshdb.MeshDB
-	BlockWatcher         *blockwatch.Watcher
-	OrderValidator       *ordervalidator.OrderValidator
-	ChainID              int
-	MaxOrders            int
-	MaxExpirationTime    *big.Int
-	LatestBlockTimestamp time.Time
+	MeshDB            *meshdb.MeshDB
+	BlockWatcher      *blockwatch.Watcher
+	OrderValidator    *ordervalidator.OrderValidator
+	ChainID           int
+	MaxOrders         int
+	MaxExpirationTime *big.Int
 }
 
 // New instantiates a new order watcher
@@ -148,7 +147,6 @@ func New(config Config) (*Watcher, error) {
 		maxExpirationTime:          big.NewInt(0).Set(config.MaxExpirationTime),
 		maxExpirationCounter:       maxExpirationCounter,
 		maxOrders:                  config.MaxOrders,
-		latestBlockTimestamp:       config.LatestBlockTimestamp,
 	}
 
 	// Check if any orders need to be removed right away due to high expiration

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -88,7 +88,7 @@ type Watcher struct {
 	maxExpirationTime          *big.Int
 	maxExpirationCounter       *slowcounter.SlowCounter
 	maxOrders                  int
-	latestBlockTimestamp       *time.Time
+	latestBlockTimestamp       time.Time
 }
 
 type Config struct {
@@ -98,7 +98,7 @@ type Config struct {
 	ChainID              int
 	MaxOrders            int
 	MaxExpirationTime    *big.Int
-	LatestBlockTimestamp *time.Time
+	LatestBlockTimestamp time.Time
 }
 
 // New instantiates a new order watcher
@@ -332,7 +332,8 @@ func (w *Watcher) removedCheckerLoop(ctx context.Context) error {
 func (w *Watcher) generateExpirationOrderEventsIfAny(ordersColTxn *db.Transaction, latestBlockTimestamp time.Time) ([]*zeroex.OrderEvent, error) {
 	orderEvents := []*zeroex.OrderEvent{}
 
-	if w.latestBlockTimestamp == nil || w.latestBlockTimestamp.Before(latestBlockTimestamp) {
+	var defaultTime time.Time
+	if w.latestBlockTimestamp == defaultTime || w.latestBlockTimestamp.Before(latestBlockTimestamp) {
 		expiredOrders := w.expirationWatcher.Prune(latestBlockTimestamp)
 		for _, expiredOrder := range expiredOrders {
 			order := &meshdb.Order{}
@@ -695,7 +696,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 	if err != nil {
 		return err
 	}
-	w.latestBlockTimestamp = &latestBlockTimestamp
+	w.latestBlockTimestamp = latestBlockTimestamp
 
 	// This timeout of 1min is for limiting how long this call should block at the ETH RPC rate limiter
 	ctx, done := context.WithTimeout(context.Background(), 1*time.Minute)

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -770,14 +770,13 @@ func setupOrderWatcher(ctx context.Context, t *testing.T, ethClient *ethclient.C
 		Client:          blockWatcherClient,
 	}
 	blockWatcher := blockwatch.New(blockWatcherConfig)
-	orderValidator, err := ordervalidator.New(ethRPCClient, constants.TestChainID, ethereumRPCMaxContentLength, 0)
+	orderValidator, err := ordervalidator.New(ethRPCClient, constants.TestChainID, ethereumRPCMaxContentLength)
 	require.NoError(t, err)
 	orderWatcher, err := New(Config{
 		MeshDB:            meshDB,
 		BlockWatcher:      blockWatcher,
 		OrderValidator:    orderValidator,
-		ChainID:         constants.TestChainID,
-		ExpirationBuffer:  0,
+		ChainID:           constants.TestChainID,
 		MaxExpirationTime: constants.UnlimitedExpirationTime,
 		MaxOrders:         1000,
 	})

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -709,7 +709,7 @@ func TestOrderWatcherOrderExpiredThenUnexpires(t *testing.T) {
 	earlierBlockTimestamp := latestBlockTimestamp.Add(-10 * time.Minute)
 	blockchainLifecycle.Mine(t, earlierBlockTimestamp)
 
-	// Await expired event
+	// Await unexpired event
 	orderEvents = waitForOrderEvents(t, orderEventsChan, 1, 4*time.Second)
 	require.Len(t, orderEvents, 1)
 	orderEvent = orderEvents[0]

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -667,7 +667,7 @@ func TestOrderWatcherERC20PartiallyFilled(t *testing.T) {
 	assert.Equal(t, false, orders[0].IsRemoved)
 	assert.Equal(t, halfAmount, orders[0].FillableTakerAssetAmount)
 }
-func TestOrderWatcherOrderExpiredAndUnexpires(t *testing.T) {
+func TestOrderWatcherOrderExpiredThenUnexpires(t *testing.T) {
 	if !serialTestsEnabled {
 		t.Skip("Serial tests (tests which cannot run in parallel) are disabled. You can enable them with the --serial flag")
 	}


### PR DESCRIPTION
Fixed: https://github.com/0xProject/0x-mesh/issues/419 and https://github.com/0xProject/0x-mesh/issues/418

This PR:

- Refactors Mesh to emit order expiration events when orders are expired according to the latest block timestamp. We no longer emit UTC-based expiration events. 
- An order can now become unexpired, if a block re-org causes the latest block timestamp to be earlier than it's predecessor. We therefore added the `UNEXPIRED` order event type.
- Removes the expiration buffer config as it is no longer needed.

