### PR TITLE
rpc,browser: Add Missing OrderEventEndState enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 ### Bug fixes 🐞 
 
 - Fix bug where Mesh nodes were logging receipt and re-sharing with peers duplicate orders already stored in it's DB, if the duplicate order was submitted via JSON-RPC. ([#529](https://github.com/0xProject/0x-mesh/pull/529))
+- Add missing `UNEXPIRED` `OrderEventEndState` enum value to both `@0x/mesh-rpc-client` and `@0x/mesh-browser` and missing `STOPPED_WATCHING` value from `@0x/mesh-rpc-client`.
 
 ## v6.0.1-beta
 

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -406,6 +406,7 @@ export enum OrderEventEndState {
     FullyFilled = 'FULLY_FILLED',
     Cancelled = 'CANCELLED',
     Expired = 'EXPIRED',
+    Unexpired = 'UNEXPIRED',
     Unfunded = 'UNFUNDED',
     FillabilityIncreased = 'FILLABILITY_INCREASED',
     StoppedWatching = 'STOPPED_WATCHING',

--- a/rpc/clients/typescript/src/types.ts
+++ b/rpc/clients/typescript/src/types.ts
@@ -286,6 +286,8 @@ export enum OrderEventEndState {
     FullyFilled = 'FULLY_FILLED',
     Cancelled = 'CANCELLED',
     Expired = 'EXPIRED',
+    Unexpired = 'UNEXPIRED',
+    StoppedWatching = 'STOPPED_WATCHING',
     Unfunded = 'UNFUNDED',
     FillabilityIncreased = 'FILLABILITY_INCREASED',
 }


### PR DESCRIPTION
This PR adds missing `UNEXPIRED` `OrderEventEndState` enum value to both `@0x/mesh-rpc-client` and `@0x/mesh-browser` and missing `STOPPED_WATCHING` value from `@0x/mesh-rpc-client`.