### PR TITLE
zeroex,rpc,browser: Add Timestamp to OrderEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 - Added a new environment variable `ENABLE_ETHEREUM_RPC_RATE_LIMITING` and config option `enableEthereumRPCRateLimiting` which can be used to completely disable Mesh's internal Ethereum RPC rate limiting features. By default it is enabled, and disabling can have some consequences depending on your RPC provider. ([#584](https://github.com/0xProject/0x-mesh/pull/584))
 - Added a `SnapshotTimestamp` field to `GetOrdersResponse`, the return type of the `mesh_getOrders` RPC method. This way, the caller can know at what point in time the snapshot had been created. ([#591](https://github.com/0xProject/0x-mesh/pull/591))
 - Improved batching of events emitted from order events subscriptions ([#566](https://github.com/0xProject/0x-mesh/pull/566))
+- Added timestamp to order events ([#602](https://github.com/0xProject/0x-mesh/pull/602))
 
 ### Bug fixes 🐞
 

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -458,7 +458,7 @@ interface WrapperOrderEvent {
  * or filled.
  */
 export interface OrderEvent {
-    timestamp: number;
+    timestampMs: number;
     orderHash: string;
     signedOrder: SignedOrder;
     endState: OrderEventEndState;
@@ -844,8 +844,7 @@ function signedOrderToWrapperSignedOrder(signedOrder: SignedOrder): WrapperSigne
 function wrapperOrderEventToOrderEvent(wrapperOrderEvent: WrapperOrderEvent): OrderEvent {
     return {
         ...wrapperOrderEvent,
-        // tslint:disable-next-line:custom-no-magic-numbers
-        timestamp: Math.round(new Date(wrapperOrderEvent.timestamp).getTime() / 1000),
+        timestampMs: new Date(wrapperOrderEvent.timestamp).getTime(),
         signedOrder: wrapperSignedOrderToSignedOrder(wrapperOrderEvent.signedOrder),
         fillableTakerAssetAmount: new BigNumber(wrapperOrderEvent.fillableTakerAssetAmount),
         contractEvents: wrapperContractEventsToContractEvents(wrapperOrderEvent.contractEvents),

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -445,6 +445,7 @@ export enum OrderEventEndState {
 }
 
 interface WrapperOrderEvent {
+    timestamp: string;
     orderHash: string;
     signedOrder: WrapperSignedOrder;
     endState: OrderEventEndState;
@@ -457,6 +458,7 @@ interface WrapperOrderEvent {
  * or filled.
  */
 export interface OrderEvent {
+    timestamp: number;
     orderHash: string;
     signedOrder: SignedOrder;
     endState: OrderEventEndState;
@@ -842,6 +844,8 @@ function signedOrderToWrapperSignedOrder(signedOrder: SignedOrder): WrapperSigne
 function wrapperOrderEventToOrderEvent(wrapperOrderEvent: WrapperOrderEvent): OrderEvent {
     return {
         ...wrapperOrderEvent,
+        // tslint:disable-next-line:custom-no-magic-numbers
+        timestamp: Math.round(new Date(wrapperOrderEvent.timestamp).getTime() / 1000),
         signedOrder: wrapperSignedOrderToSignedOrder(wrapperOrderEvent.signedOrder),
         fillableTakerAssetAmount: new BigNumber(wrapperOrderEvent.fillableTakerAssetAmount),
         contractEvents: wrapperContractEventsToContractEvents(wrapperOrderEvent.contractEvents),

--- a/integration-tests/rpc_integration_test.go
+++ b/integration-tests/rpc_integration_test.go
@@ -303,21 +303,16 @@ func TestOrdersSubscription(t *testing.T) {
 
 	// Ensure that the "AddOrders" request triggered an order event that was
 	// passed through the subscription.
-	orderEvent := <-orderEventChan
+	orderEvents := <-orderEventChan
 	signedTestOrder.ResetHash()
 	expectedFillableTakerAssetAmount := signedTestOrder.TakerAssetAmount
-	assert.EqualValues(t,
-		[]*zeroex.OrderEvent{
-			&zeroex.OrderEvent{
-				OrderHash:                expectedOrderHash,
-				SignedOrder:              signedTestOrder,
-				EndState:                 zeroex.ESOrderAdded,
-				FillableTakerAssetAmount: expectedFillableTakerAssetAmount,
-				ContractEvents:           []*zeroex.ContractEvent{},
-			},
-		},
-		orderEvent,
-	)
+	assert.Len(t, orderEvents, 1)
+	orderEvent := orderEvents[0]
+	assert.Equal(t, expectedOrderHash, orderEvent.OrderHash)
+	assert.Equal(t, signedTestOrder, orderEvent.SignedOrder)
+	assert.Equal(t, zeroex.ESOrderAdded, orderEvent.EndState)
+	assert.Equal(t, expectedFillableTakerAssetAmount, orderEvent.FillableTakerAssetAmount)
+	assert.Equal(t, []*zeroex.ContractEvent{}, orderEvent.ContractEvents)
 }
 
 func TestHeartbeatSubscription(t *testing.T) {

--- a/rpc/clients/typescript/src/types.ts
+++ b/rpc/clients/typescript/src/types.ts
@@ -312,7 +312,7 @@ export interface RawOrderEvent {
 }
 
 export interface OrderEvent {
-    timestamp: number;
+    timestampMs: number;
     orderHash: string;
     signedOrder: SignedOrder;
     endState: OrderEventEndState;

--- a/rpc/clients/typescript/src/types.ts
+++ b/rpc/clients/typescript/src/types.ts
@@ -303,6 +303,7 @@ export interface HeartbeatEventPayload {
 }
 
 export interface RawOrderEvent {
+    timestamp: string;
     orderHash: string;
     signedOrder: StringifiedSignedOrder;
     endState: OrderEventEndState;
@@ -311,6 +312,7 @@ export interface RawOrderEvent {
 }
 
 export interface OrderEvent {
+    timestamp: number;
     orderHash: string;
     signedOrder: SignedOrder;
     endState: OrderEventEndState;

--- a/rpc/clients/typescript/src/ws_client.ts
+++ b/rpc/clients/typescript/src/ws_client.ts
@@ -333,8 +333,7 @@ export class WSClient {
             const orderEvents: OrderEvent[] = [];
             rawOrderEvents.forEach(rawOrderEvent => {
                 const orderEvent = {
-                    // tslint:disable-next-line:custom-no-magic-numbers
-                    timestamp: Math.round(new Date(rawOrderEvent.timestamp).getTime() / 1000),
+                    timestampMs: new Date(rawOrderEvent.timestamp).getTime(),
                     orderHash: rawOrderEvent.orderHash,
                     signedOrder: orderParsingUtils.convertOrderStringFieldsToBigNumber(rawOrderEvent.signedOrder),
                     endState: rawOrderEvent.endState,

--- a/rpc/clients/typescript/src/ws_client.ts
+++ b/rpc/clients/typescript/src/ws_client.ts
@@ -333,6 +333,8 @@ export class WSClient {
             const orderEvents: OrderEvent[] = [];
             rawOrderEvents.forEach(rawOrderEvent => {
                 const orderEvent = {
+                    // tslint:disable-next-line:custom-no-magic-numbers
+                    timestamp: Math.round(new Date(rawOrderEvent.timestamp).getTime() / 1000),
                     orderHash: rawOrderEvent.orderHash,
                     signedOrder: orderParsingUtils.convertOrderStringFieldsToBigNumber(rawOrderEvent.signedOrder),
                     endState: rawOrderEvent.endState,

--- a/rpc/clients/typescript/test/ws_client_test.ts
+++ b/rpc/clients/typescript/test/ws_client_test.ts
@@ -267,6 +267,7 @@ describe('WSClient', () => {
     });
     describe('#subscribeToOrdersAsync', async () => {
         it('should receive subscription updates', (done: DoneCallback) => {
+            const timestamp = '2009-11-10T23:00:00Z';
             (async () => {
                 const wsServer = await setupServerAsync();
                 wsServer.on('connect', ((connection: WebSocket.connection) => {
@@ -304,7 +305,6 @@ describe('WSClient', () => {
                             // tslint:disable-next-line:custom-no-magic-numbers
                             await sleepAsync(100);
 
-                            const timestamp = '2009-11-10T23:00:00Z';
                             const eventResponse = `
                                 {
                                     "jsonrpc":"2.0",
@@ -375,7 +375,7 @@ describe('WSClient', () => {
                         expect(BigNumber.isBigNumber(orderEvents[0].signedOrder.expirationTimeSeconds)).to.equal(true);
                         expect(BigNumber.isBigNumber(orderEvents[0].fillableTakerAssetAmount)).to.equal(true);
                         // tslint:disable-next-line:custom-no-magic-numbers
-                        expect(BigNumber.isBigNumber(orderEvents[0].timestampMs)).to.equal(1257894000);
+                        expect(orderEvents[0].timestampMs).to.equal(new Date(timestamp).getTime());
 
                         client.destroy();
                     },

--- a/rpc/clients/typescript/test/ws_client_test.ts
+++ b/rpc/clients/typescript/test/ws_client_test.ts
@@ -375,7 +375,7 @@ describe('WSClient', () => {
                         expect(BigNumber.isBigNumber(orderEvents[0].signedOrder.expirationTimeSeconds)).to.equal(true);
                         expect(BigNumber.isBigNumber(orderEvents[0].fillableTakerAssetAmount)).to.equal(true);
                         // tslint:disable-next-line:custom-no-magic-numbers
-                        expect(BigNumber.isBigNumber(orderEvents[0].timestamp)).to.equal(1257894000);
+                        expect(BigNumber.isBigNumber(orderEvents[0].timestampMs)).to.equal(1257894000);
 
                         client.destroy();
                     },

--- a/rpc/clients/typescript/test/ws_client_test.ts
+++ b/rpc/clients/typescript/test/ws_client_test.ts
@@ -304,6 +304,7 @@ describe('WSClient', () => {
                             // tslint:disable-next-line:custom-no-magic-numbers
                             await sleepAsync(100);
 
+                            const timestamp = '2009-11-10T23:00:00Z';
                             const eventResponse = `
                                 {
                                     "jsonrpc":"2.0",
@@ -312,6 +313,7 @@ describe('WSClient', () => {
                                         "subscription":"0xc2ba3e8af590364c09d0fa6a12103adb",
                                         "result": [
                                             {
+                                                "timestamp": "${timestamp}",
                                                 "orderHash": "0x96e6eb6174dbf0458686bdae44c9a330d9a9eb563962512a7be545c4ecc13fd4",
                                                 "signedOrder": {
                                                     "makerAddress": "0x50f84bbee6fb250d6f49e854fa280445369d64d9",
@@ -372,6 +374,8 @@ describe('WSClient', () => {
                         expect(BigNumber.isBigNumber(orderEvents[0].signedOrder.salt)).to.equal(true);
                         expect(BigNumber.isBigNumber(orderEvents[0].signedOrder.expirationTimeSeconds)).to.equal(true);
                         expect(BigNumber.isBigNumber(orderEvents[0].fillableTakerAssetAmount)).to.equal(true);
+                        // tslint:disable-next-line:custom-no-magic-numbers
+                        expect(BigNumber.isBigNumber(orderEvents[0].timestamp)).to.equal(1257894000);
 
                         client.destroy();
                     },

--- a/zeroex/order_test.go
+++ b/zeroex/order_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/0xProject/0x-mesh/constants"
 	"github.com/0xProject/0x-mesh/zeroex/orderwatch/decoder"
@@ -55,6 +56,7 @@ func TestMarshalUnmarshalOrderEvent(t *testing.T) {
 	orderHash, err := signedOrder.ComputeOrderHash()
 	require.NoError(t, err)
 	orderEvent := OrderEvent{
+		Timestamp:                time.Now().UTC(),
 		OrderHash:                orderHash,
 		SignedOrder:              signedOrder,
 		EndState:                 ESOrderAdded,


### PR DESCRIPTION
Fixes: #557 

For Mesh-specific events, we use the current UTC time. For on-chain state triggered events, we use the block height at which the order was re-validated.