### PR TITLE
Make bandwidth banning more lenient for false positives

### DIFF
--- a/p2p/banner/banner.go
+++ b/p2p/banner/banner.go
@@ -25,10 +25,10 @@ const (
 	violationsCacheSize = 1000
 	// violationsBeforeBan is the number of times a peer is allowed to violate the
 	// bandwidth limits before being banned.
-	violationsBeforeBan = 4
+	violationsBeforeBan = 10
 	// violationsTTL is the TTL for bandwidth violations. If a peer does not have
 	// any violations during this timespan, their violation count will be reset.
-	violationsTTL = 6 * time.Hour
+	violationsTTL = 1 * time.Hour
 )
 
 var ErrProtectedIP = errors.New("cannot ban protected IP address")


### PR DESCRIPTION
We're still seeing a lot of false positives due to https://github.com/libp2p/go-libp2p-core/issues/65 and even after introducing a workaround in https://github.com/0xProject/0x-mesh/pull/478 peers are still being banned. This PR increases our tolerance for false positives by allowing up to 10 violations over the course of 1 hour before actually banning a peer (the previous version allowed 4 violations over 6 hours).