### PR TITLE
dockerfile: Fix dep install step

### DIFF
--- a/dockerfiles/mesh-bootstrap/Dockerfile
+++ b/dockerfiles/mesh-bootstrap/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /go/src/github.com/0xProject/0x-mesh
 
 ADD . ./
 
-RUN make deps-go-no-lockfile
+RUN make gobin
 
 RUN go build ./cmd/mesh-bootstrap
 

--- a/dockerfiles/mesh-bootstrap/Dockerfile
+++ b/dockerfiles/mesh-bootstrap/Dockerfile
@@ -13,8 +13,6 @@ WORKDIR /go/src/github.com/0xProject/0x-mesh
 
 ADD . ./
 
-RUN make gobin
-
 RUN go build ./cmd/mesh-bootstrap
 
 # Final Image

--- a/dockerfiles/mesh/Dockerfile
+++ b/dockerfiles/mesh/Dockerfile
@@ -13,8 +13,6 @@ WORKDIR /go/src/github.com/0xProject/0x-mesh
 
 ADD . ./
 
-RUN make gobin
-
 RUN go build ./cmd/mesh
 
 # Final Image

--- a/dockerfiles/mesh/Dockerfile
+++ b/dockerfiles/mesh/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /go/src/github.com/0xProject/0x-mesh
 
 ADD . ./
 
-RUN make deps-go-no-lockfile
+RUN make gobin
 
 RUN go build ./cmd/mesh
 


### PR DESCRIPTION
Our migration to Go Modules (https://github.com/0xProject/0x-mesh/pull/618) broke our `dockerfile`'s dep installation step. This PR fixes it.