### PR TITLE
core: Fix bug of re-emitting receipt logs, re-sharing, re-adding duplicate orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v6.0.2-beta
+
+### Bug fixes 🐞 
+
+- Fix bug where Mesh nodes were logging receipt and re-sharing with peers duplicate orders already stored in it's DB, if the duplicate order was submitted via JSON-RPC. ([#529](https://github.com/0xProject/0x-mesh/pull/529))
+
 ## v6.0.1-beta
 
 ### Bug fixes 🐞 

--- a/core/core.go
+++ b/core/core.go
@@ -709,6 +709,11 @@ func (app *App) AddOrders(signedOrdersRaw []*json.RawMessage, pinned bool) (*ord
 	}
 
 	for i, acceptedOrderInfo := range allValidationResults.Accepted {
+		// If the order isn't new, we don't add to OrderWatcher, log it's receipt
+		// or share the order with peers.
+		if !acceptedOrderInfo.IsNew {
+			continue
+		}
 		// Add the order to the OrderWatcher. This also saves the order in the
 		// database.
 		err = app.orderWatcher.Add(acceptedOrderInfo, pinned)


### PR DESCRIPTION
New behavior: If order isn't new, e.g., we've already stored it, we avoid adding it to OrderWatcher again, triggering a log event and sharing it with peers once more.

