### PR TITLE
cut-release: Fix docker image version regex 

### DIFF
--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -91,7 +91,7 @@ func updateHardCodedVersions(version string) {
 
 	// Update `docs/deployment_with_telemetry.md`
 	newVersionString = fmt.Sprintf(`image: 0xorg/mesh:%s`, version)
-	regex = `image: 0xorg/mesh:latest`
+	regex = `image: 0xorg/mesh:[0-9.]+.*`
 	updateFileWithRegex("docs/deployment_with_telemetry.md", regex, newVersionString)
 
 	// Update `CHANGELOG.md`


### PR DESCRIPTION
The docker images is now being set to a specific version instead of `latest`. This PR updates the regex to reflect this change so that it is properly updated.
