### PR TITLE
Log error when validationResults contains unknown order hash

### DIFF
--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1005,7 +1005,11 @@ func (w *Watcher) generateOrderEventsIfChanged(ctx context.Context, ordersColTxn
 	for _, acceptedOrderInfo := range validationResults.Accepted {
 		order, found := orderHashToDBOrder[acceptedOrderInfo.OrderHash]
 		if !found {
-			logger.WithField("orderHash", acceptedOrderInfo.OrderHash).Error("validationResults.Accepted contained unknown order hash")
+			logger.WithFields(logger.Fields{
+				"unknownOrderHash":   acceptedOrderInfo.OrderHash,
+				"validationResults":  validationResults,
+				"orderHashToDBOrder": orderHashToDBOrder,
+			}).Error("validationResults.Accepted contained unknown order hash")
 			continue
 		}
 		oldFillableAmount := order.FillableTakerAssetAmount
@@ -1063,7 +1067,11 @@ func (w *Watcher) generateOrderEventsIfChanged(ctx context.Context, ordersColTxn
 		case ordervalidator.ZeroExValidation:
 			order, found := orderHashToDBOrder[rejectedOrderInfo.OrderHash]
 			if !found {
-				logger.WithField("orderHash", rejectedOrderInfo.OrderHash).Error("validationResults.Rejected contained unknown order hash")
+				logger.WithFields(logger.Fields{
+					"unknownOrderHash":   rejectedOrderInfo.OrderHash,
+					"validationResults":  validationResults,
+					"orderHashToDBOrder": orderHashToDBOrder,
+				}).Error("validationResults.Rejected contained unknown order hash")
 				continue
 			}
 			oldFillableAmount := order.FillableTakerAssetAmount

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1003,7 +1003,11 @@ func (w *Watcher) generateOrderEventsIfChanged(ctx context.Context, ordersColTxn
 
 	orderEvents := []*zeroex.OrderEvent{}
 	for _, acceptedOrderInfo := range validationResults.Accepted {
-		order := orderHashToDBOrder[acceptedOrderInfo.OrderHash]
+		order, found := orderHashToDBOrder[acceptedOrderInfo.OrderHash]
+		if !found {
+			logger.WithField("orderHash", acceptedOrderInfo.OrderHash).Error("validationResults.Accepted contained unknown order hash")
+			continue
+		}
 		oldFillableAmount := order.FillableTakerAssetAmount
 		newFillableAmount := acceptedOrderInfo.FillableTakerAssetAmount
 		oldAmountIsMoreThenNewAmount := oldFillableAmount.Cmp(newFillableAmount) == 1
@@ -1057,7 +1061,11 @@ func (w *Watcher) generateOrderEventsIfChanged(ctx context.Context, ordersColTxn
 		case ordervalidator.MeshError:
 			// TODO(fabio): Do we want to handle MeshErrors somehow here?
 		case ordervalidator.ZeroExValidation:
-			order := orderHashToDBOrder[rejectedOrderInfo.OrderHash]
+			order, found := orderHashToDBOrder[rejectedOrderInfo.OrderHash]
+			if !found {
+				logger.WithField("orderHash", rejectedOrderInfo.OrderHash).Error("validationResults.Rejected contained unknown order hash")
+				continue
+			}
 			oldFillableAmount := order.FillableTakerAssetAmount
 			if oldFillableAmount.Cmp(big.NewInt(0)) == 0 {
 				// If the oldFillableAmount was already 0, this order is already flagged for removal.


### PR DESCRIPTION
See https://github.com/0xProject/0x-mesh/issues/583. The nil pointer exception appears to be occurring because `validationResults` contains an order but that order's hash is not found in `orderHashToDBOrder`.

I took a look at the code path, and I couldn't determine why this might be the case. This PR doesn't fix the underlying issue, but it does log the order hash and stop us from panicking which can help us understand what's going on.