### PR TITLE
p2p/ratevalidator: Enforce max message size

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -70,3 +70,7 @@ var UnlimitedExpirationTime *big.Int
 func init() {
 	UnlimitedExpirationTime, _ = big.NewInt(0).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
 }
+
+// MaxOrderSizeInBytes is the maximum number of bytes allowed for encoded orders. It
+// is more than 10x the size of a typical ERC20 order to account for multiAsset orders.
+const MaxOrderSizeInBytes = 8192

--- a/core/core.go
+++ b/core/core.go
@@ -181,8 +181,8 @@ func New(config Config) (*App, error) {
 	}
 	log.AddHook(loghooks.NewPeerIDHook(peerID))
 
-	if config.EthereumRPCMaxContentLength < ordervalidator.MaxOrderSizeInBytes {
-		return nil, fmt.Errorf("Cannot set `EthereumRPCMaxContentLength` to be less then MaxOrderSizeInBytes: %d", ordervalidator.MaxOrderSizeInBytes)
+	if config.EthereumRPCMaxContentLength < constants.MaxOrderSizeInBytes {
+		return nil, fmt.Errorf("Cannot set `EthereumRPCMaxContentLength` to be less then MaxOrderSizeInBytes: %d", constants.MaxOrderSizeInBytes)
 	}
 	config = unquoteConfig(config)
 

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/meshdb"
 	"github.com/0xProject/0x-mesh/p2p"
 	"github.com/0xProject/0x-mesh/zeroex"
@@ -105,7 +106,7 @@ func (app *App) HandleMessages(messages []*p2p.Message) error {
 			log.WithFields(map[string]interface{}{
 				"error":               err,
 				"from":                msg.From,
-				"maxOrderSizeInBytes": ordervalidator.MaxOrderSizeInBytes,
+				"maxOrderSizeInBytes": constants.MaxOrderSizeInBytes,
 				"actualSizeInBytes":   len(msg.Data),
 			}).Trace("received message that exceeds maximum size")
 			app.handlePeerScoreEvent(msg.From, psInvalidMessage)

--- a/core/validation.go
+++ b/core/validation.go
@@ -17,7 +17,7 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
-var errMaxSize = fmt.Errorf("message exceeds maximum size of %d bytes", ordervalidator.MaxOrderSizeInBytes)
+var errMaxSize = fmt.Errorf("message exceeds maximum size of %d bytes", constants.MaxOrderSizeInBytes)
 
 // JSON-schema schemas
 var (
@@ -214,7 +214,7 @@ func (app *App) validateOrders(orders []*zeroex.SignedOrder) (*ordervalidator.Va
 }
 
 func validateMessageSize(message *p2p.Message) error {
-	if len(message.Data) > ordervalidator.MaxOrderSizeInBytes {
+	if len(message.Data) > constants.MaxOrderSizeInBytes {
 		return errMaxSize
 	}
 	return nil
@@ -225,7 +225,7 @@ func validateOrderSize(order *zeroex.SignedOrder) error {
 	if err != nil {
 		return err
 	}
-	if len(encoded) > ordervalidator.MaxOrderSizeInBytes {
+	if len(encoded) > constants.MaxOrderSizeInBytes {
 		return errMaxSize
 	}
 	return nil

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/p2p/banner"
 	"github.com/0xProject/0x-mesh/p2p/ratevalidator"
 	lru "github.com/hashicorp/golang-lru"
@@ -240,11 +241,12 @@ func New(ctx context.Context, config Config) (*Node, error) {
 		return nil, err
 	}
 	rateValidator, err := ratevalidator.New(ctx, ratevalidator.Config{
-		MyPeerID:     basicHost.ID(),
-		GlobalLimit:  config.GlobalPubSubMessageLimit,
-		GlobalBurst:  config.GlobalPubSubMessageBurst,
-		PerPeerLimit: config.PerPeerPubSubMessageLimit,
-		PerPeerBurst: config.PerPeerPubSubMessageBurst,
+		MyPeerID:       basicHost.ID(),
+		GlobalLimit:    config.GlobalPubSubMessageLimit,
+		GlobalBurst:    config.GlobalPubSubMessageBurst,
+		PerPeerLimit:   config.PerPeerPubSubMessageLimit,
+		PerPeerBurst:   config.PerPeerPubSubMessageBurst,
+		MaxMessageSize: constants.MaxOrderSizeInBytes,
 	})
 	if err != nil {
 		return nil, err

--- a/zeroex/ordervalidator/order_validator.go
+++ b/zeroex/ordervalidator/order_validator.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/ethereum"
 	"github.com/0xProject/0x-mesh/ethereum/wrappers"
 	"github.com/0xProject/0x-mesh/zeroex"
@@ -92,10 +93,6 @@ type RejectedOrderStatus struct {
 	Message string `json:"message"`
 }
 
-// MaxOrderSizeInBytes is the maximum number of bytes allowed for encoded orders. It
-// is more than 10x the size of a typical ERC20 order to account for multiAsset orders.
-const MaxOrderSizeInBytes = 8192
-
 // RejectedOrderStatus values
 var (
 	ROEthRPCRequestFailed = RejectedOrderStatus{
@@ -160,7 +157,7 @@ var (
 	}
 	ROMaxOrderSizeExceeded = RejectedOrderStatus{
 		Code:    "MaxOrderSizeExceeded",
-		Message: fmt.Sprintf("order exceeds the maximum encoded size of %d bytes", MaxOrderSizeInBytes),
+		Message: fmt.Sprintf("order exceeds the maximum encoded size of %d bytes", constants.MaxOrderSizeInBytes),
 	}
 	ROOrderAlreadyStoredAndUnfillable = RejectedOrderStatus{
 		Code:    "OrderAlreadyStoredAndUnfillable",


### PR DESCRIPTION
This PR addresses an oversight in `ratevalidator`. One of the goals of introducing a rate limiting validator for PubSub messages is to prevent other peers from using up _your_ bandwidth allotments when you propagate messages on their behalf. Before this PR, it was possible for a peer to send an extremely large message that would still get propagated (because we were propagating messages before checking the size). For well-behaving nodes, this PR doesn't change anything.