### PR TITLE
rpc,browser: Add & improve .npmignore

### DIFF
--- a/browser/.npmignore
+++ b/browser/.npmignore
@@ -1,3 +1,6 @@
-go/
-wasm/
-scripts/
+# Blacklist all files
+.*
+*
+# Whitelist lib
+!lib/**/*
+# Package specific ignore

--- a/rpc/clients/typescript/.npmignore
+++ b/rpc/clients/typescript/.npmignore
@@ -1,0 +1,8 @@
+# Blacklist all files
+.*
+*
+# Whitelist lib
+!lib/**/*
+# Blacklist tests and publish scripts
+/lib/test/*
+# Package specific ignore


### PR DESCRIPTION
We were missing an `.npmignore` in the TS Mesh RPC client package and the one in the browser package was too permissive (publishing the WASM bundle twice!).