### PR TITLE
orderwatch: Avoid updating orders multiple times in same txn (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 ### Bug fixes 🐞
 
 - Fixed a typo ("rendervouz" --> "rendezvous") in GetStatsResponse. ([#611](https://github.com/0x-mesh/pull/611)).
+- Fix bug where we attempted to update the same order multiple times in a single DB txn, causing the later update to noop. ([#623](https://github.com/0xProject/0x-mesh/pull/623))
 
 ## v8.0.0-beta-0xv3
 

--- a/ethereum/blockchain_lifecycle.go
+++ b/ethereum/blockchain_lifecycle.go
@@ -46,6 +46,9 @@ func (b *BlockchainLifecycle) Revert(t *testing.T) {
 }
 
 // Mine force-mines a block with the specified block timestamp
+// WARNING(fabio): Using this method will brick `eth_getLogs` such that it always
+// returns the logs for the latest block, even if a specific blockHash is specified
+// Source: https://github.com/trufflesuite/ganache-cli/issues/708
 func (b *BlockchainLifecycle) Mine(t *testing.T, blockTimestamp time.Time) {
 	var didForceMine string
 	err := b.rpcClient.Call(&didForceMine, "evm_mine", blockTimestamp.Unix())

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -342,6 +342,10 @@ func (w *Watcher) removedCheckerLoop(ctx context.Context) error {
 	}
 }
 
+// handleOrderExpirations takes care of generating expired and unexpired order events for orders that do not require re-validation.
+// Since expiry is now done according to block timestamp, we can figure out which orders have expired/unexpired statically. We do not
+// process blocks that require re-validation, since the validation process will already emit the necessary events and we cannot make
+// multiple updates to an order within a single DB transaction.
 func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlockTimestamp, previousLatestBlockTimestamp time.Time, ordersToRevalidate map[common.Hash]*meshdb.Order) ([]*zeroex.OrderEvent, error) {
 	orderEvents := []*zeroex.OrderEvent{}
 	var defaultTime time.Time

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -342,7 +342,7 @@ func (w *Watcher) removedCheckerLoop(ctx context.Context) error {
 	}
 }
 
-func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlockTimestamp time.Time, previousLatestBlockTimestamp time.Time) ([]*zeroex.OrderEvent, error) {
+func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlockTimestamp, previousLatestBlockTimestamp time.Time, ordersToRevalidate map[common.Hash]*meshdb.Order) ([]*zeroex.OrderEvent, error) {
 	orderEvents := []*zeroex.OrderEvent{}
 	var defaultTime time.Time
 
@@ -350,6 +350,11 @@ func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlo
 		expiredOrders := w.expirationWatcher.Prune(latestBlockTimestamp)
 		for _, expiredOrder := range expiredOrders {
 			orderHash := common.HexToHash(expiredOrder.ID)
+			// If we will re-validate this order, the revalidation process will discover that
+			// it's expired, and an appropriate event will already be emitted
+			if _, ok := ordersToRevalidate[orderHash]; ok {
+				continue
+			}
 			order := &meshdb.Order{}
 			err := w.meshDB.Orders.FindByID(orderHash.Bytes(), order)
 			if err != nil {
@@ -381,6 +386,11 @@ func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlo
 		for _, order := range removedOrders {
 			// Orders removed due to expiration have non-zero FillableTakerAssetAmounts
 			if order.FillableTakerAssetAmount.Cmp(big.NewInt(0)) == 0 {
+				continue
+			}
+			// If we will re-validate this order, the revalidation process will discover that
+			// it's unexpired, and an appropriate event will already be emitted
+			if _, ok := ordersToRevalidate[order.Hash]; ok {
 				continue
 			}
 			expiration := time.Unix(order.SignedOrder.ExpirationTimeSeconds.Int64(), 0)
@@ -434,11 +444,6 @@ func (w *Watcher) handleBlockEvents(
 		previousLatestBlockTimestamp = previousLatestBlock.Timestamp
 	}
 	latestBlockNumber, latestBlockTimestamp := w.getBlockchainState(events)
-
-	expirationOrderEvents, err := w.handleOrderExpirations(ordersColTxn, latestBlockTimestamp, previousLatestBlockTimestamp)
-	if err != nil {
-		return err
-	}
 
 	orderHashToDBOrder := map[common.Hash]*meshdb.Order{}
 	orderHashToEvents := map[common.Hash][]*zeroex.ContractEvent{}
@@ -751,6 +756,11 @@ func (w *Watcher) handleBlockEvents(
 				}
 			}
 		}
+	}
+
+	expirationOrderEvents, err := w.handleOrderExpirations(ordersColTxn, latestBlockTimestamp, previousLatestBlockTimestamp, orderHashToDBOrder)
+	if err != nil {
+		return err
 	}
 
 	// This timeout of 1min is for limiting how long this call should block at the ETH RPC rate limiter
@@ -1142,35 +1152,52 @@ func (w *Watcher) generateOrderEventsIfChanged(
 				ContractEvents:           orderHashToEvents[order.Hash],
 			}
 			orderEvents = append(orderEvents, orderEvent)
-		} else if oldFillableAmount.Cmp(newFillableAmount) == 0 {
-			// No important state-change happened
-		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && oldAmountIsMoreThenNewAmount {
-			// Order was filled, emit event and update order in DB
-			order.FillableTakerAssetAmount = newFillableAmount
-			w.updateOrderDBEntry(ordersColTxn, order)
-			orderEvent := &zeroex.OrderEvent{
-				Timestamp:                validationBlockTimestamp,
-				OrderHash:                acceptedOrderInfo.OrderHash,
-				SignedOrder:              order.SignedOrder,
-				EndState:                 zeroex.ESOrderFilled,
-				FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
-				ContractEvents:           orderHashToEvents[order.Hash],
+		} else {
+			// If order was previously expired, check if it has become unexpired
+			if order.IsRemoved && oldFillableAmount.Cmp(big.NewInt(0)) != 0 {
+				expiration := time.Unix(order.SignedOrder.ExpirationTimeSeconds.Int64(), 0)
+				if validationBlockTimestamp.Before(expiration) {
+					w.rewatchOrder(ordersColTxn, order, order.FillableTakerAssetAmount)
+					orderEvent := &zeroex.OrderEvent{
+						Timestamp:                validationBlockTimestamp,
+						OrderHash:                order.Hash,
+						SignedOrder:              order.SignedOrder,
+						FillableTakerAssetAmount: order.FillableTakerAssetAmount,
+						EndState:                 zeroex.ESOrderUnexpired,
+					}
+					orderEvents = append(orderEvents, orderEvent)
+				}
 			}
-			orderEvents = append(orderEvents, orderEvent)
-		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && !oldAmountIsMoreThenNewAmount {
-			// The order is now fillable for more then it was before. E.g.: A fill txn reverted (block-reorg)
-			// Update order in DB and emit event
-			order.FillableTakerAssetAmount = newFillableAmount
-			w.updateOrderDBEntry(ordersColTxn, order)
-			orderEvent := &zeroex.OrderEvent{
-				Timestamp:                validationBlockTimestamp,
-				OrderHash:                acceptedOrderInfo.OrderHash,
-				SignedOrder:              order.SignedOrder,
-				EndState:                 zeroex.ESOrderFillabilityIncreased,
-				FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
-				ContractEvents:           orderHashToEvents[order.Hash],
+			if oldFillableAmount.Cmp(newFillableAmount) == 0 {
+				// No important state-change happened
+			} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && oldAmountIsMoreThenNewAmount {
+				// Order was filled, emit event and update order in DB
+				order.FillableTakerAssetAmount = newFillableAmount
+				w.updateOrderDBEntry(ordersColTxn, order)
+				orderEvent := &zeroex.OrderEvent{
+					Timestamp:                validationBlockTimestamp,
+					OrderHash:                acceptedOrderInfo.OrderHash,
+					SignedOrder:              order.SignedOrder,
+					EndState:                 zeroex.ESOrderFilled,
+					FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
+					ContractEvents:           orderHashToEvents[order.Hash],
+				}
+				orderEvents = append(orderEvents, orderEvent)
+			} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && !oldAmountIsMoreThenNewAmount {
+				// The order is now fillable for more then it was before. E.g.: A fill txn reverted (block-reorg)
+				// Update order in DB and emit event
+				order.FillableTakerAssetAmount = newFillableAmount
+				w.updateOrderDBEntry(ordersColTxn, order)
+				orderEvent := &zeroex.OrderEvent{
+					Timestamp:                validationBlockTimestamp,
+					OrderHash:                acceptedOrderInfo.OrderHash,
+					SignedOrder:              order.SignedOrder,
+					EndState:                 zeroex.ESOrderFillabilityIncreased,
+					FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
+					ContractEvents:           orderHashToEvents[order.Hash],
+				}
+				orderEvents = append(orderEvents, orderEvent)
 			}
-			orderEvents = append(orderEvents, orderEvent)
 		}
 	}
 	for _, rejectedOrderInfo := range validationResults.Rejected {

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -346,6 +346,9 @@ func (w *Watcher) removedCheckerLoop(ctx context.Context) error {
 // Since expiry is now done according to block timestamp, we can figure out which orders have expired/unexpired statically. We do not
 // process blocks that require re-validation, since the validation process will already emit the necessary events and we cannot make
 // multiple updates to an order within a single DB transaction.
+// latestBlockTimestamp is the latest block timestamp Mesh knows about
+// previousLatestBlockTimestamp is the previous latest block timestamp Mesh knew about
+// ordersToRevalidate contains all the orders Mesh needs to re-validate given the events emitted by the blocks processed
 func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlockTimestamp, previousLatestBlockTimestamp time.Time, ordersToRevalidate map[common.Hash]*meshdb.Order) ([]*zeroex.OrderEvent, error) {
 	orderEvents := []*zeroex.OrderEvent{}
 	var defaultTime time.Time


### PR DESCRIPTION
Fixes: https://github.com/0xProject/0x-mesh/issues/608

Currently it is possible that we attempt to update orders that expire or unexpire twice within the same txn. This causes the second update to noop since our DB txns do not support multiple updates within a single txn. This PR stops this from happening.