### PR TITLE
Set default RPC port to 60557

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 - Fix bug where Mesh nodes were logging receipt and re-sharing with peers duplicate orders already stored in it's DB, if the duplicate order was submitted via JSON-RPC. ([#529](https://github.com/0xProject/0x-mesh/pull/529))
 - Add missing `UNEXPIRED` `OrderEventEndState` enum value to both `@0x/mesh-rpc-client` and `@0x/mesh-browser` and missing `STOPPED_WATCHING` value from `@0x/mesh-rpc-client`.
-- Fixed a potential memory leak by using the latest version of `github.com/libp2p/go-libp2p-kad-dht` ([#539](https://github.com/0xProject/0x-mesh/pull/539)). 
+- Fixed a potential memory leak by using the latest version of `github.com/libp2p/go-libp2p-kad-dht` ([#539](https://github.com/0xProject/0x-mesh/pull/539)).
+- Changed the default port for `RPC_ADDR` from a random available port to `60557`. _Some_ documentation already assumed `60557` was the default port. Now all documentation has been updated for consistency with this change. ([#542](https://github.com/0xProject/0x-mesh/pull/542)). 
 - Fixed a potential nil pointer exception in log hooks ([#543](https://github.com/0xProject/0x-mesh/pull/543)).
 - Fixed a bug where successful closes of an rpc subscription were being reported as errors ([#544](https://github.com/0xProject/0x-mesh/pull/544)).
 

--- a/cmd/mesh/main.go
+++ b/cmd/mesh/main.go
@@ -19,9 +19,8 @@ import (
 // in standalone mode (i.e. not in a browser).
 type standaloneConfig struct {
 	// RPCAddr is the interface and port to use for the JSON-RPC API over
-	// WebSockets. By default, 0x Mesh will listen on localhost and will let the
-	// OS select a randomly available port.
-	RPCAddr string `envvar:"RPC_ADDR" default:"localhost:0"`
+	// WebSockets. By default, 0x Mesh will listen on localhost and port 60557.
+	RPCAddr string `envvar:"RPC_ADDR" default:"localhost:60557"`
 }
 
 func main() {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -140,8 +140,7 @@ Mesh executable](../cmd/mesh/main.go):
 ```go
 type standaloneConfig struct {
 	// RPCAddr is the interface and port to use for the JSON-RPC API over
-	// WebSockets. By default, 0x Mesh will listen on localhost and will let the
-	// OS select a randomly available port.
-	RPCAddr string `envvar:"RPC_ADDR" default:"localhost:0"`
+	// WebSockets. By default, 0x Mesh will listen on localhost and port 60557.
+	RPCAddr string `envvar:"RPC_ADDR" default:"localhost:60557"`
 }
 ```


### PR DESCRIPTION
There is currently a discrepancy in the documentation regarding the default RPC port. See https://0x-org.gitbook.io/mesh/v/v6.0.1-beta/getting-started/deployment.

In part of the documentation we claim:

> Ports 60557, 60558, and 60559 are the default ports used for the JSON RPC endpoint, communicating with peers over TCP, and communicating with peers over WebSockets, respectively.

However, later the documentation conflicts with this when the `RPC_ADDR` environment variable itself is documented:

>    // RPCAddr is the interface and port to use for the JSON-RPC API over
>    // WebSockets. By default, 0x Mesh will listen on localhost and will let the
>    // OS select a randomly available port.
>    RPCAddr string `envvar:"RPC_ADDR" default:"localhost:0"`

In version `6.0.1-beta`, Mesh randomly selected an available port by default. So the second part of the docs was correct.

After thinking about this some more, I actually think it makes more sense to use `60557` as the default port, as we already suggest in the __docker-compose.yml__ file for enabling telemetry. This PR updates the default `RPC_ADDR` to use port 60557 and also updates the relevant portions of our documentation so that everything is consistent.