### PR TITLE
Use a bugfix in go-flow-metrics.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -527,12 +527,11 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:83d3d59c84ff3da342ab63011d79750ccb987bda399eb64db3abd3e2fd32c18f"
+  digest = "1:1ffb29b986b15f06b10cab31b35ed95833425231da824467c4798763b56ffdfd"
   name = "github.com/libp2p/go-flow-metrics"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1f5b3acc846b2c8ce4c4e713296af74f5c24df55"
-  version = "v0.0.1"
+  revision = "45424fab0a7cfaae9c5bdda0e590ee844c12b904"
 
 [[projects]]
   digest = "1:03c4382bfd9f7af55959d5cb0199aead9a6200cffbb0f6e64217c64d552d45c6"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -87,7 +87,7 @@
 [[override]]
   name = "github.com/gballet/go-libpcsclite"
   revision = "2fd9b619dd3c5d74acbd975f997a6441984d74a7"
-  [metadata]
+  [override.metadata]
     note = "go-ethereum depends on this package and they made a breaking API change"
 
 [[constraint]]
@@ -141,3 +141,9 @@
 [[constraint]]
   branch = "master"
   name = "github.com/benbjohnson/clock"
+
+[[override]]
+  name = "github.com/libp2p/go-flow-metrics"
+  revision = "45424fab0a7cfaae9c5bdda0e590ee844c12b904"
+  [override.metadata]
+    note = "Fixes an issue with libp2p BandwidthCounter. See https://github.com/libp2p/go-libp2p-core/issues/65"


### PR DESCRIPTION
Hopefully this fixes the bug with `BandwidthCounter`. See https://github.com/libp2p/go-libp2p-core/issues/65. We'll need to deploy and then keep an eye on it for a while.