### PR TITLE
Change dockerfiles to build outside of GOPATH

### DIFF
--- a/dockerfiles/mesh-bootstrap/Dockerfile
+++ b/dockerfiles/mesh-bootstrap/Dockerfile
@@ -9,7 +9,7 @@ FROM golang:1.12.13-alpine3.9 as mesh-builder
 
 RUN apk update && apk add ca-certificates nodejs-current npm make git dep gcc build-base musl linux-headers
 
-WORKDIR /go/src/github.com/0xProject/0x-mesh
+WORKDIR /0x-mesh
 
 ADD . ./
 
@@ -22,7 +22,7 @@ RUN apk update && apk add ca-certificates --no-cache
 
 WORKDIR /usr/mesh
 
-COPY --from=mesh-builder /go/src/github.com/0xProject/0x-mesh/mesh-bootstrap /usr/mesh/mesh-bootstrap
+COPY --from=mesh-builder /0x-mesh/mesh-bootstrap /usr/mesh/mesh-bootstrap
 
 # Default port for TCP multiaddr
 EXPOSE 60558

--- a/dockerfiles/mesh/Dockerfile
+++ b/dockerfiles/mesh/Dockerfile
@@ -9,7 +9,7 @@ FROM golang:1.12.13-alpine3.9 as mesh-builder
 
 RUN apk update && apk add ca-certificates nodejs-current npm make git dep gcc build-base musl linux-headers
 
-WORKDIR /go/src/github.com/0xProject/0x-mesh
+WORKDIR /0x-mesh
 
 ADD . ./
 
@@ -22,7 +22,7 @@ RUN apk update && apk add ca-certificates --no-cache
 
 WORKDIR /usr/mesh
 
-COPY --from=mesh-builder /go/src/github.com/0xProject/0x-mesh/mesh /usr/mesh/mesh
+COPY --from=mesh-builder /0x-mesh/mesh /usr/mesh/mesh
 
 ENV RPC_ADDR=localhost:60557
 EXPOSE 60557


### PR DESCRIPTION
Prior to this PR, trying to build either the `mesh` or `mesh-bootstrap` images results in the following error:

```
db/batch.go:6:2: cannot find package "github.com/syndtr/goleveldb/leveldb/opt" in any of:
	/usr/local/go/src/github.com/syndtr/goleveldb/leveldb/opt (from $GOROOT)
	/go/src/github.com/syndtr/goleveldb/leveldb/opt (from $GOPATH)
db/batch.go:7:2: cannot find package "github.com/syndtr/goleveldb/leveldb/util" in any of:
	/usr/local/go/src/github.com/syndtr/goleveldb/leveldb/util (from $GOROOT)
	/go/src/github.com/syndtr/goleveldb/leveldb/util (from $GOPATH)
core/core.go:42:2: cannot find package "github.com/xeipuuv/gojsonschema" in any of:
	/usr/local/go/src/github.com/xeipuuv/gojsonschema (from $GOROOT)
	/go/src/github.com/xeipuuv/gojsonschema (from $GOPATH)
ethereum/signer/sign.go:12:2: cannot find package "golang.org/x/crypto/sha3" in any of:
	/usr/local/go/src/golang.org/x/crypto/sha3 (from $GOROOT)
	/go/src/golang.org/x/crypto/sha3 (from $GOPATH)
ethereum/ratelimit/rate_limiter.go:14:2: cannot find package "golang.org/x/time/rate" in any of:
	/usr/local/go/src/golang.org/x/time/rate (from $GOROOT)
	/go/src/golang.org/x/time/rate (from $GOPATH)
```

Since we switched to Go Modules, we need to build Mesh _outside_ of `$GOPATH`, which is the opposite of what we did before.

@fabioberger it may have worked for you because you still had some dependencies in a local __vendor/__ directory. If that were the case, they would get copied over into the Docker image and used instead of the ones listed in __go.mod__. I'm not 100% sure if that is the case.
