### PR TITLE
Handle nil errors from rpcSub.Err

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 - Add missing `UNEXPIRED` `OrderEventEndState` enum value to both `@0x/mesh-rpc-client` and `@0x/mesh-browser` and missing `STOPPED_WATCHING` value from `@0x/mesh-rpc-client`.
 - Fixed a potential memory leak by using the latest version of `github.com/libp2p/go-libp2p-kad-dht` ([#539](https://github.com/0xProject/0x-mesh/pull/539)). 
 - Fixed a potential nil pointer exception in log hooks ([#543](https://github.com/0xProject/0x-mesh/pull/543)).
+- Fixed a bug where successful closes of an rpc subscription were being reported as errors ([#544](https://github.com/0xProject/0x-mesh/pull/544)).
 
 ## v6.0.1-beta
 

--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -165,8 +165,12 @@ func SetupOrderStream(ctx context.Context, app *core.App) (*ethrpc.Subscription,
 					}
 				}
 			case err := <-rpcSub.Err():
-				log.WithField("err", err).Error("rpcSub returned an error")
-				orderWatcherSub.Unsubscribe()
+				if err != nil {
+					log.WithField("err", err).Error("rpcSub returned an error")
+					orderWatcherSub.Unsubscribe()
+				} else {
+					log.Debug("rpcSub was closed without error")
+				}
 				return
 			case <-notifier.Closed():
 				orderWatcherSub.Unsubscribe()

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -68,7 +68,11 @@ func SetupHeartbeat(ctx context.Context) (*ethrpc.Subscription, error) {
 		for {
 			select {
 			case err := <-rpcSub.Err():
-				log.WithField("err", err).Error("rpcSub returned an error")
+				if err != nil {
+					log.WithField("err", err).Error("rpcSub returned an error")
+				} else {
+					log.Debug("rpcSub was closed without error")
+				}
 				return
 			case <-notifier.Closed():
 				return


### PR DESCRIPTION
Based on feedback from Discord. We were seeing the following log:

```
{"err_null":null,"level":"error","msg":"rpcSub returned an error","myPeerID":"16Uiu2HAm6PCaDbQscruxnGCUWgpxvX4RXqAUk3fGZy7CACCZ4Qpj","time":"2019-11-19T01:12:04Z"}
```

It is apparently possible to receive a value of `nil` from the `rpcSub.Err()` channel. This PR updates our code to handle that edge case.
