### PR TITLE
docs: Fix docker-compose.yml example

### DIFF
--- a/docs/deployment_with_telemetry.md
+++ b/docs/deployment_with_telemetry.md
@@ -82,7 +82,24 @@ services:
 ```
 
 In most cases, the only change you need to make to the __docker-compose.yml__
-file is to set `ETHEREUM_RPC_URL` to your own Ethereum JSON RPC endpoint.
+file is to set `ETHEREUM_RPC_URL` to your own Ethereum JSON RPC endpoint. The 
+`RPC_ADDR` above will allow any Docker containers running in the same Docker 
+Compose file to access the Mesh RPC API via 
+[links](https://docs.docker.com/compose/networking/#links). To use this feature, 
+be sure to add the following line to any containers you wish to access the Mesh 
+RPC API from:
+
+```
+links:
+    - mesh
+```
+
+You can then use the URL `ws://mesh:60557` to access the RPC API.
+
+Alternatively, if you want to open up your Mesh RPC API to the public internet, 
+you can set `RPC_ADDR=0.0.0.0:60557`. If you choose to go this route, we strongly 
+recommend using an external firewall to restrict who can access your RPC API.
+
 
 ### Deploying with Docker Machine
 

--- a/docs/deployment_with_telemetry.md
+++ b/docs/deployment_with_telemetry.md
@@ -53,7 +53,7 @@ services:
         environment:
             - VERBOSITY=5
             - ETHEREUM_CHAIN_ID=1
-            - RPC_ADDR=0.0.0.0:60557
+            - RPC_ADDR=localhost:60557
             # Set your backing Ethereum JSON RPC endpoint below
             - ETHEREUM_RPC_URL=
             - BLOCK_POLLING_INTERVAL=5s
@@ -82,7 +82,10 @@ services:
 ```
 
 In most cases, the only change you need to make to the __docker-compose.yml__
-file is to set `ETHEREUM_RPC_URL` to your own Ethereum JSON RPC endpoint.
+file is to set `ETHEREUM_RPC_URL` to your own Ethereum JSON RPC endpoint. If you 
+wish to connect to your Mesh node over a subnet or over the public internet, you
+ must set the `RPC_ADDR` to something other than `localhost` (e.g., `0.0.0.0` for 
+ the public internet).
 
 ### Deploying with Docker Machine
 

--- a/docs/deployment_with_telemetry.md
+++ b/docs/deployment_with_telemetry.md
@@ -53,7 +53,7 @@ services:
         environment:
             - VERBOSITY=5
             - ETHEREUM_CHAIN_ID=1
-            - RPC_ADDR=localhost:60557
+            - RPC_ADDR=mesh:60557
             # Set your backing Ethereum JSON RPC endpoint below
             - ETHEREUM_RPC_URL=
             - BLOCK_POLLING_INTERVAL=5s
@@ -82,10 +82,7 @@ services:
 ```
 
 In most cases, the only change you need to make to the __docker-compose.yml__
-file is to set `ETHEREUM_RPC_URL` to your own Ethereum JSON RPC endpoint. If you 
-wish to connect to your Mesh node over a subnet or over the public internet, you
- must set the `RPC_ADDR` to something other than `localhost` (e.g., `0.0.0.0` for 
- the public internet).
+file is to set `ETHEREUM_RPC_URL` to your own Ethereum JSON RPC endpoint.
 
 ### Deploying with Docker Machine
 

--- a/docs/deployment_with_telemetry.md
+++ b/docs/deployment_with_telemetry.md
@@ -53,6 +53,7 @@ services:
         environment:
             - VERBOSITY=5
             - ETHEREUM_CHAIN_ID=1
+            - RPC_ADDR=0.0.0.0:60557
             # Set your backing Ethereum JSON RPC endpoint below
             - ETHEREUM_RPC_URL=
             - BLOCK_POLLING_INTERVAL=5s


### PR DESCRIPTION
Now that we use `RPC_ADDR` to specify the port, we need to set it to `mesh:60557` since the default is now `localhost:*` but we specifically port map `60557`.