### PR TITLE
POC: core, node, rpc: Add support for advertising and discovering RFQ quote providers

### DIFF
--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -176,6 +176,61 @@ func (handler *rpcHandler) GetStats() (result *rpc.GetStatsResponse, err error) 
 	return getStatsResponse, nil
 }
 
+// AdvertiseAsQuoteProvider is called when an RPC client requests to advertise themselves as a quote provider
+func (handler *rpcHandler) AdvertiseAsQuoteProvider(standard, assetPair string, ttl time.Duration) (err error) {
+	log.Debug("received AdvertiseAsQuoteProvider request via RPC")
+	// Catch panics, log stack trace and return RPC error message
+	defer func() {
+		if r := recover(); r != nil {
+			internalErr, ok := r.(error)
+			if !ok {
+				// If r is not of type error, convert it.
+				internalErr = fmt.Errorf("Recovered from non-error: (%T) %v", r, r)
+			}
+			log.WithFields(log.Fields{
+				"error":      internalErr,
+				"method":     "AdvertiseAsQuoteProvider",
+				"stackTrace": string(debug.Stack()),
+			}).Error("RPC method handler crashed")
+			err = errors.New("method handler crashed in AdvertiseAsQuoteProvider RPC call (check logs for stack trace)")
+		}
+	}()
+	err = handler.app.AdvertiseAsQuoteProvider(standard, assetPair, ttl)
+	if err != nil {
+		log.WithField("error", err.Error()).Error("internal error in AdvertiseAsQuoteProvider RPC call")
+		return constants.ErrInternal
+	}
+	return nil
+}
+
+// GetQuoteProviders is called when an RPC client requests to retrieve all the RFQ quote providers advertised
+// on the DHT for a specific asset pair and adhering to a specific RFQ specification
+func (handler *rpcHandler) GetQuoteProviders(standard, assetPair string) (quoteProviders []string, err error) {
+	log.Debug("received GetQuoteProviders request via RPC")
+	// Catch panics, log stack trace and return RPC error message
+	defer func() {
+		if r := recover(); r != nil {
+			internalErr, ok := r.(error)
+			if !ok {
+				// If r is not of type error, convert it.
+				internalErr = fmt.Errorf("Recovered from non-error: (%T) %v", r, r)
+			}
+			log.WithFields(log.Fields{
+				"error":      internalErr,
+				"method":     "GetQuoteProviders",
+				"stackTrace": string(debug.Stack()),
+			}).Error("RPC method handler crashed")
+			err = errors.New("method handler crashed in GetQuoteProviders RPC call (check logs for stack trace)")
+		}
+	}()
+	quoteProviders, err = handler.app.GetQuoteProviders(standard, assetPair)
+	if err != nil {
+		log.WithField("error", err.Error()).Error("internal error in GetQuoteProviders RPC call")
+		return nil, constants.ErrInternal
+	}
+	return quoteProviders, nil
+}
+
 // SubscribeToOrders is called when an RPC client sends a `mesh_subscribe` request with the `orders` topic parameter
 func (handler *rpcHandler) SubscribeToOrders(ctx context.Context) (result *ethrpc.Subscription, err error) {
 	log.Debug("received order event subscription request via RPC")

--- a/examples/go/advertise-quote-provider/main.go
+++ b/examples/go/advertise-quote-provider/main.go
@@ -1,0 +1,40 @@
+// +build !js
+
+// demo/add_order is a short program that adds an order to 0x Mesh via RPC
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/0xProject/0x-mesh/rpc"
+	"github.com/plaid/go-envvar/envvar"
+	log "github.com/sirupsen/logrus"
+)
+
+type clientEnvVars struct {
+	// RPCAddress is the address of the 0x Mesh node to communicate with.
+	RPCAddress string `envvar:"RPC_ADDRESS"`
+}
+
+func main() {
+	env := clientEnvVars{}
+	if err := envvar.Parse(&env); err != nil {
+		panic(err)
+	}
+
+	client, err := rpc.NewClient(env.RPCAddress)
+	if err != nil {
+		log.WithError(err).Fatal("could not create client")
+	}
+	fmt.Println("Client created...")
+
+	standard := "zaidan-v1.0"
+	assetPair := "WETH/DAI"
+	advertisementTTL := 5 * time.Minute
+	err = client.AdvertiseAsQuoteProvider(standard, assetPair, advertisementTTL)
+	if err != nil {
+		log.WithError(err).Fatal("error from AdvertiseAsQuoteProvider")
+	}
+	fmt.Println("Quote provider advertised")
+}

--- a/examples/go/get-quote-providers/main.go
+++ b/examples/go/get-quote-providers/main.go
@@ -1,0 +1,38 @@
+// +build !js
+
+// demo/add_order is a short program that adds an order to 0x Mesh via RPC
+package main
+
+import (
+	"fmt"
+
+	"github.com/0xProject/0x-mesh/rpc"
+	"github.com/plaid/go-envvar/envvar"
+	log "github.com/sirupsen/logrus"
+)
+
+type clientEnvVars struct {
+	// RPCAddress is the address of the 0x Mesh node to communicate with.
+	RPCAddress string `envvar:"RPC_ADDRESS"`
+}
+
+func main() {
+	env := clientEnvVars{}
+	if err := envvar.Parse(&env); err != nil {
+		panic(err)
+	}
+
+	client, err := rpc.NewClient(env.RPCAddress)
+	if err != nil {
+		log.WithError(err).Fatal("could not create client")
+	}
+	fmt.Println("Client created...")
+
+	standard := "zaidan-v1.0"
+	assetPair := "WETH/DAI"
+	quoteProviders, err := client.GetQuoteProviders(standard, assetPair)
+	if err != nil {
+		log.WithError(err).Fatal("error from GetQuoteProviders")
+	}
+	log.WithField("quoteProviders", quoteProviders).Info("Got quote providers!")
+}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -116,6 +116,28 @@ func (c *Client) GetStats() (*GetStatsResponse, error) {
 	return getStatsResponse, nil
 }
 
+// AdvertiseAsQuoteProvider instructs the Mesh node to advertise it's IP address
+// as the host of an RFQ quote provider server that adheres to an RFQ specification and provides
+// quotes for a specific asset pair. The advertisement will be added to the Mesh DHT for the
+// specified `ttl` duration (max 3hrs). In order to continue advertising the service, this method
+// must be called again after `ttl` has elapsed.
+func (c *Client) AdvertiseAsQuoteProvider(standard, assetPair string, ttl time.Duration) error {
+	if err := c.rpcClient.Call(nil, "mesh_advertiseAsQuoteProvider", standard, assetPair, ttl); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetQuoteProviders instructs the Mesh node to find all advertised RFQ quote provider endpoints
+// for a specific asset pair, adhering to a specific RFQ specification
+func (c *Client) GetQuoteProviders(standard, assetPair string) ([]string, error) {
+	quoteProviders := []string{}
+	if err := c.rpcClient.Call(&quoteProviders, "mesh_getQuoteProviders", standard, assetPair); err != nil {
+		return nil, err
+	}
+	return quoteProviders, nil
+}
+
 // SubscribeToOrders subscribes a stream of order events
 // Note copied from `go-ethereum` codebase: Slow subscribers will be dropped eventually. Client
 // buffers up to 8000 notifications before considering the subscriber dead. The subscription Err

--- a/rpc/service.go
+++ b/rpc/service.go
@@ -33,6 +33,10 @@ type RPCHandler interface {
 	GetOrders(page, perPage int, snapshotID string) (*GetOrdersResponse, error)
 	// AddPeer is called when the client sends an AddPeer request.
 	AddPeer(peerInfo peerstore.PeerInfo) error
+	// AdvertiseAsQuoteProvider is called when the client sends an AdvertiseAsQuoteProvider request.
+	AdvertiseAsQuoteProvider(standard, assetPair string, ttl time.Duration) error
+	// GetQuoteProviders is called when the client sends an GetQuoteProviders request.
+	GetQuoteProviders(standard, assetPair string) ([]string, error)
 	// GetStats is called when the client sends an GetStats request.
 	GetStats() (*GetStatsResponse, error)
 	// SubscribeToOrders is called when a client sends a Subscribe to `orders` request
@@ -166,4 +170,14 @@ func (s *rpcService) AddPeer(peerID string, multiaddrs []string) error {
 // GetStats calls rpcHandler.GetStats. If there is an error, it returns it.
 func (s *rpcService) GetStats() (*GetStatsResponse, error) {
 	return s.rpcHandler.GetStats()
+}
+
+// AdvertiseAsQuoteProvider calls rpcHandler.AdvertiseAsQuoteProvider. If there is an error, it returns it.
+func (s *rpcService) AdvertiseAsQuoteProvider(standard, assetPair string, ttl time.Duration) error {
+	return s.rpcHandler.AdvertiseAsQuoteProvider(standard, assetPair, ttl)
+}
+
+// GetQuoteProviders calls rpcHandler.GetQuoteProviders. If there is an error, it returns it.
+func (s *rpcService) GetQuoteProviders(standard, assetPair string) ([]string, error) {
+	return s.rpcHandler.GetQuoteProviders(standard, assetPair)
 }


### PR DESCRIPTION
This PR provides a proof-of-concept implementation of the functionality to advertise and discover RFQ quote providers over Mesh's DHT. The quote provider would run a Mesh node at the same IP address as their quote provider server endpoint, and periodically refresh their advertisement on the DHT. Any other Mesh user, can find the endpoints for quote providers via their own Mesh node.

Rendez-vous string format:

`/0x-rfq/version/${versionNumber}/chain/${chainID}/standard/${standard}/assetPair/${assetPair}`

Standards examples: `zaidan-v1.0`, `zaidan-v2.0`, `rfqLite-v1.0`

AssetPair examples: `weth/dai`, `0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/0x6b175474e89094c44da98b954eedeac495271d0f`

### `mesh_advertiseAsQuoteProvider`

A quote provider can advertise themselves as providing quotes for a specific asset pair over an endpoint that adheres to a specific standard. The advertisement will be placed on the DHT for traders to find.

Request:
```json
{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "mesh_advertiseAsQuoteProvider",
    "params": {
        "standard": "zaidan-v1.0",
        "assetPair": "weth/dai",
        "ttl": "3hr"
    }
}
```

Response:
```json
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": true,
}
```

### `mesh_getQuoteProviders`

A trader can request a list of quote provider IP addresses that offer quotes for a specific asset pair and that comply to a specific standard. They can then use a client designed for the specified standard to start requesting quotes from these endpoints.

Request:
```json
{
    "id": 1,
    "jsonrpc": "2.0",
    "method": "mesh_getQuoteProviders",
    "params": {
        "standard": "zaidan-v1.0",
        "assetPair": "weth/dai"
    }
}
```

Response:
```json
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": [
        "192.168.178.158",
        "167.172.201.142",
        "18.204.221.103",
        ...
    ],
}
```