### PR TITLE
Fix a possible nil pointer exception in log hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 - Fix bug where Mesh nodes were logging receipt and re-sharing with peers duplicate orders already stored in it's DB, if the duplicate order was submitted via JSON-RPC. ([#529](https://github.com/0xProject/0x-mesh/pull/529))
 - Add missing `UNEXPIRED` `OrderEventEndState` enum value to both `@0x/mesh-rpc-client` and `@0x/mesh-browser` and missing `STOPPED_WATCHING` value from `@0x/mesh-rpc-client`.
 - Fixed a potential memory leak by using the latest version of `github.com/libp2p/go-libp2p-kad-dht` ([#539](https://github.com/0xProject/0x-mesh/pull/539)). 
+- Fixed a potential nil pointer exception in log hooks ([#543](https://github.com/0xProject/0x-mesh/pull/543)).
 
 ## v6.0.1-beta
 

--- a/loghooks/key_suffix_hook.go
+++ b/loghooks/key_suffix_hook.go
@@ -58,6 +58,9 @@ func (h *KeySuffixHook) Fire(entry *log.Entry) error {
 
 // getTypeForValue returns a string representation of the type of the given val.
 func getTypeForValue(val interface{}) (string, error) {
+	if val == nil {
+		return "null", nil
+	}
 	if _, ok := val.(json.Marshaler); ok {
 		// If val implements json.Marshaler, return the type of json.Marshal(val)
 		// instead of the type of val.


### PR DESCRIPTION
Based on an issue reported on Discord. Though it doesn't happen often, `val` can sometimes be `nil`. Not handling this case explicitly results in a nil pointer exception.
