### PR TITLE
Add a README for both browser and Go examples

### DIFF
--- a/examples/browser/README.md
+++ b/examples/browser/README.md
@@ -1,0 +1,29 @@
+## 0x Mesh Browser Example
+
+This directory contains an example of how to run Mesh in the browser.
+
+### Running the Example
+
+To run the example, first change into the __examples/browser__ directory and
+then run:
+
+```
+yarn install --force && yarn build
+```
+
+Then simply serve the __examples/browser/dist__ directory using the web server
+of your choice and navigate to the page in your browser. For example, you could
+use `goexec`:
+
+```
+go get -u github.com/shurcooL/goexec
+goexec 'http.ListenAndServe(":8000", http.FileServer(http.Dir("./dist")))'
+```
+
+Then navigate to [localhost:8000](http://localhost:8000) in your browser (Chrome
+or Firefox are recommended).
+
+### More Information
+
+- [Browser Guide](https://0x-org.gitbook.io/mesh/getting-started/browser)
+- [Browser API Documentation](https://0x-org.gitbook.io/mesh/getting-started/reference)

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,0 +1,18 @@
+## 0x Mesh Example Go Usage
+
+This directory contains some example code for using the Go RPC client.
+
+### Running the Examples
+
+Simply use `go run` to run an example. Each example requires some environment
+variables.
+
+
+```
+RPC_ADDRESS=ws://167.71.80.233:60557 go run ./examples/go/subscribe-to-orders/main.go
+```
+
+### More Information
+
+- [RPC API Documentation](https://0x-org.gitbook.io/mesh/getting-started/rpc_api)
+- [Go RPC Client Documentation](https://godoc.org/github.com/0xProject/0x-mesh/rpc)


### PR DESCRIPTION
This will also help fix an issue with broken links on GitBook (seems that when linking to directories, GitBook assumes that a __README.md__ file exists and tries to link to it even if it's not there).
