### PR TITLE
rpc: Add RPC request timeout to default wsOpts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 - Fixed a race-condition when adding new orders to Mesh which could result in order-relevant events being missed if they occured very soon after the order was submitted and the order validation RPC call took a long time ([#566](https://github.com/0xProject/0x-mesh/pull/566)).
 - Upgraded the `web3-provider` dependency used by `@0x/mesh-rpc-client` in order to fix a bug where it was requiring either `process` OR `window` to exist in the global scope ([#601](https://github.com/0xProject/0x-mesh/pull/601)).
 - Fixed an issue where the internal Ethereum RPC rate limiter could be too aggressive in certain scenarios ([#596](https://github.com/0xProject/0x-mesh/pull/596)).
+- Add a default RPC request timeout of 30sec to all non-subscription requests sent by `@0x/mesh-rpc-client` to avoid the client from hanging endlessly if it misses a response due to network disruption ([#603](https://github.com/0xProject/0x-mesh/pull/603)).
 
 
 ## v6.1.2-beta

--- a/rpc/clients/typescript/src/ws_client.ts
+++ b/rpc/clients/typescript/src/ws_client.ts
@@ -45,13 +45,14 @@ const CLOSE_REASON_NO_HEARTBEAT = 3001;
 const CLOSE_DESCRIPTION_NO_HEARTBEAT = 'No heartbeat received';
 
 const DEFAULT_RECONNECT_AFTER_MS = 5000;
+const DEFAULT_RPC_REQUEST_TIMEOUT = 30000;
 const DEFAULT_WS_OPTS = {
     clientConfig: {
         // For some reason fragmenting the payloads causes the connection to close
         // Source: https://github.com/theturtle32/WebSocket-Node/issues/359
         fragmentOutgoingMessages: false,
     },
-    timeout: 30000,
+    timeout: DEFAULT_RPC_REQUEST_TIMEOUT,
     reconnectDelay: DEFAULT_RECONNECT_AFTER_MS,
 };
 

--- a/rpc/clients/typescript/src/ws_client.ts
+++ b/rpc/clients/typescript/src/ws_client.ts
@@ -51,6 +51,7 @@ const DEFAULT_WS_OPTS = {
         // Source: https://github.com/theturtle32/WebSocket-Node/issues/359
         fragmentOutgoingMessages: false,
     },
+    timeout: 30000,
     reconnectAfter: DEFAULT_RECONNECT_AFTER_MS,
 };
 


### PR DESCRIPTION
Fixes: https://github.com/0xProject/0x-mesh/issues/600

Currently if one instantiates a `WSClient` without supplying a custom `wsOpts` param, the client defaults to not having a timeout length on the RPC requests it sends. This is problematic, because during network disruptions, it is possible for the client to miss a response and hang forever. Because of this, we are changing the default to include a 30sec timeout on all non-subscription RPC requests. 