### PR TITLE
Update go-libp2p-kad-dht to fix memory leak

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -634,7 +634,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:f5aaf57e0484fb766257137c03b35662acf928fa201b0515ed7940220097e9e8"
+  digest = "1:76120e78893593ad83f0c202f699da54b1eafb967cdb1bfe318279087086c1cc"
   name = "github.com/libp2p/go-libp2p-kad-dht"
   packages = [
     ".",
@@ -644,19 +644,19 @@
     "providers",
   ]
   pruneopts = "UT"
-  revision = "a12e621d84028a4e0f165da8e2ca6be4f5af0502"
-  version = "v0.2.0"
+  revision = "8ecf9380a4f75200f628339883acdf56c2b85a5a"
+  version = "v0.3.0"
 
 [[projects]]
-  digest = "1:d750c3b6c1c69bab8ed996ca6c053e0a13db53d2c51937a0debc40174c77bfc1"
+  digest = "1:a8e19025329b4b8c5d406856dcaee8e4a503c7d33a2d61dfa2e7921303eddc8b"
   name = "github.com/libp2p/go-libp2p-kbucket"
   packages = [
     ".",
     "keyspace",
   ]
   pruneopts = "UT"
-  revision = "3752ea0128fd84b4fef0a66739b8ca95c8a471b6"
-  version = "v0.2.0"
+  revision = "8b77351e0f784a5f71749d23000897c8aee71a76"
+  version = "v0.2.1"
 
 [[projects]]
   digest = "1:645c5ab1429b06141e0d22852df9561e04b3759380f6657f0b510a30eef83665"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -78,7 +78,7 @@
 
 [[constraint]]
   name = "github.com/libp2p/go-libp2p-kad-dht"
-  version = "0.2.0"
+  version = "0.3.0"
 
 [[constraint]]
   name = "github.com/libp2p/go-libp2p-connmgr"

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -319,13 +319,6 @@ func (n *Node) ID() peer.ID {
 // Start causes the Node to continuously send messages to and receive messages
 // from its peers. It blocks until an error is encountered or `Stop` is called.
 func (n *Node) Start() error {
-	// Note: dht.Bootstrap has a somewhat confusing name. It doesn't automatically
-	// connect to the bootstrap peers. It just starts the background process of
-	// searching for new peers.
-	if err := n.dht.Bootstrap(n.ctx); err != nil {
-		return err
-	}
-
 	// Use the default bootstrap list if none was provided.
 	if len(n.config.BootstrapList) == 0 {
 		n.config.BootstrapList = DefaultBootstrapList


### PR DESCRIPTION
This is a potential solution to https://github.com/0xProject/0x-mesh/issues/452. Memory snapshots revealed that `go.opencensus.io/tag.(*Map).insert` was responsible for an unusually large amount of memory (up to 100MB after a few days). That package is used by `github.com/libp2p/go-libp2p-kad-dht`. https://github.com/libp2p/go-libp2p-kad-dht/issues/389 mentions this leak which was reported as fixed in version 0.2.1.

This PR updates `github.com/libp2p/go-libp2p-kad-dht` to the latest version. We will need to continue to monitor memory usage to see if this fixes the problem.
