### PR TITLE
core,ethereum: Allow testnet contract addressses override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v8.2.0
+
+### Features ✅
+
+- Developers can now override the contract addresses for any testnet using the `CUSTOM_CONTRACT_ADDRESSES` env config ([#640](https://github.com/0xProject/0x-mesh/pull/640)).
+
 ## v8.1.0
 
 ### Features ✅

--- a/core/core.go
+++ b/core/core.go
@@ -126,14 +126,15 @@ type Config struct {
 	// is typically only needed for testing on custom chains/networks. The given
 	// addresses are added to the default list of addresses for known chains/networks and
 	// overriding any contract addresses for known chains/networks is not allowed. The
-	// addresses for exchange, devUtils, erc20Proxy, and erc721Proxy are required
+	// addresses for exchange, devUtils, erc20Proxy, erc721Proxy and erc1155Proxy are required
 	// for each chain/network. For example:
 	//
 	//    {
 	//        "exchange":"0x48bacb9266a570d521063ef5dd96e61686dbe788",
 	//        "devUtils": "0x38ef19fdf8e8415f18c307ed71967e19aac28ba1",
 	//        "erc20Proxy": "0x1dc4c1cefef38a777b15aa20260a54e584b16c48",
-	//        "erc721Proxy": "0x1d7022f5b17d2f8b695918fb48fa1089c9f85401"
+	//        "erc721Proxy": "0x1d7022f5b17d2f8b695918fb48fa1089c9f85401",
+	//        "erc1155Proxy": "0x64517fa2b480ba3678a2a3c0cf08ef7fd4fad36f"
 	//    }
 	//
 	CustomContractAddresses string `envvar:"CUSTOM_CONTRACT_ADDRESSES" default:""`

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -17,8 +17,8 @@ func GetContractAddressesForChainID(chainID int) (ContractAddresses, error) {
 }
 
 func AddContractAddressesForChainID(chainID int, addresses ContractAddresses) error {
-	if _, alreadExists := ChainIDToContractAddresses[chainID]; alreadExists {
-		return fmt.Errorf("cannot add contract addresses for chain ID %d: addresses for this chain id are already defined", chainID)
+	if _, alreadExists := ChainIDToContractAddresses[chainID]; alreadExists && chainID == 1 {
+		return fmt.Errorf("cannot add contract addresses for chain ID %d: addresses for this chain id are hard-coded", chainID)
 	}
 	if addresses.Exchange == constants.NullAddress {
 		return fmt.Errorf("cannot add contract addresses for chain ID %d: Exchange address is required", chainID)

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -103,7 +103,7 @@ var ChainIDToContractAddresses = map[int]ContractAddresses{
 		ERC1155Proxy:        common.HexToAddress("0x64517fa2b480ba3678a2a3c0cf08ef7fd4fad36f"),
 		Coordinator:         common.HexToAddress("0xd29e59e51e8ab5f94121efaeebd935ca4214e257"),
 		CoordinatorRegistry: common.HexToAddress("0x09fb99968c016a3ff537bf58fb3d9fe55a7975d5"),
-		DevUtils:            common.HexToAddress("0x80101f90446d9e19a80109ac2767c8c957debb29"),
+		DevUtils:            common.HexToAddress("0x09a379ef7218bcfd8913faa8b281ebc5a2e0bc04"),
 		WETH9:               common.HexToAddress("0xd0a1e359811322d97991e03f863a0c30c2cf029c"),
 		ZRXToken:            common.HexToAddress("0x2002d3812f58e35f0ea1ffbf80a75a38c32175fa"),
 	},

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -17,8 +17,8 @@ func GetContractAddressesForChainID(chainID int) (ContractAddresses, error) {
 }
 
 func AddContractAddressesForChainID(chainID int, addresses ContractAddresses) error {
-	if _, alreadExists := ChainIDToContractAddresses[chainID]; alreadExists && chainID == 1 {
-		return fmt.Errorf("cannot add contract addresses for chain ID %d: addresses for this chain id are hard-coded", chainID)
+	if chainID == 1 {
+		return fmt.Errorf("cannot add contract addresses for chainID 1: addresses for mainnet are hard-coded and cannot be changed")
 	}
 	if addresses.Exchange == constants.NullAddress {
 		return fmt.Errorf("cannot add contract addresses for chain ID %d: Exchange address is required", chainID)

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -103,7 +103,7 @@ var ChainIDToContractAddresses = map[int]ContractAddresses{
 		ERC1155Proxy:        common.HexToAddress("0x64517fa2b480ba3678a2a3c0cf08ef7fd4fad36f"),
 		Coordinator:         common.HexToAddress("0xd29e59e51e8ab5f94121efaeebd935ca4214e257"),
 		CoordinatorRegistry: common.HexToAddress("0x09fb99968c016a3ff537bf58fb3d9fe55a7975d5"),
-		DevUtils:            common.HexToAddress("0x09a379ef7218bcfd8913faa8b281ebc5a2e0bc04"),
+		DevUtils:            common.HexToAddress("0x80101f90446d9e19a80109ac2767c8c957debb29"),
 		WETH9:               common.HexToAddress("0xd0a1e359811322d97991e03f863a0c30c2cf029c"),
 		ZRXToken:            common.HexToAddress("0x2002d3812f58e35f0ea1ffbf80a75a38c32175fa"),
 	},


### PR DESCRIPTION
Several developers have been slowed down by having to wait until a smart contract fix be officially included in Mesh. This PR allows them to point their Mesh node to the fixed smart contract on testnets while still guarding mainnet contracts from being swapped out.
