### PR TITLE
Increase max order size and create separate max message size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 ### Features ✅
 
-- Increased the maximum size for encoded orders from ~8k to 16k bytes ([#631](https://github.com/0xProject/0x-mesh/pull/631)).
+- Increased the maximum size for encoded orders from ~8kB to 16kB ([#631](https://github.com/0xProject/0x-mesh/pull/631)).
 
 ### Bug fixes 🐞
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
-## v8.0.1
+## v8.1.0
+
+### Features ✅
+
+- Increased the maximum size for encoded orders from ~8k to 16k bytes ([#631](https://github.com/0xProject/0x-mesh/pull/631)).
 
 ### Bug fixes 🐞
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -75,14 +75,27 @@ func init() {
 	UnlimitedExpirationTime, _ = big.NewInt(0).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
 }
 
-// MaxOrderSizeInBytes is the maximum number of bytes allowed for encoded orders. It
-// is more than 10x the size of a typical ERC20 order to account for multiAsset orders.
-const MaxOrderSizeInBytes = 8192
+const (
+	// MaxOrderSizeInBytes is the maximum number of bytes allowed for encoded
+	// orders. It allows for MultiAssetProxy orders with roughly 45 total ERC20
+	// assets or roughly 36 total ERC721 assets (combined between both maker and
+	// taker; depends on the other fields of the order).
+	MaxOrderSizeInBytes = 16000
+	messageOverhead     = len(`{"messageType":"order","Order":}`)
+	// MaxMessageSizeInBytes is the maximum size for messages sent through
+	// GossipSub. It is the max order size plus some overhead for the message
+	// format.
+	MaxMessageSizeInBytes = MaxOrderSizeInBytes + messageOverhead
+)
 
 // MaxBlocksStoredInNonArchiveNode is the max number of historical blocks for which a regular Ethereum
 // node stores archive-level state. One cannot make `eth_call` requests specifying blocks earlier than
 // 128 blocks ago on non-archive nodes.
 const MaxBlocksStoredInNonArchiveNode = 128
 
-// ErrMaxMessageSize is the error emitted when a message exceeds it's max size
-var ErrMaxMessageSize = fmt.Errorf("message exceeds maximum size of %d bytes", MaxOrderSizeInBytes)
+var (
+	// ErrMaxMessageSize is the error emitted when a GossipSub message exceeds the
+	// max size.
+	ErrMaxMessageSize = fmt.Errorf("message exceeds maximum size of %d bytes", MaxMessageSizeInBytes)
+	ErrMaxOrderSize   = fmt.Errorf("order exceeds maximum size of %d bytes", MaxOrderSizeInBytes)
+)

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -94,8 +94,10 @@ const (
 const MaxBlocksStoredInNonArchiveNode = 128
 
 var (
-	// ErrMaxMessageSize is the error emitted when a GossipSub message exceeds the
-	// max size.
+	// ErrMaxMessageSize is returned or emitted when a GossipSub message exceeds
+	// the max size.
 	ErrMaxMessageSize = fmt.Errorf("message exceeds maximum size of %d bytes", MaxMessageSizeInBytes)
-	ErrMaxOrderSize   = fmt.Errorf("order exceeds maximum size of %d bytes", MaxOrderSizeInBytes)
+	// ErrMaxOrderSize is returned or emitted when a signed order encoded as JSON
+	// exceeds the max size.
+	ErrMaxOrderSize = fmt.Errorf("order exceeds maximum size of %d bytes", MaxOrderSizeInBytes)
 )

--- a/core/message_handler.go
+++ b/core/message_handler.go
@@ -112,10 +112,10 @@ func (app *App) HandleMessages(ctx context.Context, messages []*p2p.Message) err
 	for _, msg := range messages {
 		if err := validateMessageSize(msg); err != nil {
 			log.WithFields(map[string]interface{}{
-				"error":               err,
-				"from":                msg.From,
-				"maxOrderSizeInBytes": constants.MaxOrderSizeInBytes,
-				"actualSizeInBytes":   len(msg.Data),
+				"error":                 err,
+				"from":                  msg.From,
+				"maxMessageSizeInBytes": constants.MaxMessageSizeInBytes,
+				"actualSizeInBytes":     len(msg.Data),
 			}).Trace("received message that exceeds maximum size")
 			app.handlePeerScoreEvent(msg.From, psInvalidMessage)
 			continue

--- a/core/validation.go
+++ b/core/validation.go
@@ -84,7 +84,7 @@ func (app *App) schemaValidateMeshMessage(o []byte) (*gojsonschema.Result, error
 }
 
 func validateMessageSize(message *p2p.Message) error {
-	if len(message.Data) > constants.MaxOrderSizeInBytes {
+	if len(message.Data) > constants.MaxMessageSizeInBytes {
 		return constants.ErrMaxMessageSize
 	}
 	return nil

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -246,7 +246,7 @@ func New(ctx context.Context, config Config) (*Node, error) {
 		GlobalBurst:    config.GlobalPubSubMessageBurst,
 		PerPeerLimit:   config.PerPeerPubSubMessageLimit,
 		PerPeerBurst:   config.PerPeerPubSubMessageBurst,
-		MaxMessageSize: constants.MaxOrderSizeInBytes,
+		MaxMessageSize: constants.MaxMessageSizeInBytes,
 	})
 	if err != nil {
 		return nil, err

--- a/p2p/ratevalidator/validator.go
+++ b/p2p/ratevalidator/validator.go
@@ -102,7 +102,7 @@ func (v *Validator) Validate(ctx context.Context, peerID peer.ID, msg *pubsub.Me
 		return true
 	}
 
-	if msg.Size() > v.config.MaxMessageSize {
+	if len(msg.Data) > v.config.MaxMessageSize {
 		return false
 	}
 

--- a/p2p/ratevalidator/validator.go
+++ b/p2p/ratevalidator/validator.go
@@ -102,7 +102,7 @@ func (v *Validator) Validate(ctx context.Context, peerID peer.ID, msg *pubsub.Me
 		return true
 	}
 
-	if len(msg.Data) > v.config.MaxMessageSize {
+	if data := msg.GetData(); data != nil && len(data) > v.config.MaxMessageSize {
 		return false
 	}
 

--- a/p2p/ratevalidator/validator_test.go
+++ b/p2p/ratevalidator/validator_test.go
@@ -108,10 +108,21 @@ func TestValidatorMaxMessageSize(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	valid := validator.Validate(ctx, peerIDs[1], &pubsub.Message{
-		Message: &pb.Message{
-			Data: make([]byte, maxSize+1),
-		},
-	})
-	assert.False(t, valid, "message should be valid")
+	{
+		isValid := validator.Validate(ctx, peerIDs[1], &pubsub.Message{
+			Message: &pb.Message{
+				Data: make([]byte, maxSize),
+			},
+		})
+		assert.True(t, isValid, "message should be valid")
+	}
+
+	{
+		isValid := validator.Validate(ctx, peerIDs[1], &pubsub.Message{
+			Message: &pb.Message{
+				Data: make([]byte, maxSize+1),
+			},
+		})
+		assert.False(t, isValid, "message should be invalid")
+	}
 }

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1356,7 +1356,7 @@ func (w *Watcher) meshSpecificOrderValidation(orders []*zeroex.SignedOrder, chai
 			}
 		}
 		if err := validateOrderSize(order); err != nil {
-			if err == constants.ErrMaxMessageSize {
+			if err == constants.ErrMaxOrderSize {
 				results.Rejected = append(results.Rejected, &ordervalidator.RejectedOrderInfo{
 					OrderHash:   orderHash,
 					SignedOrder: order,
@@ -1420,7 +1420,7 @@ func validateOrderSize(order *zeroex.SignedOrder) error {
 		return err
 	}
 	if len(encoded) > constants.MaxOrderSizeInBytes {
-		return constants.ErrMaxMessageSize
+		return constants.ErrMaxOrderSize
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #615.

This PR increases the maximum order size to 16k bytes. It also introduces a separate limit called `MaxMessageSizeInBytes` and a corresponding error `ErrMaxMessageSize`. Previously we were conflating these two limits, but they should technically be different.