### PR TITLE
core,docs: Enforce reasonable configs for BlockPollingInterval and EthereumRPCMaxRequestsPer24HrUTC

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -43,12 +43,12 @@ import (
 )
 
 const (
-	blockWatcherRetentionLimit           = 20
-	ethereumRPCRequestTimeout            = 30 * time.Second
-	peerConnectTimeout                   = 60 * time.Second
-	checkNewAddrInterval                 = 20 * time.Second
-	expirationPollingInterval            = 50 * time.Millisecond
-	rateLimiterCheckpointInterval        = 1 * time.Minute
+	blockWatcherRetentionLimit    = 20
+	ethereumRPCRequestTimeout     = 30 * time.Second
+	peerConnectTimeout            = 60 * time.Second
+	checkNewAddrInterval          = 20 * time.Second
+	expirationPollingInterval     = 50 * time.Millisecond
+	rateLimiterCheckpointInterval = 1 * time.Minute
 	// Computed with default blockPollingInterval (5s), and EthereumRPCMaxRequestsPer24HrUTC (100k)
 	defaultNonPollingEthRPCRequestBuffer = 82720
 	// logStatsInterval is how often to log stats for this node.

--- a/core/core.go
+++ b/core/core.go
@@ -189,10 +189,7 @@ func New(config Config) (*App, error) {
 	config = unquoteConfig(config)
 
 	// Ensure ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC is reasonably set given BLOCK_POLLING_INTERVAL
-	// HACK(fabio): Since we haven't upgraded to Golang 1.13 yet, we don't have access to
-	// duration.milliseconds(), so we do `duration / 1000000` for now
-	perSecond := 1000 / float64(config.BlockPollingInterval/1000000)
-	per24HrPollingRequests := int(perSecond * 60 * 60 * 24)
+	per24HrPollingRequests := int((24 * time.Hour) / config.BlockPollingInterval)
 	minNumOfEthRPCRequestsIn24HrPeriod := per24HrPollingRequests + defaultNonPollingEthRPCRequestBuffer
 	if minNumOfEthRPCRequestsIn24HrPeriod > config.EthereumRPCMaxRequestsPer24HrUTC {
 		return nil, fmt.Errorf(

--- a/core/core.go
+++ b/core/core.go
@@ -190,15 +190,10 @@ func New(config Config) (*App, error) {
 
 	// Ensure ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC is reasonably set given BLOCK_POLLING_INTERVAL
 	var per24HrPollingRequests int
-	if config.BlockPollingInterval > 1*time.Second {
-		perMinute := 60 / float64(config.BlockPollingInterval.Seconds())
-		per24HrPollingRequests = int(perMinute * 60 * 24)
-	} else {
-		// HACK(fabio): Since we haven't upgraded to Golang 1.13 yet, we don't have access to
-		// duration.milliseconds(), so we do `duration / 1000000` for now
-		perSecond := 1000 / float64(config.BlockPollingInterval/1000000)
-		per24HrPollingRequests = int(perSecond * 60 * 60 * 24)
-	}
+	// HACK(fabio): Since we haven't upgraded to Golang 1.13 yet, we don't have access to
+	// duration.milliseconds(), so we do `duration / 1000000` for now
+	perSecond := 1000 / float64(config.BlockPollingInterval/1000000)
+	per24HrPollingRequests = int(perSecond * 60 * 60 * 24)
 	minNumOfEthRPCRequestsIn24HrPeriod := per24HrPollingRequests + defaultNonPollingEthRPCRequestBuffer
 	if minNumOfEthRPCRequestsIn24HrPeriod > config.EthereumRPCMaxRequestsPer24HrUTC {
 		return nil, fmt.Errorf(

--- a/core/core.go
+++ b/core/core.go
@@ -189,11 +189,10 @@ func New(config Config) (*App, error) {
 	config = unquoteConfig(config)
 
 	// Ensure ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC is reasonably set given BLOCK_POLLING_INTERVAL
-	var per24HrPollingRequests int
 	// HACK(fabio): Since we haven't upgraded to Golang 1.13 yet, we don't have access to
 	// duration.milliseconds(), so we do `duration / 1000000` for now
 	perSecond := 1000 / float64(config.BlockPollingInterval/1000000)
-	per24HrPollingRequests = int(perSecond * 60 * 60 * 24)
+	per24HrPollingRequests := int(perSecond * 60 * 60 * 24)
 	minNumOfEthRPCRequestsIn24HrPeriod := per24HrPollingRequests + defaultNonPollingEthRPCRequestBuffer
 	if minNumOfEthRPCRequestsIn24HrPeriod > config.EthereumRPCMaxRequestsPer24HrUTC {
 		return nil, fmt.Errorf(

--- a/core/core.go
+++ b/core/core.go
@@ -199,12 +199,12 @@ func New(config Config) (*App, error) {
 		perSecond := 1000 / float64(config.BlockPollingInterval/1000000)
 		per24HrPollingRequests = int(perSecond * 60 * 60 * 24)
 	}
-	requiredNumOfEthRPCRequestsIn24HrPeriod := per24HrPollingRequests + defaultNonPollingEthRPCRequestBuffer
-	if requiredNumOfEthRPCRequestsIn24HrPeriod > config.EthereumRPCMaxRequestsPer24HrUTC {
+	minNumOfEthRPCRequestsIn24HrPeriod := per24HrPollingRequests + defaultNonPollingEthRPCRequestBuffer
+	if minNumOfEthRPCRequestsIn24HrPeriod > config.EthereumRPCMaxRequestsPer24HrUTC {
 		return nil, fmt.Errorf(
 			"Given BLOCK_POLLING_INTERVAL (%s), there are insufficient remaining ETH RPC requests in a 24hr period for Mesh to function properly. Increase ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC to at least %d (currently configured to: %d)",
 			config.BlockPollingInterval,
-			requiredNumOfEthRPCRequestsIn24HrPeriod,
+			minNumOfEthRPCRequestsIn24HrPeriod,
 			config.EthereumRPCMaxRequestsPer24HrUTC,
 		)
 	}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,7 +43,8 @@ machine where all Mesh-related data will be stored.
 -   Ports 60557, 60558, and 60559 are the default ports used for the JSON RPC endpoint, communicating with peers over TCP, and communicating with peers over WebSockets, respectively.
 -   In order to disable P2P order discovery and sharing, set `USE_BOOTSTRAP_LIST` to `false`.
 -   Running a VPN may interfere with Mesh. If you are having difficulty connecting to peers, disable your VPN.
--   If you are running against a POA testnet (e.g., Kovan), you might want to shorten the `BLOCK_POLLING_INTERVAL` since blocks are mined more frequently then on mainnet.
+-   If you are running against a POA testnet (e.g., Kovan), you might want to shorten the `BLOCK_POLLING_INTERVAL` since blocks are mined more frequently then on mainnet. If you do this, your node will use more Ethereum RPC calls, so you will also need to adjust the `ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC` to around `380000` (*warning:* this will not fit within Infura's
+free tier).
 -   If you want to run the mesh in "detached" mode, add the `-d` switch to the docker run command so that your console doesn't get blocked.
 
 ## Persisting State

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,7 +43,7 @@ machine where all Mesh-related data will be stored.
 -   Ports 60557, 60558, and 60559 are the default ports used for the JSON RPC endpoint, communicating with peers over TCP, and communicating with peers over WebSockets, respectively.
 -   In order to disable P2P order discovery and sharing, set `USE_BOOTSTRAP_LIST` to `false`.
 -   Running a VPN may interfere with Mesh. If you are having difficulty connecting to peers, disable your VPN.
--   If you are running against a POA testnet (e.g., Kovan), you might want to shorten the `BLOCK_POLLING_INTERVAL` since blocks are mined more frequently then on mainnet. If you do this, your node will use more Ethereum RPC calls, so you will also need to adjust the `ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC` to around `380000` (*warning:* this will not fit within Infura's
+-   If you are running against a POA testnet (e.g., Kovan), you might want to shorten the `BLOCK_POLLING_INTERVAL` since blocks are mined more frequently then on mainnet. If you do this, your node will use more Ethereum RPC calls, so you will also need to adjust the `ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC` upwards (*warning:* setting this higher than 100k won't fit into Infura's
 free tier).
 -   If you want to run the mesh in "detached" mode, add the `-d` switch to the docker run command so that your console doesn't get blocked.
 


### PR DESCRIPTION
I noticed that I had accidentally started my Kovan Mesh node with `BlockPollingInterval` set to `300ms` and `EthereumRPCMaxRequestsPer24HrUTC` defaulted to 100k requests. The math didn't add up and my node would definitively use up it's 24hr request limit and then stall. This PR does some math on Mesh startup to make sure these two configs won't eventually cause the Mesh node to malfunction due to using up all allowed requests for block polling alone.