### PR TITLE
Block as needed inside core.App until started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v6.1.2-beta
+
+### Bug fixes 🐞
+
+- Fixed a bug which could cause Mesh to crash with a nil pointer exception if RPC requests are sent too quickly during/immediately after start up ([#560](https://github.com/0xProject/0x-mesh/pull/560)).
+
+
 ## v6.1.1-beta
 
 ### Bug fixes 🐞

--- a/core/core.go
+++ b/core/core.go
@@ -451,6 +451,12 @@ func (app *App) Start(ctx context.Context) error {
 	}
 
 	// Initialize the p2p node.
+	// Note(albrow): The main reason that we need to use a `started` channel in
+	// some methods is that we cannot call p2p.New without passing in a context
+	// (due to how libp2p works). This means that before app.Start is called,
+	// app.node will be nil and attempting to call any methods on app.node will
+	// panic with a nil pointer exception. All the other fields of core.App that
+	// we need to use will have already been initialized and are ready to use.
 	bootstrapList := p2p.DefaultBootstrapList
 	if app.config.BootstrapList != "" {
 		bootstrapList = strings.Split(app.config.BootstrapList, ",")

--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -72,7 +72,6 @@ type Watcher struct {
 	blockScope      event.SubscriptionScope // Subscription scope tracking current live listeners
 	wasStartedOnce  bool                    // Whether the block watcher has previously been started
 	pollingInterval time.Duration
-	ticker          *time.Ticker
 	withLogs        bool
 	topics          []common.Hash
 	mu              sync.RWMutex


### PR DESCRIPTION
Fixes #558.

As far as I can tell there is only one case where a field may not be fully initialized which can result in a nil pointer exception. All the issues we were seeing stem from this. The problem is that `app.node` is nil before `app.Start` is called (and sort of has to be because of how the libp2p works).

This PR fixes the issue by using a `started` channel inside of `core.App` to signal when `app.node` has been initialized. Any methods that depend on `app.node` will block by waiting to receive on the `app.started` channel. This can be easily extended to support other edge cases for any fields cannot be initialized until after `Start` is called.
