### PR TITLE
Simplify Ethereum RPC rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 ### Breaking changes 🛠 
 
 - Changed the response from `@0x/mesh-ts-client`'s `getOrdersAsync` endpoint to include the `snapshotID` and `snapshotTimestamp` at which the Mesh DB was queried along with the orders found. ([#591](https://github.com/0xProject/0x-mesh/pull/591))
+- Increased the default `ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC` from 100k to 200k ([#596](https://github.com/0xProject/0x-mesh/pull/596)).
 
 ### Features ✅
 
@@ -19,6 +20,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 - Fixed an issue where order updates could have been missed if Mesh discovered blocks but didn't have time to process them before getting shut down. Now, blocks are only persisted to the DB once any order updates resulting from it have been processed. ([#566](https://github.com/0xProject/0x-mesh/pull/566)).
 - Fixed a race-condition when adding new orders to Mesh which could result in order-relevant events being missed if they occured very soon after the order was submitted and the order validation RPC call took a long time ([#566](https://github.com/0xProject/0x-mesh/pull/566)).
+- Fixed an issue where the internal Ethereum RPC rate limiter could be too aggressive in certain scenarios ([#596](https://github.com/0xProject/0x-mesh/pull/596)).
 
 
 ## v6.1.2-beta

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -95,9 +95,9 @@ export interface Config {
     // ethereumRPCMaxRequestsPerSecond will have no effect.
     enableEthereumRPCRateLimiting?: boolean;
     // A cap on the number of Ethereum JSON-RPC requests a Mesh node will make
-    // per 24hr UTC time window (time window starts and ends at 12am UTC). It
-    // defaults to the 100k limit on Infura's free tier but can be increased
-    // well beyond this limit for those using alternative infra/plans.
+    // per 24hr UTC time window (time window starts and ends at midnight UTC).
+    // It defaults to 200k but can be increased well beyond this limit depending
+    // on your infrastructure or Ethereum RPC provider.
     ethereumRPCMaxRequestsPer24HrUTC?: number;
     // A cap on the number of Ethereum JSON-RPC requests a Mesh node will make
     // per second. This limits the concurrency of these requests and prevents

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -42,8 +42,7 @@ machine where all Mesh-related data will be stored.
 -   Ports 60557, 60558, and 60559 are the default ports used for the JSON RPC endpoint, communicating with peers over TCP, and communicating with peers over WebSockets, respectively.
 -   In order to disable P2P order discovery and sharing, set `USE_BOOTSTRAP_LIST` to `false`.
 -   Running a VPN may interfere with Mesh. If you are having difficulty connecting to peers, disable your VPN.
--   If you are running against a POA testnet (e.g., Kovan), you might want to shorten the `BLOCK_POLLING_INTERVAL` since blocks are mined more frequently then on mainnet. If you do this, your node will use more Ethereum RPC calls, so you will also need to adjust the `ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC` upwards (*warning:* setting this higher than 100k won't fit into Infura's
-free tier).
+-   If you are running against a POA testnet (e.g., Kovan), you might want to shorten the `BLOCK_POLLING_INTERVAL` since blocks are mined more frequently then on mainnet. If you do this, your node will use more Ethereum RPC calls, so you will also need to adjust the `ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC` upwards (*warning:* changing this setting can exceed the limits of your Ethereum RPC provider).
 -   If you want to run the mesh in "detached" mode, add the `-d` switch to the docker run command so that your console doesn't get blocked.
 
 ## Persisting State
@@ -109,9 +108,9 @@ type Config struct {
 	// and ethereumRPCMaxRequestsPerSecond will have no effect.
 	EnableEthereumRPCRateLimiting bool `envvar:"ENABLE_ETHEREUM_RPC_RATE_LIMITING" default:"true"`
 	// EthereumRPCMaxRequestsPer24HrUTC caps the number of Ethereum JSON-RPC requests a Mesh node will make
-	// per 24hr UTC time window (time window starts and ends at 12am UTC). It defaults to the 100k limit on
-	// Infura's free tier but can be increased well beyond this limit for those using alternative infra/plans.
-	EthereumRPCMaxRequestsPer24HrUTC int `envvar:"ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC" default:"100000"`
+	// per 24hr UTC time window (time window starts and ends at midnight UTC). It defaults to 200k but
+	// can be increased well beyond this limit depending on your infrastructure or Ethereum RPC provider.
+	EthereumRPCMaxRequestsPer24HrUTC int `envvar:"ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC" default:"200000"`
 	// EthereumRPCMaxRequestsPerSecond caps the number of Ethereum JSON-RPC requests a Mesh node will make per
 	// second. This limits the concurrency of these requests and prevents the Mesh node from getting rate-limited.
 	// It defaults to the recommended 30 rps for Infura's free tier, and can be increased to 100 rpc for pro users,

--- a/ethereum/ratelimit/rate_limiter.go
+++ b/ethereum/ratelimit/rate_limiter.go
@@ -3,7 +3,6 @@ package ratelimit
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -13,10 +12,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/syndtr/goleveldb/leveldb"
 	"golang.org/x/time/rate"
-)
-
-const (
-	lowestPossibleMaxRequestsPer24Hrs = 40000
 )
 
 var ErrTooManyRequestsIn24Hours = errors.New("too many Ethereum RPC requests have been sent this 24 hour period")
@@ -44,10 +39,6 @@ type rateLimiter struct {
 
 // New instantiates a new RateLimiter
 func New(maxRequestsPer24Hrs int, maxRequestsPerSecond float64, meshDB *meshdb.MeshDB, aClock clock.Clock) (RateLimiter, error) {
-	if maxRequestsPer24Hrs < lowestPossibleMaxRequestsPer24Hrs {
-		return nil, fmt.Errorf("EthereumRPCMaxRequestsPer24HrUTC too low. Should be at least %d", lowestPossibleMaxRequestsPer24Hrs)
-	}
-
 	metadata, err := meshDB.GetMetadata()
 	if err != nil {
 		return nil, err

--- a/ethereum/ratelimit/rate_limiter.go
+++ b/ethereum/ratelimit/rate_limiter.go
@@ -16,10 +16,6 @@ import (
 )
 
 const (
-	// maxRequestsPer24HrsBuffer is the buffer subtracted from the operator supplied
-	// maxRequestsPer24Hrs. This buffer helps ensure that we don't overstep the desired
-	// max number of requests.
-	maxRequestsPer24HrsBuffer         = 1000
 	lowestPossibleMaxRequestsPer24Hrs = 40000
 )
 
@@ -47,12 +43,10 @@ type rateLimiter struct {
 }
 
 // New instantiates a new RateLimiter
-func New(maxRequestsPer24HrsWithoutBuffer int, maxRequestsPerSecond float64, meshDB *meshdb.MeshDB, aClock clock.Clock) (RateLimiter, error) {
-	if maxRequestsPer24HrsWithoutBuffer < lowestPossibleMaxRequestsPer24Hrs {
+func New(maxRequestsPer24Hrs int, maxRequestsPerSecond float64, meshDB *meshdb.MeshDB, aClock clock.Clock) (RateLimiter, error) {
+	if maxRequestsPer24Hrs < lowestPossibleMaxRequestsPer24Hrs {
 		return nil, fmt.Errorf("EthereumRPCMaxRequestsPer24HrUTC too low. Should be at least %d", lowestPossibleMaxRequestsPer24Hrs)
 	}
-	// Reduce the requested maxRequestsPer24Hrs by maxRequestsPer24HrsBuffer out of extra precaution
-	maxRequestsPer24Hrs := maxRequestsPer24HrsWithoutBuffer - maxRequestsPer24HrsBuffer
 
 	metadata, err := meshDB.GetMetadata()
 	if err != nil {

--- a/ethereum/ratelimit/rate_limiter.go
+++ b/ethereum/ratelimit/rate_limiter.go
@@ -105,7 +105,7 @@ func (r *rateLimiter) Start(ctx context.Context, checkpointInterval time.Duratio
 			case <-ctx.Done():
 				return
 			case <-r.aClock.After(untilNextUTCCheckpoint):
-				// Reset the number of requests granted and the set the next UTC
+				// Reset the number of requests granted and set the next UTC
 				// checkpoint.
 				r.mu.Lock()
 				r.currentUTCCheckpoint = nextUTCCheckpoint

--- a/ethereum/ratelimit/rate_limiter_test.go
+++ b/ethereum/ratelimit/rate_limiter_test.go
@@ -15,41 +15,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	maxRequestsPer24HrsWithoutBuffer      = 301000
-	maxRequestsPer24hrs                   = maxRequestsPer24HrsWithoutBuffer - maxRequestsPer24HrsBuffer
-	maxRequestsPerSecond                  = 10.0
-	twentyFourHrs                         = 24 * time.Hour
-	maxExpectedDelay                      = twentyFourHrs / time.Duration(maxRequestsPer24hrs)
-	minExpectedDelay                      = 1 * time.Second / time.Duration(maxRequestsPerSecond)
-	defaultCheckpointInterval             = 1 * time.Minute
-	expectedMaxElapsedTimeForFirstRequest = 1 * time.Millisecond
-	expectedDeltaMinExpectedDelay         = 20 * time.Millisecond
-	expectedDeltaMaxExpectedDelay         = 20 * time.Millisecond
+const (
+	defaultMaxRequestsPer24HrsWithoutBuffer = 100000
+	defaultMaxRequestsPerSecond             = 10.0
+	defaultCheckpointInterval               = 1 * time.Minute
+	grantTimingTolerance                    = 15 * time.Millisecond
 )
 
-// Scenario1: Mesh starts X seconds after UTC midnight (start of next UTC day) and
-// therefore there are Y request grants that have accrued. This test verifies that
-// the first request is granted immediately, the next Y - 1 grants are issued at the
-// expected minimum rate imposed by the per second rate, and all subsequent requests
-// are issued at the max rate imposed by the per 24hr rate limit.
+// Scenario1: If the 24 hour limit has not been hit, requests should be granted
+// based on the per second limiter.
 func TestScenario1(t *testing.T) {
 	meshDB, err := meshdb.New("/tmp/meshdb_testing/" + uuid.New().String())
 	require.NoError(t, err)
 	defer meshDB.Close()
-
 	initMetadata(t, meshDB)
 
-	// Set mock clock to three grants past UTC midnight
+	// Set up some constants for this test.
+	const maxRequestsPer24HrsWithoutBuffer = 100000
+	const maxRequestsPerSecond = 10
+
+	// Set mock clock to UTC midnight
 	aClock := clock.NewMock()
-	now := time.Now()
-	midnightUTC := GetUTCMidnightOfDate(now)
-	threeGrantsPastUTCMidnight := midnightUTC.Add(maxExpectedDelay * 3)
-	aClock.Set(threeGrantsPastUTCMidnight)
+	aClock.Set(GetUTCMidnightOfDate(time.Now()))
 
 	rateLimiter, err := New(maxRequestsPer24HrsWithoutBuffer, maxRequestsPerSecond, meshDB, aClock)
 	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -58,52 +49,47 @@ func TestScenario1(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	for i := 0; i < 5; i++ {
-		now := time.Now()
-		ctx := context.Background()
-		err = rateLimiter.Wait(ctx)
-		require.NoError(t, err)
-		elapsed := time.Since(now)
-
-		// First request goes through immediately
-		if i == 0 {
-			assert.True(t, elapsed < expectedMaxElapsedTimeForFirstRequest, "First request did not get granted immediately")
-		} else if i > 0 && i <= 3 {
-			// Subsequent requests take 1sec / maxRequestsPerSecond
-			// Note: Despite initially waiting for 3 grants to accrue, by
-			// the time we request the 4th, another has accrued.
-			delta := math.Abs(float64(minExpectedDelay - elapsed))
-			assert.True(t, time.Duration(delta) < expectedDeltaMinExpectedDelay, "Delta between minExpectedDelay and rate limit delay too large")
-		} else {
-			// Subsequent requests take 24hrs / maxRequestsPer24hrs
-			delta := math.Abs(float64(maxExpectedDelay - elapsed))
-			assert.True(t, time.Duration(delta) < expectedDeltaMaxExpectedDelay, "Delta between maxExpectedDelay and rate limit delay too large")
-		}
-	}
+	// First maxRequestsPerSecond should be granted pretty much immediately.
+	expectRequestsGranted(t, rateLimiter, int(maxRequestsPerSecond), 0, grantTimingTolerance)
+	// Next 5 requests should be granted after 1s / maxRequestsPerSecond
+	expectedDelay := (1 * time.Second) / time.Duration(maxRequestsPerSecond)
+	expectRequestsGranted(t, rateLimiter, 5, expectedDelay-grantTimingTolerance, expectedDelay+grantTimingTolerance)
 
 	cancel()
 	wg.Wait()
 }
 
-// Scenario 2: Request grants have accrued but after 12am UTC, they get cleared
-// and a new day starts
+// Scenario 2: Max requests per 24 hours used up. Subsequent calls to Wait
+// should return an error.
 func TestScenario2(t *testing.T) {
 	meshDB, err := meshdb.New("/tmp/meshdb_testing/" + uuid.New().String())
 	require.NoError(t, err)
 	defer meshDB.Close()
 
-	initMetadata(t, meshDB)
-
-	// Set mock clock close to end of current UTC day
-	aClock := clock.NewMock()
 	now := time.Now()
-	midnightUTC := GetUTCMidnightOfDate(now)
-	rightBeforeMidnight := midnightUTC.Add(twentyFourHrs - (500 * time.Millisecond))
-	aClock.Set(rightBeforeMidnight)
+	startOfCurrentUTCDay := GetUTCMidnightOfDate(now)
+	requestsRemainingInCurrentDay := 10
+	requestsSentInCurrentDay := defaultMaxRequestsPer24HrsWithoutBuffer - maxRequestsPer24HrsBuffer - requestsRemainingInCurrentDay
 
-	rateLimiter, err := New(maxRequestsPer24HrsWithoutBuffer, maxRequestsPerSecond, meshDB, aClock)
+	// Set metadata to just short of maximum requests per 24 hours.
+	metadata := &meshdb.Metadata{
+		EthereumChainID:                   1337,
+		MaxExpirationTime:                 constants.UnlimitedExpirationTime,
+		StartOfCurrentUTCDay:              startOfCurrentUTCDay,
+		EthRPCRequestsSentInCurrentUTCDay: requestsSentInCurrentDay,
+	}
+	err = meshDB.SaveMetadata(metadata)
 	require.NoError(t, err)
-	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start a new rate limiter and set time to a few hours past midnight.
+	// We set the max requests per second extremely high here because it's not
+	// what we're trying to test.
+	aClock := clock.NewMock()
+	aClock.Set(startOfCurrentUTCDay.Add(3 * time.Hour))
+	rateLimiter, err := New(defaultMaxRequestsPer24HrsWithoutBuffer, math.MaxFloat64, meshDB, aClock)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -112,57 +98,17 @@ func TestScenario2(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	// Prior to re-setting the bucket for the next day, grant requests
-	// should happen according to the second rate (since many are queued)
-	for i := 0; i < 2; i++ {
-		now := time.Now()
-		ctx := context.Background()
-		err = rateLimiter.Wait(ctx)
-		require.NoError(t, err)
-		elapsed := time.Since(now)
+	// Up until we reach the 24 hour limit, requests should be granted pretty much
+	// immediately.
+	expectRequestsGranted(t, rateLimiter, requestsRemainingInCurrentDay, 0, grantTimingTolerance)
 
-		// First request goes through immediately
-		if i == 0 {
-			assert.True(t, elapsed < expectedMaxElapsedTimeForFirstRequest, "First request did not get granted immediately")
-		} else {
-			// Subsequent requests take 1sec / maxRequestsPerSecond
-			// Note: Despite initially waiting for 3 grants to accrue, by
-			// the time we request the 4th, another has accrued.
-			delta := math.Abs(float64(minExpectedDelay - elapsed))
-			assert.True(t, time.Duration(delta) < expectedDeltaMinExpectedDelay, "Delta between minExpectedDelay and rate limit delay too large")
-		}
-	}
-
-	// Move time forward by 500ms
-	// NOTE: This does not move time forward within the rate.Limiter instances
-	// we use. They unfortunately don't expose their internal clock to us
-	aClock.Add(500 * time.Millisecond)
-
-	// After moving into the next UTC day, the accrued grant requests should have been
-	// cleared, causing subsequent requests to happen according to the 24hr rate (since
-	// none are queued)
-	for i := 0; i < 3; i++ {
-		now := time.Now()
-		ctx := context.Background()
-		err = rateLimiter.Wait(ctx)
-		require.NoError(t, err)
-		elapsed := time.Since(now)
-
-		// First request takes 500 extra miliseconds because the clock within rate.Limiter
-		// is actually 500ms behind. This means the RateLimiter will attempt to
-		// empty the bucket AS IF the 500ms has passed, but because it hasn't, we will
-		// wait 500ms for those last grants to accrue before the bucket can clear.
-		// The remaining time is close to what we'd expect from an empty bucket the needs
-		// refilling.
-		if i == 0 {
-			expectedDuration := (500 * time.Millisecond) + maxExpectedDelay
-			delta := elapsed - expectedDuration
-			assert.True(t, delta < expectedDuration/10, "Delta between expected and elapsed duration too large")
-		} else {
-			// Subsequent requests take 24hrs / maxRequestsPer24hrs
-			delta := math.Abs(float64(maxExpectedDelay - elapsed))
-			assert.True(t, time.Duration(delta) < expectedDeltaMaxExpectedDelay, "Delta between maxExpectedDelay and rate limit delay too large")
-		}
+	// Subsequent reuqests should result in ErrTooManyRequestsIn24Hours
+	for i := 0; i < 5; i++ {
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer waitCancel()
+		err := rateLimiter.Wait(waitCtx)
+		require.Error(t, err, "expected ErrTooManyRequestsIn24Hours")
+		assert.Equal(t, ErrTooManyRequestsIn24Hours.Error(), err.Error(), "wrong error message")
 	}
 
 	cancel()
@@ -193,30 +139,36 @@ func TestScenario3(t *testing.T) {
 	require.NoError(t, err)
 
 	aClock := clock.NewMock()
-	rateLimiter, err := New(maxRequestsPer24HrsWithoutBuffer, maxRequestsPerSecond, meshDB, aClock)
+	aClock.Set(now)
+	rateLimiter, err := New(defaultMaxRequestsPer24HrsWithoutBuffer, defaultMaxRequestsPerSecond, meshDB, aClock)
 	require.NoError(t, err)
 
 	// Check that grant count and currentUTCCheckpoint were reset during instantiation
 	assert.Equal(t, 0, rateLimiter.getGrantedInLast24hrsUTC())
-	now = aClock.Now()
-	expectedCurrentUTCCheckpoint := GetUTCMidnightOfDate(now)
+	expectedCurrentUTCCheckpoint := GetUTCMidnightOfDate(aClock.Now())
 	assert.Equal(t, expectedCurrentUTCCheckpoint, rateLimiter.getCurrentUTCCheckpoint())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	checkpointInterval := 200 * time.Millisecond
+	// Start the rateLimiter
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := rateLimiter.Start(ctx, checkpointInterval)
+		err := rateLimiter.Start(ctx, defaultCheckpointInterval)
 		require.NoError(t, err)
 	}()
 
-	// Grant a request
-	err = rateLimiter.Wait(ctx)
-	require.NoError(t, err)
+	// Grant a request. It should be granted immediately.
+	expectRequestsGranted(t, rateLimiter, 1, 0, 5*time.Millisecond)
 
-	time.Sleep(checkpointInterval + 50*time.Millisecond)
+	// Wait for rate-limiter background process to start.
+	time.Sleep(10 * time.Millisecond)
+
+	// Advance time past the checkpointInterval
+	aClock.Add(defaultCheckpointInterval + 1*time.Millisecond)
+
+	// Wait for the metadata to be updated.
+	time.Sleep(50 * time.Millisecond)
 
 	// Check metadata was stored in DB
 	metadata, err = meshDB.GetMetadata()
@@ -247,7 +199,7 @@ func TestScenario4(t *testing.T) {
 
 	// If we are not properly converting times to UTC, instantiation will fail with err
 	// `Wait(n=450000) exceeds limiter's burst 300000`
-	_, err = New(maxRequestsPer24HrsWithoutBuffer, maxRequestsPerSecond, meshDB, aClock)
+	_, err = New(defaultMaxRequestsPer24HrsWithoutBuffer, defaultMaxRequestsPerSecond, meshDB, aClock)
 	require.NoError(t, err)
 }
 
@@ -258,4 +210,17 @@ func initMetadata(t *testing.T, meshDB *meshdb.MeshDB) {
 	}
 	err := meshDB.SaveMetadata(metadata)
 	require.NoError(t, err)
+}
+
+func expectRequestsGranted(t *testing.T, rateLimiter RateLimiter, numRequests int, minDelay time.Duration, maxDelay time.Duration) {
+	for i := 0; i < numRequests; i++ {
+		now := time.Now()
+		ctx, cancel := context.WithTimeout(context.Background(), maxDelay)
+		defer cancel()
+		err := rateLimiter.Wait(ctx)
+		require.NoError(t, err, "waited too long to grant request %d", i)
+		elapsed := time.Since(now)
+		assert.True(t, elapsed <= maxDelay, "waited too long to grant request %d", i)
+		assert.True(t, elapsed >= minDelay, "request %d was granted too quickly", i)
+	}
 }

--- a/ethereum/ratelimit/rate_limiter_test.go
+++ b/ethereum/ratelimit/rate_limiter_test.go
@@ -19,9 +19,9 @@ var (
 	maxRequestsPer24HrsWithoutBuffer      = 301000
 	maxRequestsPer24hrs                   = maxRequestsPer24HrsWithoutBuffer - maxRequestsPer24HrsBuffer
 	maxRequestsPerSecond                  = 10.0
-	twentyFourHrs                         = (24 * 60 * 60 * 1000 * time.Millisecond)
+	twentyFourHrs                         = 24 * time.Hour
 	maxExpectedDelay                      = twentyFourHrs / time.Duration(maxRequestsPer24hrs)
-	minExpectedDelay                      = time.Duration(1000) / time.Duration(maxRequestsPerSecond) * time.Millisecond
+	minExpectedDelay                      = 1 * time.Second / time.Duration(maxRequestsPerSecond)
 	defaultCheckpointInterval             = 1 * time.Minute
 	expectedMaxElapsedTimeForFirstRequest = 1 * time.Millisecond
 	expectedDeltaMinExpectedDelay         = 20 * time.Millisecond

--- a/ethereum/ratelimit/rate_limiter_test.go
+++ b/ethereum/ratelimit/rate_limiter_test.go
@@ -23,7 +23,7 @@ const (
 	// grantTimingTolerance is the maximum allowed difference between the expected
 	// time for a request to be granted and the actual time it is granted. Used
 	// throughout these tests to account for subtle timing differences.
-	grantTimingTolerance = 15 * time.Millisecond
+	grantTimingTolerance = 20 * time.Millisecond
 )
 
 // Scenario1: If the 24 hour limit has *not* been hit, requests should be

--- a/ethereum/ratelimit/rate_limiter_test.go
+++ b/ethereum/ratelimit/rate_limiter_test.go
@@ -106,7 +106,7 @@ func TestScenario2(t *testing.T) {
 	// immediately.
 	expectRequestsGranted(t, rateLimiter, requestsRemainingInCurrentDay, 0, grantTimingTolerance)
 
-	// Subsequent reuqests should result in ErrTooManyRequestsIn24Hours
+	// Subsequent requests should result in ErrTooManyRequestsIn24Hours
 	for i := 0; i < 5; i++ {
 		waitCtx, waitCancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer waitCancel()

--- a/ethereum/ratelimit/rate_limiter_test.go
+++ b/ethereum/ratelimit/rate_limiter_test.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	defaultMaxRequestsPer24HrsWithoutBuffer = 100000
-	defaultMaxRequestsPerSecond             = 10.0
-	defaultCheckpointInterval               = 1 * time.Minute
-	grantTimingTolerance                    = 15 * time.Millisecond
+	defaultMaxRequestsPer24Hrs  = 100000
+	defaultMaxRequestsPerSecond = 10.0
+	defaultCheckpointInterval   = 1 * time.Minute
+	grantTimingTolerance        = 15 * time.Millisecond
 )
 
 // Scenario1: If the 24 hour limit has not been hit, requests should be granted
@@ -31,14 +31,14 @@ func TestScenario1(t *testing.T) {
 	initMetadata(t, meshDB)
 
 	// Set up some constants for this test.
-	const maxRequestsPer24HrsWithoutBuffer = 100000
+	const maxRequestsPer24Hrs = 100000
 	const maxRequestsPerSecond = 10
 
 	// Set mock clock to UTC midnight
 	aClock := clock.NewMock()
 	aClock.Set(GetUTCMidnightOfDate(time.Now()))
 
-	rateLimiter, err := New(maxRequestsPer24HrsWithoutBuffer, maxRequestsPerSecond, meshDB, aClock)
+	rateLimiter, err := New(maxRequestsPer24Hrs, maxRequestsPerSecond, meshDB, aClock)
 	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	wg := &sync.WaitGroup{}
@@ -69,7 +69,7 @@ func TestScenario2(t *testing.T) {
 	now := time.Now()
 	startOfCurrentUTCDay := GetUTCMidnightOfDate(now)
 	requestsRemainingInCurrentDay := 10
-	requestsSentInCurrentDay := defaultMaxRequestsPer24HrsWithoutBuffer - maxRequestsPer24HrsBuffer - requestsRemainingInCurrentDay
+	requestsSentInCurrentDay := defaultMaxRequestsPer24Hrs - requestsRemainingInCurrentDay
 
 	// Set metadata to just short of maximum requests per 24 hours.
 	metadata := &meshdb.Metadata{
@@ -86,7 +86,7 @@ func TestScenario2(t *testing.T) {
 	// what we're trying to test.
 	aClock := clock.NewMock()
 	aClock.Set(startOfCurrentUTCDay.Add(3 * time.Hour))
-	rateLimiter, err := New(defaultMaxRequestsPer24HrsWithoutBuffer, math.MaxFloat64, meshDB, aClock)
+	rateLimiter, err := New(defaultMaxRequestsPer24Hrs, math.MaxFloat64, meshDB, aClock)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -140,7 +140,7 @@ func TestScenario3(t *testing.T) {
 
 	aClock := clock.NewMock()
 	aClock.Set(now)
-	rateLimiter, err := New(defaultMaxRequestsPer24HrsWithoutBuffer, defaultMaxRequestsPerSecond, meshDB, aClock)
+	rateLimiter, err := New(defaultMaxRequestsPer24Hrs, defaultMaxRequestsPerSecond, meshDB, aClock)
 	require.NoError(t, err)
 
 	// Check that grant count and currentUTCCheckpoint were reset during instantiation
@@ -199,7 +199,7 @@ func TestScenario4(t *testing.T) {
 
 	// If we are not properly converting times to UTC, instantiation will fail with err
 	// `Wait(n=450000) exceeds limiter's burst 300000`
-	_, err = New(defaultMaxRequestsPer24HrsWithoutBuffer, defaultMaxRequestsPerSecond, meshDB, aClock)
+	_, err = New(defaultMaxRequestsPer24Hrs, defaultMaxRequestsPerSecond, meshDB, aClock)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This PR simplifies our implementation of Ethereum RPC rate limiting in order to address some potential bugs and make it easier to test. In general, it also loosens the restrictions of the rate limiter to make it less likely to affect non-spammers under normal network conditions.

This is most likely a fix for #585.

Summary of changes:

1. Removed the `rate.Limiter` that was used to enforce `ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC`. This limit is now enforced via a simple counter which is reset every UTC midnight. This greatly simplifies our implementation and makes it easier to write tests. It also reduces the chances of artificially limiting the rate of requests for non-spammers (especially around UTC midnight). But it does come with the downside of not guaranteeing that RPC requests will be evenly distributed throughout the 24 hour period.
2. Removed the buffer for `maxRequestsPer24Hrs`. The consequences for exceeding this limit are usually not severe, so we feel the buffer is no longer necessary.
3. Removed the `lowestPossibleMaxRequestsPer24Hrs` constraint. We already have a check in the `core` package to prevent you from setting `ETHEREUM_RPC_MAX_REQUESTS_PER_24_HR_UTC` too low based on `BLOCK_POLLING_INTERVAL`.
4. Added a small burst to the per second `rate.Limiter`. Currently set to `maxRequestsPerSecond/2`. IMO the old implementation which set the burst to `1` was too restrictive. It guaranteed that we would never exceed `maxRequestsPerSecond` for any one second period but also enforced a _minimum delay_ of `1/maxRequestsPerSecond` seconds between subsequent requests. This delay was enforced even after long periods of not sending any requests. This works out to 30ms with the default settings, which is nearly twice the median response time for some Ethereum hosting providers (our Alchemy dashboard is showing 16ms). This can be a significant delay for some time-sensitive/performance-sensitive use cases.