### PR TITLE
docs: Remove dead link from sidebar

### DIFF
--- a/docs/summary.md
+++ b/docs/summary.md
@@ -4,7 +4,6 @@
 
 * [Deployment guide](deployment.md)
 * [Deploying a Telemetry-Enabled Mesh Node](deployment_with_telemetry.md)
-* [Mesh Beta participation guide](../examples/beta_telemetry_node/README.md)
 * [JSON-RPC API documentation](rpc_api.md)
 * [Browser API documentation](browser/reference.md)
 * [Browser guide](browser.md)


### PR DESCRIPTION
I'm guessing a bad merge kept this around. It's been replaced by ` * [Deploying a Telemetry-Enabled Mesh Node](deployment_with_telemetry.md)`