### PR TITLE
Fix bug in KeySuffixHook that caused double suffixes

### DIFF
--- a/loghooks/key_suffix_hook.go
+++ b/loghooks/key_suffix_hook.go
@@ -31,6 +31,7 @@ func (h *KeySuffixHook) Levels() []log.Level {
 }
 
 func (h *KeySuffixHook) Fire(entry *log.Entry) error {
+	newFields := log.Fields{}
 	for key, value := range entry.Data {
 		typ, err := getTypeForValue(value)
 		if err != nil {
@@ -38,21 +39,20 @@ func (h *KeySuffixHook) Fire(entry *log.Entry) error {
 				// We can't safely log nested map types, so replace the value with a
 				// string.
 				newKey := fmt.Sprintf("%s_json_string", key)
-				delete(entry.Data, key)
 				mapString, err := json.Marshal(value)
 				if err != nil {
 					return err
 				}
-				entry.Data[newKey] = string(mapString)
+				newFields[newKey] = string(mapString)
 				continue
 			} else {
 				return err
 			}
 		}
 		newKey := fmt.Sprintf("%s_%s", key, typ)
-		delete(entry.Data, key)
-		entry.Data[newKey] = value
+		newFields[newKey] = value
 	}
+	entry.Data = newFields
 	return nil
 }
 


### PR DESCRIPTION
I was looking at the logs in Kibana and found that fields would sometimes have duplicated type suffixes. This was happening because fo the way `KeySuffixHook` iterated over a map while making edits to that same map in each iteration. The new implementation creates a new map to avoid the issue.

![Screen Shot 2019-11-05 at 3 08 30 PM](https://user-images.githubusercontent.com/800857/68254027-55463d80-ffde-11e9-9d8c-13eddb3cc921.png)
 