### PR TITLE
Fix bug in Go RPC client when unmarshaling contract events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 ### Bug fixes 🐞 
 
 - Improved the aggressiveness at which we permanently delete orders that have been flagged for removal. Previously we would wait for the cleanup job to handle this (once an hour), but that meant many removed orders would accumulate. We now prune them every 5 minutes. ([#471](https://github.com/0xProject/0x-mesh/pull/471))
+- Fixed a bug in the Go RPC client which resulted in errors when receving order events with at least one contract event ([#496](https://github.com/0xProject/0x-mesh/pull/496)).
 
 ## v5.1.0-beta
 

--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/0xProject/0x-mesh/constants"
+	"github.com/0xProject/0x-mesh/zeroex/orderwatch/decoder"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,22 @@ func TestMarshalUnmarshalOrderEvent(t *testing.T) {
 		SignedOrder:              signedOrder,
 		EndState:                 ESOrderAdded,
 		FillableTakerAssetAmount: big.NewInt(2000),
-		ContractEvents:           []*ContractEvent{},
+		ContractEvents: []*ContractEvent{
+			{
+				BlockHash: common.HexToHash("0x3fcd58a6613265e2b0deba902d7ff693f330a0af6e5b04805b44bbffd8a415d4"),
+				TxHash:    common.HexToHash("0x3fcd58a6613265e2b0deba902d7ff693f330a0af6e5b04805b44bbffd8a415d5"),
+				TxIndex:   42,
+				LogIndex:  1337,
+				IsRemoved: true,
+				Address:   common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c49"),
+				Kind:      "ERC20TransferEvent",
+				Parameters: decoder.ERC20TransferEvent{
+					From:  common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c50"),
+					To:    common.HexToAddress("0x1dc4c1cefef38a777b15aa20260a54e584b16c51"),
+					Value: big.NewInt(120),
+				},
+			},
+		},
 	}
 
 	buf := &bytes.Buffer{}

--- a/zeroex/orderwatch/decoder/event_decoder.go
+++ b/zeroex/orderwatch/decoder/event_decoder.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -49,13 +50,34 @@ type ERC20TransferEvent struct {
 	Value *big.Int
 }
 
+type erc20TransferEventJSON struct {
+	From  string `json:"from"`
+	To    string `json:"to"`
+	Value string `json:"value"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the ERC20TransferEvent type
 func (e ERC20TransferEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"from":  e.From.Hex(),
-		"to":    e.To.Hex(),
-		"value": e.Value.String(),
+	return json.Marshal(erc20TransferEventJSON{
+		From:  e.From.Hex(),
+		To:    e.To.Hex(),
+		Value: e.Value.String(),
 	})
+}
+
+func (e *ERC20TransferEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON erc20TransferEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.From = common.HexToAddress(eventJSON.From)
+	e.To = common.HexToAddress(eventJSON.To)
+	var ok bool
+	e.Value, ok = math.ParseBig256(eventJSON.Value)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ERC20TransferEvent.Value: %q", eventJSON.Value)
+	}
+	return nil
 }
 
 // ERC20ApprovalEvent represents an ERC20 Approval event
@@ -65,13 +87,34 @@ type ERC20ApprovalEvent struct {
 	Value   *big.Int
 }
 
+type erc20ApprovalEventJSON struct {
+	Owner   string `json:"owner"`
+	Spender string `json:"spender"`
+	Value   string `json:"value"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the ERC20ApprovalEvent type
 func (e ERC20ApprovalEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"owner":   e.Owner.Hex(),
-		"spender": e.Spender.Hex(),
-		"value":   e.Value.String(),
+	return json.Marshal(erc20ApprovalEventJSON{
+		Owner:   e.Owner.Hex(),
+		Spender: e.Spender.Hex(),
+		Value:   e.Value.String(),
 	})
+}
+
+func (e *ERC20ApprovalEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON erc20ApprovalEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.Owner = common.HexToAddress(eventJSON.Owner)
+	e.Spender = common.HexToAddress(eventJSON.Spender)
+	var ok bool
+	e.Value, ok = math.ParseBig256(eventJSON.Value)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ERC20ApprovalEvent.Value: %q", eventJSON.Value)
+	}
+	return nil
 }
 
 // ERC721TransferEvent represents an ERC721 Transfer event
@@ -81,13 +124,34 @@ type ERC721TransferEvent struct {
 	TokenId *big.Int
 }
 
+type erc721TransferEventJSON struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	TokenId string `json:"tokenId"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the ERC721TransferEvent type
 func (e ERC721TransferEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"from":    e.From.Hex(),
-		"to":      e.To.Hex(),
-		"tokenId": e.TokenId.String(),
+	return json.Marshal(erc721TransferEventJSON{
+		From:    e.From.Hex(),
+		To:      e.To.Hex(),
+		TokenId: e.TokenId.String(),
 	})
+}
+
+func (e *ERC721TransferEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON erc721TransferEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.From = common.HexToAddress(eventJSON.From)
+	e.To = common.HexToAddress(eventJSON.To)
+	var ok bool
+	e.TokenId, ok = math.ParseBig256(eventJSON.TokenId)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ERC20ApprovalEvent.TokenId: %q", eventJSON.TokenId)
+	}
+	return nil
 }
 
 // ERC721ApprovalEvent represents an ERC721 Approval event
@@ -97,45 +161,48 @@ type ERC721ApprovalEvent struct {
 	TokenId  *big.Int
 }
 
+type erc721ApprovalEventJSON struct {
+	Owner    string `json:"owner"`
+	Approved string `json:"approved"`
+	TokenId  string `json:"tokenId"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the ERC721ApprovalEvent type
 func (e ERC721ApprovalEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"owner":    e.Owner.Hex(),
-		"approved": e.Approved.Hex(),
-		"tokenId":  e.TokenId.String(),
+	return json.Marshal(erc721ApprovalEventJSON{
+		Owner:    e.Owner.Hex(),
+		Approved: e.Approved.Hex(),
+		TokenId:  e.TokenId.String(),
 	})
+}
+
+func (e *ERC721ApprovalEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON erc721ApprovalEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.Owner = common.HexToAddress(eventJSON.Owner)
+	e.Approved = common.HexToAddress(eventJSON.Approved)
+	var ok bool
+	e.TokenId, ok = math.ParseBig256(eventJSON.TokenId)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ERC721ApprovalEvent.TokenId: %q", eventJSON.TokenId)
+	}
+	return nil
 }
 
 // ERC721ApprovalForAllEvent represents an ERC721 ApprovalForAll event
 type ERC721ApprovalForAllEvent struct {
-	Owner    common.Address
-	Operator common.Address
-	Approved bool
-}
-
-// MarshalJSON implements a custom JSON marshaller for the ERC721ApprovalForAllEvent type
-func (e ERC721ApprovalForAllEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"owner":    e.Owner.Hex(),
-		"operator": e.Operator.Hex(),
-		"approved": e.Approved,
-	})
+	Owner    common.Address `json:"owner"`
+	Operator common.Address `json:"operator"`
+	Approved bool           `json:"approved"`
 }
 
 // ERC1155ApprovalForAllEvent represents an ERC1155 ApprovalForAll event
 type ERC1155ApprovalForAllEvent struct {
-	Owner    common.Address
-	Operator common.Address
-	Approved bool
-}
-
-// MarshalJSON implements a custom JSON marshaller for the ERC1155ApprovalForAllEvent type
-func (e ERC1155ApprovalForAllEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"owner":    e.Owner.Hex(),
-		"operator": e.Operator.Hex(),
-		"approved": e.Approved,
-	})
+	Owner    common.Address `json:"owner"`
+	Operator common.Address `json:"operator"`
+	Approved bool           `json:"approved"`
 }
 
 // ERC1155TransferSingleEvent represents an ERC1155 TransfeSingler event
@@ -147,15 +214,43 @@ type ERC1155TransferSingleEvent struct {
 	Value    *big.Int
 }
 
+type erc1155TransferSingleEventJSON struct {
+	Operator string `json:"operator"`
+	From     string `json:"from"`
+	To       string `json:"to"`
+	Id       string `json:"id"`
+	Value    string `json:"value"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the ERC1155TransferSingleEvent type
 func (e ERC1155TransferSingleEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"operator": e.Operator.Hex(),
-		"from":     e.From.Hex(),
-		"to":       e.To.Hex(),
-		"id":       e.Id.String(),
-		"value":    e.Value.String(),
+	return json.Marshal(erc1155TransferSingleEventJSON{
+		Operator: e.Operator.Hex(),
+		From:     e.From.Hex(),
+		To:       e.To.Hex(),
+		Id:       e.Id.String(),
+		Value:    e.Value.String(),
 	})
+}
+
+func (e *ERC1155TransferSingleEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON erc1155TransferSingleEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.Operator = common.HexToAddress(eventJSON.Operator)
+	e.From = common.HexToAddress(eventJSON.From)
+	e.To = common.HexToAddress(eventJSON.To)
+	var ok bool
+	e.Id, ok = math.ParseBig256(eventJSON.Id)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ERC1155TransferSingleEvent.Id: %q", eventJSON.Id)
+	}
+	e.Value, ok = math.ParseBig256(eventJSON.Value)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ERC1155TransferSingleEvent.Value: %q", eventJSON.Value)
+	}
+	return nil
 }
 
 // ERC1155TransferBatchEvent represents an ERC1155 TransfeSingler event
@@ -167,23 +262,58 @@ type ERC1155TransferBatchEvent struct {
 	Values   []*big.Int
 }
 
+type erc1155TransferBatchEventJSON struct {
+	Operator string   `json:"operator"`
+	From     string   `json:"from"`
+	To       string   `json:"to"`
+	Ids      []string `json:"ids"`
+	Values   []string `json:"values"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the ERC1155TransferBatchEvent type
 func (e ERC1155TransferBatchEvent) MarshalJSON() ([]byte, error) {
-	ids := []string{}
-	for _, id := range e.Ids {
-		ids = append(ids, id.String())
+	ids := make([]string, len(e.Ids))
+	for i, id := range e.Ids {
+		ids[i] = id.String()
 	}
-	values := []string{}
-	for _, value := range e.Values {
-		values = append(values, value.String())
+	values := make([]string, len(e.Values))
+	for i, value := range e.Values {
+		values[i] = value.String()
 	}
-	return json.Marshal(map[string]interface{}{
-		"operator": e.Operator.Hex(),
-		"from":     e.From.Hex(),
-		"to":       e.To.Hex(),
-		"ids":      ids,
-		"values":   values,
+	return json.Marshal(erc1155TransferBatchEventJSON{
+		Operator: e.Operator.Hex(),
+		From:     e.From.Hex(),
+		To:       e.To.Hex(),
+		Ids:      ids,
+		Values:   values,
 	})
+}
+
+func (e *ERC1155TransferBatchEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON erc1155TransferBatchEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.Operator = common.HexToAddress(eventJSON.Operator)
+	e.From = common.HexToAddress(eventJSON.From)
+	e.To = common.HexToAddress(eventJSON.To)
+	e.Ids = make([]*big.Int, len(eventJSON.Ids))
+	var ok bool
+	for i, idString := range eventJSON.Ids {
+		e.Ids[i], ok = math.ParseBig256(idString)
+		if !ok {
+			return fmt.Errorf("Invalid uint256 number for ERC1155TransferBatchEvent.Ids: %v", eventJSON.Ids)
+		}
+	}
+	e.Values = make([]*big.Int, len(eventJSON.Values))
+	for i, valString := range eventJSON.Values {
+		e.Values[i], ok = math.ParseBig256(valString)
+		if !ok {
+			return fmt.Errorf("Invalid uint256 number for ERC1155TransferBatchEvent.Values: %v", eventJSON.Values)
+		}
+	}
+
+	return nil
 }
 
 // ExchangeFillEvent represents a 0x Exchange Fill event
@@ -201,6 +331,20 @@ type ExchangeFillEvent struct {
 	TakerAssetData         []byte
 }
 
+type exchangeFillEventJSON struct {
+	MakerAddress           string `json:"makerAddress"`
+	TakerAddress           string `json:"takerAddress"`
+	SenderAddress          string `json:"senderAddress"`
+	FeeRecipientAddress    string `json:"feeRecipientAddress"`
+	MakerAssetFilledAmount string `json:"makerAssetFilledAmount"`
+	TakerAssetFilledAmount string `json:"takerAssetFilledAmount"`
+	MakerFeePaid           string `json:"makerFeePaid"`
+	TakerFeePaid           string `json:"takerFeePaid"`
+	OrderHash              string `json:"orderHash"`
+	MakerAssetData         string `json:"makerAssetData"`
+	TakerAssetData         string `json:"takerAssetData"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the ExchangeFillEvent type
 func (e ExchangeFillEvent) MarshalJSON() ([]byte, error) {
 	makerAssetData := ""
@@ -211,19 +355,52 @@ func (e ExchangeFillEvent) MarshalJSON() ([]byte, error) {
 	if len(e.TakerAssetData) != 0 {
 		takerAssetData = fmt.Sprintf("0x%s", common.Bytes2Hex(e.TakerAssetData))
 	}
-	return json.Marshal(map[string]interface{}{
-		"makerAddress":           e.MakerAddress.Hex(),
-		"takerAddress":           e.TakerAddress.Hex(),
-		"senderAddress":          e.SenderAddress.Hex(),
-		"feeRecipientAddress":    e.FeeRecipientAddress.Hex(),
-		"makerAssetFilledAmount": e.MakerAssetFilledAmount.String(),
-		"takerAssetFilledAmount": e.TakerAssetFilledAmount.String(),
-		"makerFeePaid":           e.MakerFeePaid.String(),
-		"takerFeePaid":           e.TakerFeePaid.String(),
-		"orderHash":              e.OrderHash.Hex(),
-		"makerAssetData":         makerAssetData,
-		"takerAssetData":         takerAssetData,
+	return json.Marshal(exchangeFillEventJSON{
+		MakerAddress:           e.MakerAddress.Hex(),
+		TakerAddress:           e.TakerAddress.Hex(),
+		SenderAddress:          e.SenderAddress.Hex(),
+		FeeRecipientAddress:    e.FeeRecipientAddress.Hex(),
+		MakerAssetFilledAmount: e.MakerAssetFilledAmount.String(),
+		TakerAssetFilledAmount: e.TakerAssetFilledAmount.String(),
+		MakerFeePaid:           e.MakerFeePaid.String(),
+		TakerFeePaid:           e.TakerFeePaid.String(),
+		OrderHash:              e.OrderHash.Hex(),
+		MakerAssetData:         makerAssetData,
+		TakerAssetData:         takerAssetData,
 	})
+}
+
+func (e *ExchangeFillEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON exchangeFillEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.MakerAddress = common.HexToAddress(eventJSON.MakerAddress)
+	e.TakerAddress = common.HexToAddress(eventJSON.TakerAddress)
+	e.SenderAddress = common.HexToAddress(eventJSON.SenderAddress)
+	e.FeeRecipientAddress = common.HexToAddress(eventJSON.FeeRecipientAddress)
+	var ok bool
+	e.MakerAssetFilledAmount, ok = math.ParseBig256(eventJSON.MakerAssetFilledAmount)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ExchangeFillEvent.MakerAssetFilledAmount: %q", eventJSON.MakerAssetFilledAmount)
+	}
+	e.TakerAssetFilledAmount, ok = math.ParseBig256(eventJSON.TakerAssetFilledAmount)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ExchangeFillEvent.TakerAssetFilledAmount: %q", eventJSON.TakerAssetFilledAmount)
+	}
+	e.MakerFeePaid, ok = math.ParseBig256(eventJSON.MakerFeePaid)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ExchangeFillEvent.MakerFeePaid: %q", eventJSON.MakerFeePaid)
+	}
+	e.TakerFeePaid, ok = math.ParseBig256(eventJSON.TakerFeePaid)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ExchangeFillEvent.TakerFeePaid: %q", eventJSON.TakerFeePaid)
+	}
+	e.OrderHash = common.HexToHash(eventJSON.OrderHash)
+	e.MakerAssetData = common.FromHex(eventJSON.MakerAssetData)
+	e.TakerAssetData = common.FromHex(eventJSON.TakerAssetData)
+
+	return nil
 }
 
 // ExchangeCancelEvent represents a 0x Exchange Cancel event
@@ -236,6 +413,15 @@ type ExchangeCancelEvent struct {
 	TakerAssetData      []byte
 }
 
+type exchangeCancelEventJSON struct {
+	MakerAddress        string `json:"makerAddress"`
+	FeeRecipientAddress string `json:"feeRecipientAddress"`
+	SenderAddress       string `json:"senderAddress"`
+	OrderHash           string `json:"orderHash"`
+	MakerAssetData      string `json:"makerAssetData"`
+	TakerAssetData      string `json:"takerAssetData"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the ExchangeCancelEvent type
 func (e ExchangeCancelEvent) MarshalJSON() ([]byte, error) {
 	makerAssetData := ""
@@ -246,14 +432,29 @@ func (e ExchangeCancelEvent) MarshalJSON() ([]byte, error) {
 	if len(e.TakerAssetData) != 0 {
 		takerAssetData = fmt.Sprintf("0x%s", common.Bytes2Hex(e.TakerAssetData))
 	}
-	return json.Marshal(map[string]interface{}{
-		"makerAddress":        e.MakerAddress.Hex(),
-		"senderAddress":       e.SenderAddress.Hex(),
-		"feeRecipientAddress": e.FeeRecipientAddress.Hex(),
-		"orderHash":           e.OrderHash.Hex(),
-		"makerAssetData":      makerAssetData,
-		"takerAssetData":      takerAssetData,
+	return json.Marshal(exchangeCancelEventJSON{
+		MakerAddress:        e.MakerAddress.Hex(),
+		SenderAddress:       e.SenderAddress.Hex(),
+		FeeRecipientAddress: e.FeeRecipientAddress.Hex(),
+		OrderHash:           e.OrderHash.Hex(),
+		MakerAssetData:      makerAssetData,
+		TakerAssetData:      takerAssetData,
 	})
+}
+
+func (e *ExchangeCancelEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON exchangeCancelEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.MakerAddress = common.HexToAddress(eventJSON.MakerAddress)
+	e.FeeRecipientAddress = common.HexToAddress(eventJSON.FeeRecipientAddress)
+	e.SenderAddress = common.HexToAddress(eventJSON.SenderAddress)
+	e.OrderHash = common.HexToHash(eventJSON.OrderHash)
+	e.MakerAssetData = common.FromHex(eventJSON.MakerAssetData)
+	e.TakerAssetData = common.FromHex(eventJSON.TakerAssetData)
+
+	return nil
 }
 
 // ExchangeCancelUpToEvent represents a 0x Exchange CancelUpTo event
@@ -263,13 +464,35 @@ type ExchangeCancelUpToEvent struct {
 	OrderEpoch    *big.Int
 }
 
+type exchangeCancelUpToEventJSON struct {
+	MakerAddress  string `json:"makerAddress"`
+	SenderAddress string `json:"senderAddress"`
+	OrderEpoch    string `json:"orderEpoch"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the ExchangeCancelUpToEvent type
 func (e ExchangeCancelUpToEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"makerAddress":  e.MakerAddress.Hex(),
-		"senderAddress": e.SenderAddress.Hex(),
-		"orderEpoch":    e.OrderEpoch.String(),
+	return json.Marshal(exchangeCancelUpToEventJSON{
+		MakerAddress:  e.MakerAddress.Hex(),
+		SenderAddress: e.SenderAddress.Hex(),
+		OrderEpoch:    e.OrderEpoch.String(),
 	})
+}
+
+func (e *ExchangeCancelUpToEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON exchangeCancelUpToEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.MakerAddress = common.HexToAddress(eventJSON.MakerAddress)
+	e.SenderAddress = common.HexToAddress(eventJSON.SenderAddress)
+	var ok bool
+	e.OrderEpoch, ok = math.ParseBig256(eventJSON.OrderEpoch)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for ExchangeCancelUpToEvent.OrderEpoch: %q", eventJSON.OrderEpoch)
+	}
+
+	return nil
 }
 
 // WethWithdrawalEvent represents a wrapped Ether Withdraw event
@@ -278,12 +501,32 @@ type WethWithdrawalEvent struct {
 	Value *big.Int
 }
 
+type wethWithdrawalEventJSON struct {
+	Owner string `json:"owner"`
+	Value string `json:"value"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the WethWithdrawalEvent type
 func (w WethWithdrawalEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"owner": w.Owner.Hex(),
-		"value": w.Value.String(),
+	return json.Marshal(wethWithdrawalEventJSON{
+		Owner: w.Owner.Hex(),
+		Value: w.Value.String(),
 	})
+}
+
+func (e *WethWithdrawalEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON wethWithdrawalEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.Owner = common.HexToAddress(eventJSON.Owner)
+	var ok bool
+	e.Value, ok = math.ParseBig256(eventJSON.Value)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for WethWithdrawalEvent.Value: %q", eventJSON.Value)
+	}
+
+	return nil
 }
 
 // WethDepositEvent represents a wrapped Ether Deposit event
@@ -292,12 +535,32 @@ type WethDepositEvent struct {
 	Value *big.Int
 }
 
+type wethDepositEventJSON struct {
+	Owner string `json:"owner"`
+	Value string `json:"value"`
+}
+
 // MarshalJSON implements a custom JSON marshaller for the WethDepositEvent type
 func (w WethDepositEvent) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"owner": w.Owner.Hex(),
-		"value": w.Value.String(),
+	return json.Marshal(wethDepositEventJSON{
+		Owner: w.Owner.Hex(),
+		Value: w.Value.String(),
 	})
+}
+
+func (e *WethDepositEvent) UnmarshalJSON(data []byte) error {
+	var eventJSON wethDepositEventJSON
+	if err := json.Unmarshal(data, &eventJSON); err != nil {
+		return err
+	}
+	e.Owner = common.HexToAddress(eventJSON.Owner)
+	var ok bool
+	e.Value, ok = math.ParseBig256(eventJSON.Value)
+	if !ok {
+		return fmt.Errorf("Invalid uint256 number for WethDepositEvent.Value: %q", eventJSON.Value)
+	}
+
+	return nil
 }
 
 // UnsupportedEventError is thrown when an unsupported topic is encountered

--- a/zeroex/orderwatch/decoder/event_decoder_test.go
+++ b/zeroex/orderwatch/decoder/event_decoder_test.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -8,9 +9,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var erc20TokenAddress common.Address = common.HexToAddress("0x02b3c88b805f1c6982e38ea1d40a1d83f159c3d4")
@@ -452,4 +453,198 @@ func unmarshalLogStr(logStr string, out interface{}) error {
 		return err
 	}
 	return nil
+}
+
+func TestJSONMarshalUnmarshalERC20Transfer(t *testing.T) {
+	expectedEvent := ERC20TransferEvent{
+		From:  common.HexToAddress("0x90CF64CbB199523C893A1D519243E214b8e0b472"),
+		To:    common.HexToAddress("0xFE5854255eb1Eb921525fa856a3947Ed2412A1D7"),
+		Value: big.NewInt(63874940000),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ERC20TransferEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalERC20Approval(t *testing.T) {
+	expectedEvent := ERC20ApprovalEvent{
+		Owner:   common.HexToAddress("0xcf67fdd3c580f148d20a26844b2169d52e2326db"),
+		Spender: common.HexToAddress("0x448a5065aebb8e423f0896e6c5d525c040f59af3"),
+		Value:   big.NewInt(1000000000000000000),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ERC20ApprovalEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalERC721Transfer(t *testing.T) {
+	expectedEvent := ERC721TransferEvent{
+		From:    common.HexToAddress("0xD8c67d024Db85B271b6F6EeaC5234E29C4D6bbB5"),
+		To:      common.HexToAddress("0xF13685a175B95FAa79DB765631483ac79fB3D8E8"),
+		TokenId: big.NewInt(50609),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ERC721TransferEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalERC721Approval(t *testing.T) {
+	expectedEvent := ERC721ApprovalEvent{
+		Owner:    common.HexToAddress("0xF4985070Ce32b6B1994329DF787D1aCc9a2dd9e2"),
+		Approved: common.HexToAddress("0x0000000000000000000000000000000000000000"),
+		TokenId:  big.NewInt(43398),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ERC721ApprovalEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalERC721ApprovalForAll(t *testing.T) {
+	expectedEvent := ERC721ApprovalForAllEvent{
+		Owner:    common.HexToAddress("0x6aA0FC9fc46Acb60E98439f9F89782ca78fB0990"),
+		Operator: common.HexToAddress("0x185b257AA51Fdc45176cF1FfaC6a0bFB5cF28afD"),
+		Approved: true,
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ERC721ApprovalForAllEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalERC1155TransferSingle(t *testing.T) {
+	expectedEvent := ERC1155TransferSingleEvent{
+		Operator: common.HexToAddress("0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb"),
+		From:     common.HexToAddress("0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb"),
+		To:       common.HexToAddress("0x1D7022f5B17d2F8B695918FB48fa1089C9f85401"),
+		Id:       big.NewInt(3402823669209384),
+		Value:    big.NewInt(250),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ERC1155TransferSingleEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalERC1155TransferBatch(t *testing.T) {
+	expectedEvent := ERC1155TransferBatchEvent{
+		Operator: common.HexToAddress("0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb"),
+		From:     common.HexToAddress("0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb"),
+		To:       common.HexToAddress("0x1D7022f5B17d2F8B695918FB48fa1089C9f85401"),
+		Ids:      []*big.Int{big.NewInt(3402823669209384)},
+		Values:   []*big.Int{big.NewInt(1)},
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ERC1155TransferBatchEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalERC1155ApprovalForAll(t *testing.T) {
+	expectedEvent := ERC1155ApprovalForAllEvent{
+		Owner:    common.HexToAddress("0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb"),
+		Operator: common.HexToAddress("0xE36Ea790bc9d7AB70C55260C66D52b1eca985f84"),
+		Approved: true,
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ERC1155ApprovalForAllEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalExchangeFill(t *testing.T) {
+	expectedEvent := ExchangeFillEvent{
+		MakerAddress:           common.HexToAddress("0x90079aABC47b5BeA2dFC358d7114Ade57Ee39209"),
+		TakerAddress:           common.HexToAddress("0x61b9898C9b60A159fC91ae8026563cd226B7a0C1"),
+		SenderAddress:          common.HexToAddress("0x00000000000000000000000000563cd226b7a0c1"),
+		FeeRecipientAddress:    common.HexToAddress("0x61b9898C9b60A159fC91ae8026563cd226B7a0C1"),
+		MakerAssetFilledAmount: big.NewInt(36832327913963520),
+		TakerAssetFilledAmount: big.NewInt(142668604964864),
+		MakerFeePaid:           big.NewInt(142668604964864),
+		TakerFeePaid:           big.NewInt(142668604964864),
+		OrderHash:              common.HexToHash("0xe5cd991e034cd4517cbf180307031074f3d560949fe9ddae9a06a829052dc759"),
+		MakerAssetData:         common.Hex2Bytes("f47261b000000000000000000000000038ae374ecf4db50b0ff37125b591a04997106a32"),
+		TakerAssetData:         common.Hex2Bytes("f47261b0000000000000000000000000aa7427d8f17d87a28f5e1ba3adbb270badbe1011"),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ExchangeFillEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalExchangeCancel(t *testing.T) {
+	expectedEvent := ExchangeCancelEvent{
+		MakerAddress:        common.HexToAddress("0x504a2ee3558612dB56c90186A73e690eCd57FE9E"),
+		SenderAddress:       common.HexToAddress("0x504a2ee3558612dB56c90186A73e690eCd57FE9E"),
+		FeeRecipientAddress: common.HexToAddress("0xA258b39954ceF5cB142fd567A46cDdB31a670124"),
+		OrderHash:           common.HexToHash("0xdd50b0eec7425c3a365037a1bdeae9e12b59e06075b2bf2bdbfff8976f7419aa"),
+		MakerAssetData:      common.Hex2Bytes("f47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"),
+		TakerAssetData:      common.Hex2Bytes("f47261b000000000000000000000000089d24a6b4ccb1b6faa2625fe562bdd9a23260359"),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ExchangeCancelEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalExchangeCancelUpTo(t *testing.T) {
+	expectedEvent := ExchangeCancelUpToEvent{
+		MakerAddress:  common.HexToAddress("0x638C1eF824ACD48E63E6ACC84948f8eAD46f08De"),
+		SenderAddress: common.HexToAddress("0x0000000000000000000000000000000000000000"),
+		OrderEpoch:    big.NewInt(1554341123041),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent ExchangeCancelUpToEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+
+func TestJSONMarshalUnmarshalWethDeposit(t *testing.T) {
+	expectedEvent := WethDepositEvent{
+		Owner: common.HexToAddress("0x81228eA33D680B0F51271aBAb1105886eCd01C2c"),
+		Value: big.NewInt(200000000000000000),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent WethDepositEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
+}
+func TestJSONMarshalUnmarshalWethWithdrawal(t *testing.T) {
+	expectedEvent := WethWithdrawalEvent{
+		Owner: common.HexToAddress("0xb3fa5bA98fdB56E493C4C362920289A42948294e"),
+		Value: big.NewInt(353732490000000000),
+	}
+
+	buf := bytes.Buffer{}
+	require.NoError(t, json.NewEncoder(&buf).Encode(expectedEvent))
+	var unmarshaledEvent WethWithdrawalEvent
+	require.NoError(t, json.NewDecoder(&buf).Decode(&unmarshaledEvent))
+	assert.Equal(t, expectedEvent, unmarshaledEvent)
 }

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -396,7 +396,7 @@ func (w *Watcher) handleBlockEvents(events []*blockwatch.Event) error {
 		latestBlockNumber = rpc.BlockNumber(event.BlockHeader.Number.Int64())
 		latestBlockTimestamp = event.BlockHeader.Timestamp
 		for _, log := range event.BlockHeader.Logs {
-			var parameters zeroex.ContractEventParameters
+			var parameters interface{}
 			eventType, err := w.eventDecoder.FindEventType(log)
 			if err != nil {
 				switch err.(type) {


### PR DESCRIPTION
This PR fixes a bug in the GO RPC client  that was most likely introduced in `5.0.0-beta`. The bug occurred when subscribing to order events and receiving one with one or more contract events:

```
json: cannot unmarshal object into Go struct field ContractEvent.Parameters of type zeroex.ContractEventParameters
```

This PR fixes the bug by adding an `UnmarshalJSON` event for each type of contract event.