### PR TITLE
Add Drone CI configuration file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,77 @@
+kind: pipeline
+type: docker
+name: mesh
+
+steps:
+- name: mesh-autotag  
+  image: plugins/docker
+  settings:
+    repo: 0xorg/mesh
+    auto_tag: true
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    dockerfile: dockerfiles/mesh/Dockerfile
+---
+kind: pipeline
+type: docker
+name: mesh-bootstrap-autotag
+
+steps:
+- name: mesh-bootstrap-autotag  
+  image: plugins/docker
+  settings:
+    repo: 0xorg/mesh-bootstrap
+    auto_tag: true
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    dockerfile: dockerfiles/mesh/Dockerfile
+---
+kind: pipeline
+type: docker
+name: mesh-development
+
+steps:
+- name: mesh-dev  
+  image: plugins/docker
+  settings:
+    repo: 0xorg/mesh
+    tags:
+      - development
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    dockerfile: dockerfiles/mesh/Dockerfile
+trigger:
+  branch:
+  - development
+  event:
+    include:
+      - push
+---
+kind: pipeline
+type: docker
+name: mesh-bootstrap-development
+
+steps:
+- name: mesh-bootstrap-dev  
+  image: plugins/docker
+  settings:
+    repo: 0xorg/mesh-bootstrap
+    tags:
+      - development
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    dockerfile: dockerfiles/mesh/Dockerfile
+trigger:
+  branch:
+  - development
+  event:
+    include:
+      - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,8 @@ steps:
     password:
       from_secret: docker_password
     dockerfile: dockerfiles/mesh/Dockerfile
+node_selector:
+  drone-builds: true
 ---
 kind: pipeline
 type: docker
@@ -29,6 +31,8 @@ steps:
     password:
       from_secret: docker_password
     dockerfile: dockerfiles/mesh/Dockerfile
+node_selector:
+  drone-builds: true
 ---
 kind: pipeline
 type: docker
@@ -52,6 +56,8 @@ trigger:
   event:
     include:
       - push
+node_selector:
+  drone-builds: true
 ---
 kind: pipeline
 type: docker
@@ -75,3 +81,5 @@ trigger:
   event:
     include:
       - push
+node_selector:
+  drone-builds: true


### PR DESCRIPTION
About
===

This PR adds a a Drone [0] CI configuration file which:
- Builds `latest` (if on `master`) and git-tagged based on `auto_tag` [1] which:
```
[...] will automatically tag the image using the standard major, minor, release convention. For example:

1.0.0 produces docker tags 1, 1.0, 1.0.0
1.0.0-rc.1 produces docker tags 1.0.0-rc.1
When the event type is push and the target branch is your default branch (e.g. master) the plugin will automatically tag the image as latest. All other event types and branches are ignored.
```
- Builds `development` branches tagged as `develop`

[0] - https://github.com/0xProject/0x-mesh/blob/master/CONTRIBUTING.md
[1] - http://plugins.drone.io/drone-plugins/drone-docker/