### PR TITLE
Fix bug for pinned option in TypeScript RPC client

### DIFF
--- a/rpc/clients/typescript/src/ws_client.ts
+++ b/rpc/clients/typescript/src/ws_client.ts
@@ -252,7 +252,7 @@ export class WSClient {
         assert.isArray('signedOrders', signedOrders);
         const rawValidationResults: RawValidationResults = await (this._wsProvider as any).send('mesh_addOrders', [
             signedOrders,
-            pinned,
+            { pinned },
         ]);
         const validationResults: ValidationResults = {
             accepted: WSClient._convertRawAcceptedOrderInfos(rawValidationResults.accepted),


### PR DESCRIPTION
This PR fixes a bug when trying to add orders via the TypeScript RPC client:

```
Error: Node error: {"code":-32602,"message":"invalid argument 1: json: cannot unmarshal bool into Go value of type rpc.AddOrdersOpts"}
```