### PR TITLE
WIP: Completely reset 24 hour rate limiter every midnight UTC

### DIFF
--- a/ethereum/ratelimit/rate_limiter_test.go
+++ b/ethereum/ratelimit/rate_limiter_test.go
@@ -19,9 +19,9 @@ var (
 	maxRequestsPer24HrsWithoutBuffer      = 301000
 	maxRequestsPer24hrs                   = maxRequestsPer24HrsWithoutBuffer - maxRequestsPer24HrsBuffer
 	maxRequestsPerSecond                  = 10.0
-	twentyFourHrs                         = (24 * 60 * 60 * 1000 * time.Millisecond)
+	twentyFourHrs                         = 24 * time.Hour
 	maxExpectedDelay                      = twentyFourHrs / time.Duration(maxRequestsPer24hrs)
-	minExpectedDelay                      = time.Duration(1000) / time.Duration(maxRequestsPerSecond) * time.Millisecond
+	minExpectedDelay                      = 1 * time.Second / time.Duration(maxRequestsPerSecond)
 	defaultCheckpointInterval             = 1 * time.Minute
 	expectedMaxElapsedTimeForFirstRequest = 1 * time.Millisecond
 	expectedDeltaMinExpectedDelay         = 15 * time.Millisecond


### PR DESCRIPTION
This is a potential fix for #585. We think that the issue might be due to a mismatch in our accounting of how many requests have been granted and the accounting inside of the `rate.Limiter`. If that is the problem, this PR fixes it by creating a fresh `rate.Limiter` every time at midnight UTC. Instead of trying to track the number of tokens we need to drain, we simply drain all of them.
