### PR TITLE
Upgrade to Go 1.12.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     environment:
       BASH_ENV: ~/.nvm/nvm.sh
     docker:
-      - image: circleci/golang:1.12.9-browsers
+      - image: circleci/golang:1.12.13-browsers
       - image: 0xorg/ganache-cli:latest
         environment:
             VERSION: 4.3.3

--- a/dockerfiles/mesh-bootstrap/Dockerfile
+++ b/dockerfiles/mesh-bootstrap/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # mesh-builder produces a statically linked binary
-FROM golang:1.12.9-alpine3.9 as mesh-builder
+FROM golang:1.12.13-alpine3.9 as mesh-builder
 
 
 RUN apk update && apk add ca-certificates nodejs-current npm make git dep gcc build-base musl linux-headers

--- a/dockerfiles/mesh/Dockerfile
+++ b/dockerfiles/mesh/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # mesh-builder produces a statically linked binary
-FROM golang:1.12.9-alpine3.9 as mesh-builder
+FROM golang:1.12.13-alpine3.9 as mesh-builder
 
 
 RUN apk update && apk add ca-certificates nodejs-current npm make git dep gcc build-base musl linux-headers


### PR DESCRIPTION
There have been some security fixes since Go 1.12.9. See https://golang.org/doc/devel/release.html#go1.12.