### PR TITLE
Handle null fee asset data in browser bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v7.2.2-beta-0xv3
+
+### Bug fixes 🐞
+
+- Fixed a bug where `makerAssetFeeData` or `takerAssetFeeData` were sometimes being set to an empty string instead of `0x` in the browser ([#579](https://github.com/0xProject/0x-mesh/pull/579)).
+
 ## v7.2.1-beta-0xv3
 
 ### Bug fixes 🐞

--- a/zeroex/order.go
+++ b/zeroex/order.go
@@ -539,6 +539,9 @@ func (s SignedOrder) MarshalJSON() ([]byte, error) {
 	if len(s.MakerAssetData) != 0 {
 		makerAssetData = fmt.Sprintf("0x%s", common.Bytes2Hex(s.MakerAssetData))
 	}
+	// Note(albrow): Because of how our smart contracts work, most fields of an
+	// order cannot be null. However, makerAssetFeeData and takerAssetFeeData are
+	// the exception. For these fields, "0x" is used to indicate a null value.
 	makerFeeAssetData := "0x"
 	if len(s.MakerFeeAssetData) != 0 {
 		makerFeeAssetData = fmt.Sprintf("0x%s", common.Bytes2Hex(s.MakerFeeAssetData))

--- a/zeroex/order_js.go
+++ b/zeroex/order_js.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"syscall/js"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -17,7 +18,7 @@ func (o OrderEvent) JSValue() js.Value {
 	return js.ValueOf(map[string]interface{}{
 		"orderHash":                o.OrderHash.Hex(),
 		"signedOrder":              o.SignedOrder.JSValue(),
-		"endState":                     string(o.EndState),
+		"endState":                 string(o.EndState),
 		"fillableTakerAssetAmount": o.FillableTakerAssetAmount.String(),
 		"contractEvents":           contractEventsJS,
 	})
@@ -28,7 +29,10 @@ func (s SignedOrder) JSValue() js.Value {
 	if len(s.MakerAssetData) != 0 {
 		makerAssetData = fmt.Sprintf("0x%s", common.Bytes2Hex(s.MakerAssetData))
 	}
-	makerFeeAssetData := ""
+	// Note(albrow): Because of how our smart contracts work, most fields of an
+	// order cannot be null. However, makerAssetFeeData and takerAssetFeeData are
+	// the exception. For these fields, "0x" is used to indicate a null value.
+	makerFeeAssetData := "0x"
 	if len(s.MakerFeeAssetData) != 0 {
 		makerFeeAssetData = fmt.Sprintf("0x%s", common.Bytes2Hex(s.MakerFeeAssetData))
 	}
@@ -36,7 +40,7 @@ func (s SignedOrder) JSValue() js.Value {
 	if len(s.TakerAssetData) != 0 {
 		takerAssetData = fmt.Sprintf("0x%s", common.Bytes2Hex(s.TakerAssetData))
 	}
-	takerFeeAssetData := ""
+	takerFeeAssetData := "0x"
 	if len(s.TakerFeeAssetData) != 0 {
 		takerFeeAssetData = fmt.Sprintf("0x%s", common.Bytes2Hex(s.TakerFeeAssetData))
 	}
@@ -68,12 +72,12 @@ func (s SignedOrder) JSValue() js.Value {
 
 func (c ContractEvent) JSValue() js.Value {
 	m := map[string]interface{}{
-		"blockHash": c.BlockHash.Hex(),
-		"txHash":    c.TxHash.Hex(),
-		"txIndex":   c.TxIndex,
-		"logIndex":  c.LogIndex,
-		"isRemoved": c.IsRemoved,
-		"kind":      c.Kind,
+		"blockHash":  c.BlockHash.Hex(),
+		"txHash":     c.TxHash.Hex(),
+		"txIndex":    c.TxIndex,
+		"logIndex":   c.LogIndex,
+		"isRemoved":  c.IsRemoved,
+		"kind":       c.Kind,
 		"parameters": c.Parameters.(js.Wrapper).JSValue(),
 	}
 	return js.ValueOf(m)


### PR DESCRIPTION
Previously, a null `makerAssetFeeData` or `takerAssetFeeData` was being encoded as an empty string, which is incorrect.