### PR TITLE
Fix telemetry guide formatting

### DIFF
--- a/docs/deployment_with_telemetry.md
+++ b/docs/deployment_with_telemetry.md
@@ -153,7 +153,7 @@ You can DM `fabio#1058`, `Alex Browne | 0x#2975` or `ovrmrrw#0454` and we'll
 whitelist your node :)
 
 I hope that was easy enough! If you ran into any issues, please ping us in the
-#mesh channel on [Discord](https://discord.gg/HF7fHwk). To learn more about
+`#mesh` channel on [Discord](https://discord.gg/HF7fHwk). To learn more about
 connecting to your Mesh node's JSON RPC interface, check out the
 [JSON-RPC API Documentation](rpc_api.md). Your node's JSON RPC endpoint
 should be available at `ws://<your-ip-address>:60557` and you can discover your


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/210914/68165414-3bd8bf00-ff14-11e9-84dd-1d6556eb4161.png)

The `#` in the Discord channel name was getting picked up as a header tag, so I added ``s around it.

