### PR TITLE
Improve formatting for subscribe-to-orders example

### DIFF
--- a/examples/go/subscribe-to-orders/main.go
+++ b/examples/go/subscribe-to-orders/main.go
@@ -18,6 +18,8 @@ type clientEnvVars struct {
 }
 
 func main() {
+	log.SetFormatter(&log.JSONFormatter{})
+
 	env := clientEnvVars{}
 	if err := envvar.Parse(&env); err != nil {
 		panic(err)
@@ -40,7 +42,9 @@ func main() {
 		select {
 		case orderEvents := <-orderEventsChan:
 			for _, orderEvent := range orderEvents {
-				log.Printf("Received order event: %+v\n", orderEvent)
+				log.WithFields(log.Fields{
+					"event": orderEvent,
+				}).Printf("received order event")
 			}
 		case err := <-clientSubscription.Err():
 			log.Fatal(err)


### PR DESCRIPTION
Before:
<img width="1678" alt="Screen Shot 2019-11-05 at 9 03 41 PM" src="https://user-images.githubusercontent.com/800857/68269756-dd910680-000f-11ea-9d9b-2177aeae80b3.png">

After (with `jq`):
<img width="1201" alt="Screen Shot 2019-11-05 at 9 02 57 PM" src="https://user-images.githubusercontent.com/800857/68269757-df5aca00-000f-11ea-91e1-88c5d31c2789.png">
