### PR TITLE
Add new ENABLE_ETHEREUM_RPC_RATE_LIMITING environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This changelog is a work in progress and may contain notes for versions which ha
 ### Features ✅
 
 - Instead of progressing Mesh forward by a single block on every invocation of the `BLOCK_POLLING_INTERVAL`, we now attempt to sync as many blocks as necessary to reach the latest block available. This will reduce the chances of Mesh becoming out-of-sync with it's backing Ethereum node ([#564](https://github.com/0xProject/0x-mesh/pull/564))
+- Added a new environment variable `ENABLE_ETHEREUM_RPC_RATE_LIMITING` and config option `enableEthereumRPCRateLimiting` which can be used to completely disable Mesh's internal Ethereum RPC rate limiting features. By default it is enabled, and disabling can have some consequences depending on your RPC provider. ([#584](https://github.com/0xProject/0x-mesh/pull/584))
+
+
+## v6.1.2-beta
 
 ### Bug fixes 🐞
 

--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -89,6 +89,7 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 		EthereumRPCMaxContentLength:      524288,
 		EthereumRPCMaxRequestsPer24HrUTC: 100000,
 		EthereumRPCMaxRequestsPerSecond:  30,
+		EnableEthereumRPCRateLimiting:    true,
 		MaxOrdersInStorage:               100000,
 	}
 
@@ -125,6 +126,9 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 	}
 	if ethereumRPCMaxRequestsPerSecond := jsConfig.Get("ethereumRPCMaxRequestsPerSecond"); !isNullOrUndefined(ethereumRPCMaxRequestsPerSecond) {
 		config.EthereumRPCMaxRequestsPerSecond = ethereumRPCMaxRequestsPerSecond.Float()
+	}
+	if enableEthereumRPCRateLimiting := jsConfig.Get("enableEthereumRPCRateLimiting"); !isNullOrUndefined(enableEthereumRPCRateLimiting) {
+		config.EnableEthereumRPCRateLimiting = enableEthereumRPCRateLimiting.Bool()
 	}
 	if customContractAddresses := jsConfig.Get("customContractAddresses"); !isNullOrUndefined(customContractAddresses) {
 		config.CustomContractAddresses = customContractAddresses.String()

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -97,6 +97,14 @@ export interface Config {
     // 30 rps for Infura's free tier, and can be increased to 100 rpc for pro
     // users, and potentially higher on alternative infrastructure.
     ethereumRPCMaxRequestsPerSecond?: number;
+    // Determines whether or not Mesh should limit the number of Ethereum RPC
+    // requests it sends. It defaults to true. Disabling Ethereum RPC rate
+    // limiting can reduce latency for receiving order events in some network
+    // conditions, but can also potentially lead to higher costs or other rate
+    // limiting issues outside of Mesh, depending on your Ethereum RPC provider.
+    // If set to false, ethereumRPCMaxRequestsPer24HrUTC and
+    // ethereumRPCMaxRequestsPerSecond will have no effect.
+    enableEthereumRPCRateLimiting?: boolean;
     // A set of custom addresses to use for the configured network ID. The
     // contract addresses for most common networks are already included by
     // default, so this is typically only needed for testing on custom networks.
@@ -168,6 +176,7 @@ interface WrapperConfig {
     ethereumRPCMaxContentLength?: number;
     ethereumRPCMaxRequestsPer24HrUTC?: number;
     ethereumRPCMaxRequestsPerSecond?: number;
+    enableEthereumRPCRateLimiting?: boolean;
     customContractAddresses?: string; // json-encoded instead of Object.
     maxOrdersInStorage?: number;
 }

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -86,6 +86,14 @@ export interface Config {
     // Parity, feel free to double the default max in order to reduce the number
     // of RPC calls made by Mesh. Defaults to 524288 bytes.
     ethereumRPCMaxContentLength?: number;
+    // Determines whether or not Mesh should limit the number of Ethereum RPC
+    // requests it sends. It defaults to true. Disabling Ethereum RPC rate
+    // limiting can reduce latency for receiving order events in some network
+    // conditions, but can also potentially lead to higher costs or other rate
+    // limiting issues outside of Mesh, depending on your Ethereum RPC provider.
+    // If set to false, ethereumRPCMaxRequestsPer24HrUTC and
+    // ethereumRPCMaxRequestsPerSecond will have no effect.
+    enableEthereumRPCRateLimiting?: boolean;
     // A cap on the number of Ethereum JSON-RPC requests a Mesh node will make
     // per 24hr UTC time window (time window starts and ends at 12am UTC). It
     // defaults to the 100k limit on Infura's free tier but can be increased
@@ -97,14 +105,6 @@ export interface Config {
     // 30 rps for Infura's free tier, and can be increased to 100 rpc for pro
     // users, and potentially higher on alternative infrastructure.
     ethereumRPCMaxRequestsPerSecond?: number;
-    // Determines whether or not Mesh should limit the number of Ethereum RPC
-    // requests it sends. It defaults to true. Disabling Ethereum RPC rate
-    // limiting can reduce latency for receiving order events in some network
-    // conditions, but can also potentially lead to higher costs or other rate
-    // limiting issues outside of Mesh, depending on your Ethereum RPC provider.
-    // If set to false, ethereumRPCMaxRequestsPer24HrUTC and
-    // ethereumRPCMaxRequestsPerSecond will have no effect.
-    enableEthereumRPCRateLimiting?: boolean;
     // A set of custom addresses to use for the configured network ID. The
     // contract addresses for most common networks are already included by
     // default, so this is typically only needed for testing on custom networks.

--- a/core/core.go
+++ b/core/core.go
@@ -98,6 +98,14 @@ type Config struct {
 	// or Infura. If using Alchemy or Parity, feel free to double the default max in order to reduce the
 	// number of RPC calls made by Mesh.
 	EthereumRPCMaxContentLength int `envvar:"ETHEREUM_RPC_MAX_CONTENT_LENGTH" default:"524288"`
+	// EnableEthereumRPCRateLimiting determines whether or not Mesh should limit
+	// the number of Ethereum RPC requests it sends. It defaults to true.
+	// Disabling Ethereum RPC rate limiting can reduce latency for receiving order
+	// events in some network conditions, but can also potentially lead to higher
+	// costs or other rate limiting issues outside of Mesh, depending on your
+	// Ethereum RPC provider. If set to false, ethereumRPCMaxRequestsPer24HrUTC
+	// and ethereumRPCMaxRequestsPerSecond will have no effect.
+	EnableEthereumRPCRateLimiting bool `envvar:"ENABLE_ETHEREUM_RPC_RATE_LIMITING" default:"true"`
 	// EthereumRPCMaxRequestsPer24HrUTC caps the number of Ethereum JSON-RPC requests a Mesh node will make
 	// per 24hr UTC time window (time window starts and ends at 12am UTC). It defaults to the 100k limit on
 	// Infura's free tier but can be increased well beyond this limit for those using alternative infra/plans.
@@ -107,14 +115,6 @@ type Config struct {
 	// It defaults to the recommended 30 rps for Infura's free tier, and can be increased to 100 rpc for pro users,
 	// and potentially higher on alternative infrastructure.
 	EthereumRPCMaxRequestsPerSecond float64 `envvar:"ETHEREUM_RPC_MAX_REQUESTS_PER_SECOND" default:"30"`
-	// EnableEthereumRPCRateLimiting determines whether or not Mesh should limit
-	// the number of Ethereum RPC requests it sends. It defaults to true.
-	// Disabling Ethereum RPC rate limiting can reduce latency for receiving order
-	// events in some network conditions, but can also potentially lead to higher
-	// costs or other rate limiting issues outside of Mesh, depending on your
-	// Ethereum RPC provider. If set to false, ethereumRPCMaxRequestsPer24HrUTC
-	// and ethereumRPCMaxRequestsPerSecond will have no effect.
-	EnableEthereumRPCRateLimiting bool `envvar:"ENABLE_ETHEREUM_RPC_RATE_LIMITING" default:"true"`
 	// CustomContractAddresses is a JSON-encoded string representing a set of
 	// custom addresses to use for the configured chain ID. The contract
 	// addresses for most common chains/networks are already included by default, so this

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -109,6 +109,14 @@ type Config struct {
 	// It defaults to the recommended 30 rps for Infura's free tier, and can be increased to 100 rpc for pro users,
 	// and potentially higher on alternative infrastructure.
 	EthereumRPCMaxRequestsPerSecond float64 `envvar:"ETHEREUM_RPC_MAX_REQUESTS_PER_SECOND" default:"30"`
+	// EnableEthereumRPCRateLimiting determines whether or not Mesh should limit
+	// the number of Ethereum RPC requests it sends. It defaults to true.
+	// Disabling Ethereum RPC rate limiting can reduce latency for receiving order
+	// events in some network conditions, but can also potentially lead to higher
+	// costs or other rate limiting issues outside of Mesh, depending on your
+	// Ethereum RPC provider. If set to false, ethereumRPCMaxRequestsPer24HrUTC
+	// and ethereumRPCMaxRequestsPerSecond will have no effect.
+	EnableEthereumRPCRateLimiting bool `envvar:"ENABLE_ETHEREUM_RPC_RATE_LIMITING" default:"true"`
 	// CustomContractAddresses is a JSON-encoded string representing a set of
 	// custom addresses to use for the configured chain ID. The contract
 	// addresses for most common chains/networks are already included by default, so this

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -100,6 +100,14 @@ type Config struct {
 	// or Infura. If using Alchemy or Parity, feel free to double the default max in order to reduce the
 	// number of RPC calls made by Mesh.
 	EthereumRPCMaxContentLength int `envvar:"ETHEREUM_RPC_MAX_CONTENT_LENGTH" default:"524288"`
+	// EnableEthereumRPCRateLimiting determines whether or not Mesh should limit
+	// the number of Ethereum RPC requests it sends. It defaults to true.
+	// Disabling Ethereum RPC rate limiting can reduce latency for receiving order
+	// events in some network conditions, but can also potentially lead to higher
+	// costs or other rate limiting issues outside of Mesh, depending on your
+	// Ethereum RPC provider. If set to false, ethereumRPCMaxRequestsPer24HrUTC
+	// and ethereumRPCMaxRequestsPerSecond will have no effect.
+	EnableEthereumRPCRateLimiting bool `envvar:"ENABLE_ETHEREUM_RPC_RATE_LIMITING" default:"true"`
 	// EthereumRPCMaxRequestsPer24HrUTC caps the number of Ethereum JSON-RPC requests a Mesh node will make
 	// per 24hr UTC time window (time window starts and ends at 12am UTC). It defaults to the 100k limit on
 	// Infura's free tier but can be increased well beyond this limit for those using alternative infra/plans.
@@ -109,14 +117,6 @@ type Config struct {
 	// It defaults to the recommended 30 rps for Infura's free tier, and can be increased to 100 rpc for pro users,
 	// and potentially higher on alternative infrastructure.
 	EthereumRPCMaxRequestsPerSecond float64 `envvar:"ETHEREUM_RPC_MAX_REQUESTS_PER_SECOND" default:"30"`
-	// EnableEthereumRPCRateLimiting determines whether or not Mesh should limit
-	// the number of Ethereum RPC requests it sends. It defaults to true.
-	// Disabling Ethereum RPC rate limiting can reduce latency for receiving order
-	// events in some network conditions, but can also potentially lead to higher
-	// costs or other rate limiting issues outside of Mesh, depending on your
-	// Ethereum RPC provider. If set to false, ethereumRPCMaxRequestsPer24HrUTC
-	// and ethereumRPCMaxRequestsPerSecond will have no effect.
-	EnableEthereumRPCRateLimiting bool `envvar:"ENABLE_ETHEREUM_RPC_RATE_LIMITING" default:"true"`
 	// CustomContractAddresses is a JSON-encoded string representing a set of
 	// custom addresses to use for the configured chain ID. The contract
 	// addresses for most common chains/networks are already included by default, so this

--- a/ethereum/ratelimit/fake_rate_limiter.go
+++ b/ethereum/ratelimit/fake_rate_limiter.go
@@ -13,8 +13,10 @@ type fakeLimiter struct {
 	mu                    sync.Mutex
 }
 
-// NewFakeLimiter returns a new fakeLimiter
-func NewFakeLimiter() RateLimiter {
+// NewUnlimited returns a new RateLimiter without any limits. It will always
+// allow requests immediately. It still keeps track of the number of requests
+// that are allowed.
+func NewUnlimited() RateLimiter {
 	return &fakeLimiter{
 		currentUTCCheckpoint:  getUTCMidnightOfDate(time.Now()),
 		grantedInLast24hrsUTC: 0,

--- a/zeroex/ordervalidator/order_validator_test.go
+++ b/zeroex/ordervalidator/order_validator_test.go
@@ -147,7 +147,7 @@ func TestBatchValidateOffChainCases(t *testing.T) {
 
 	for _, testCase := range testCases {
 
-		rateLimiter := ratelimit.NewFakeLimiter()
+		rateLimiter := ratelimit.NewUnlimited()
 		ethClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 		require.NoError(t, err)
 
@@ -182,7 +182,7 @@ func TestBatchValidateAValidOrder(t *testing.T) {
 		signedOrder,
 	}
 
-	rateLimiter := ratelimit.NewFakeLimiter()
+	rateLimiter := ratelimit.NewUnlimited()
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
@@ -210,7 +210,7 @@ func TestBatchValidateSignatureInvalid(t *testing.T) {
 		signedOrder,
 	}
 
-	rateLimiter := ratelimit.NewFakeLimiter()
+	rateLimiter := ratelimit.NewUnlimited()
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
@@ -238,7 +238,7 @@ func TestBatchValidateUnregisteredCoordinatorSoftCancels(t *testing.T) {
 		signedOrder,
 	}
 
-	rateLimiter := ratelimit.NewFakeLimiter()
+	rateLimiter := ratelimit.NewUnlimited()
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
@@ -269,7 +269,7 @@ func TestBatchValidateCoordinatorSoftCancels(t *testing.T) {
 		signedOrder,
 	}
 
-	rateLimiter := ratelimit.NewFakeLimiter()
+	rateLimiter := ratelimit.NewUnlimited()
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
@@ -321,7 +321,7 @@ func TestComputeOptimalChunkSizesMaxContentLengthTooLow(t *testing.T) {
 	signedOrder, err := zeroex.SignTestOrder(&testSignedOrder.Order)
 	require.NoError(t, err)
 
-	rateLimiter := ratelimit.NewFakeLimiter()
+	rateLimiter := ratelimit.NewUnlimited()
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
@@ -339,7 +339,7 @@ func TestComputeOptimalChunkSizes(t *testing.T) {
 	signedOrder, err := zeroex.SignTestOrder(&testSignedOrder.Order)
 	require.NoError(t, err)
 
-	rateLimiter := ratelimit.NewFakeLimiter()
+	rateLimiter := ratelimit.NewUnlimited()
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
@@ -377,7 +377,7 @@ func TestComputeOptimalChunkSizesMultiAssetOrder(t *testing.T) {
 	signedMultiAssetOrder, err := zeroex.SignTestOrder(&testMultiAssetSignedOrder.Order)
 	require.NoError(t, err)
 
-	rateLimiter := ratelimit.NewFakeLimiter()
+	rateLimiter := ratelimit.NewUnlimited()
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -810,7 +810,7 @@ func watchOrder(t *testing.T, orderWatcher *Watcher, signedOrder *zeroex.SignedO
 }
 
 func setupOrderWatcher(ctx context.Context, t *testing.T, ethClient *ethclient.Client, meshDB *meshdb.MeshDB) *Watcher {
-	rateLimiter := ratelimit.NewFakeLimiter()
+	rateLimiter := ratelimit.NewUnlimited()
 	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, ethereumRPCRequestTimeout, rateLimiter)
 	require.NoError(t, err)
 	blockWatcherClient, err := blockwatch.NewRpcClient(ethRPCClient)


### PR DESCRIPTION
This new environment variable will allow users to completely disable Ethereum RPC rate limiting. Disabling the feature does come with some risks and can lead to abnormally high bills for services like Infura and Alchemy depending on network conditions. Still, some users, and in particular market makers, might prefer higher costs to the alternative of not receiving order updates quickly.