### PR TITLE
Upgrade to Go 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     environment:
       BASH_ENV: ~/.nvm/nvm.sh
     docker:
-      - image: circleci/golang:1.12.13-browsers
+      - image: circleci/golang:1.13.4-browsers
       - image: 0xorg/ganache-cli:istanbul
         environment:
             VERSION: 5.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ the dropdown menu in the GitHub UI to select `development`.
 ## Prerequisites
 
 -   [GNU Make](https://www.gnu.org/software/make/) If you are using a Unix-like OS, you probably already have this.
--   [Go version 1.12.x](https://golang.org/dl/) (or use [the version manager called "g"](https://github.com/stefanmaric/g)). Go 1.13 is not supported yet (see https://github.com/0xProject/0x-mesh/issues/480).
+-   [Go version 1.13.x](https://golang.org/dl/) (or use [the version manager called "g"](https://github.com/stefanmaric/g)).
 -   [Node.js version >=11](https://nodejs.org/en/download/) (or use the [nvm version manager](https://github.com/creationix/nvm))
 -   [Yarn package manager](https://yarnpkg.com/en/)
 -   [golangci-lint version 1.22.2](https://github.com/golangci/golangci-lint#install)

--- a/browser/ts/wasm_exec.ts
+++ b/browser/ts/wasm_exec.ts
@@ -509,15 +509,8 @@
 
         _makeFuncWrapper(id: any) {
             const go = this;
-            return function() {
-                // Original version was:
-                //
-                //     const event = { id: id, this: this, args: arguments };
-                //
-                // TypeScript compiler complained about `this: this`. I think
-                // in this context, `this` is undefined. TODO(albrow): Look into
-                // this more. It might be a bug.
-                const event = { id: id, this: undefined, args: arguments };
+            return function(this: any) {
+                const event = { id: id, this: this, args: arguments };
                 (go as any)._pendingEvent = event;
                 go._resume();
                 return (event as any).result;

--- a/browser/ts/wasm_exec.ts
+++ b/browser/ts/wasm_exec.ts
@@ -1,9 +1,20 @@
 // Copyright 2018 The Go Authors. All rights reserved.
+// Modified work copyright 2020 ZeroEx, Inc.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the GO_LICENSE file.
 
 /* tslint:disable */
+
 (() => {
+    // Map multiple JavaScript environments to a single common API,
+    // preferring web standards over Node.js API.
+    //
+    // Environments considered:
+    // - Browsers
+    // - Node.js
+    // - Electron
+    // - Parcel
+
     if (typeof global !== 'undefined') {
         // global already exists
     } else if (typeof window !== 'undefined') {
@@ -15,118 +26,124 @@
     }
 
     // NOTE(albrow): Since we know this file is only for inclusion in browser
-    // environments, we can skip some Node.js-related logic.
+    // environments, we can skip some Node.js-related logic. This means
+    // commenting out anything that involves `require`.
 
-    // // Map web browser API and Node.js API to a single common API (preferring web standards over Node.js API).
-    // const isNodeJS = global.process && global.process.title === "node";
-    // if (isNodeJS) {
-    // 	global.require = require;
-    // 	global.fs = require("fs");
-
-    // 	const nodeCrypto = require("crypto");
-    // 	global.crypto = {
-    // 		getRandomValues(b) {
-    // 			nodeCrypto.randomFillSync(b);
-    // 		},
-    // 	};
-
-    // 	global.performance = {
-    // 		now() {
-    // 			const [sec, nsec] = process.hrtime();
-    // 			return sec * 1000 + nsec / 1000000;
-    // 		},
-    // 	};
-
-    // 	const util = require("util");
-    // 	global.TextEncoder = util.TextEncoder;
-    // 	global.TextDecoder = util.TextDecoder;
-    // } else {
-    let outputBuf = '';
-    (global as any).fs = {
-        constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1 }, // unused
-        writeSync(fd: any, buf: any) {
-            outputBuf += decoder.decode(buf);
-            const nl = outputBuf.lastIndexOf('\n');
-            if (nl != -1) {
-                console.log(outputBuf.substr(0, nl));
-                outputBuf = outputBuf.substr(nl + 1);
-            }
-            return buf.length;
-        },
-        write(fd: any, buf: any, offset: any, length: any, position: any, callback: any) {
-            if (offset !== 0 || length !== buf.length || position !== null) {
-                throw new Error('not implemented');
-            }
-            const n = this.writeSync(fd, buf);
-            callback(null, n);
-        },
-        open(path: any, flags: any, mode: any, callback: any) {
-            const err = new Error('not implemented');
-            (err as any).code = 'ENOSYS';
-            callback(err);
-        },
-        read(fd: any, buffer: any, offset: any, length: any, position: any, callback: any) {
-            const err = new Error('not implemented');
-            (err as any).code = 'ENOSYS';
-            callback(err);
-        },
-        fsync(fd: any, callback: any) {
-            callback(null);
-        },
-    };
+    // if (!(global as any).require && typeof require !== 'undefined') {
+    //     (global as any).require = require;
     // }
+
+    // if (!(global as any).fs && (global as any).require) {
+    //     (global as any).fs = require('fs');
+    // }
+
+    if (!(global as any).fs) {
+        let outputBuf = '';
+        (global as any).fs = {
+            constants: { O_WRONLY: -1, O_RDWR: -1, O_CREAT: -1, O_TRUNC: -1, O_APPEND: -1, O_EXCL: -1 }, // unused
+            writeSync(fd: any, buf: any) {
+                outputBuf += decoder.decode(buf);
+                const nl = outputBuf.lastIndexOf('\n');
+                if (nl != -1) {
+                    console.log(outputBuf.substr(0, nl));
+                    outputBuf = outputBuf.substr(nl + 1);
+                }
+                return buf.length;
+            },
+            write(
+                fd: any,
+                buf: string | any[],
+                offset: number,
+                length: any,
+                position: null,
+                callback: (arg0: null, arg1: any) => void,
+            ) {
+                if (offset !== 0 || length !== buf.length || position !== null) {
+                    throw new Error('not implemented');
+                }
+                const n = this.writeSync(fd, buf);
+                callback(null, n);
+            },
+            open(path: any, flags: any, mode: any, callback: (arg0: Error) => void) {
+                const err: any = new Error('not implemented');
+                err.code = 'ENOSYS';
+                callback(err);
+            },
+            read(fd: any, buffer: any, offset: any, length: any, position: any, callback: (arg0: Error) => void) {
+                const err: any = new Error('not implemented');
+                err.code = 'ENOSYS';
+                callback(err);
+            },
+            fsync(fd: any, callback: (arg0: null) => void) {
+                callback(null);
+            },
+        };
+    }
+
+    // if (!(global as any).crypto) {
+    //     const nodeCrypto = require('crypto');
+    //     (global as any).crypto = {
+    //         getRandomValues(b: any) {
+    //             nodeCrypto.randomFillSync(b);
+    //         },
+    //     };
+    // }
+
+    if (!(global as any).performance) {
+        (global as any).performance = {
+            now() {
+                const [sec, nsec] = process.hrtime();
+                return sec * 1000 + nsec / 1000000;
+            },
+        };
+    }
+
+    // if (!(global as any).TextEncoder) {
+    //     (global as any).TextEncoder = require('util').TextEncoder;
+    // }
+
+    // if (!(global as any).TextDecoder) {
+    //     (global as any).TextDecoder = require('util').TextDecoder;
+    // }
+
+    // End of polyfills for common API.
 
     const encoder = new (TextEncoder as any)('utf-8');
     const decoder = new TextDecoder('utf-8');
 
     (global as any).Go = class {
-        argv: any;
-        env: any;
-        exit: any;
-        _callbackTimeouts: any;
-        _nextCallbackTimeoutID: any;
-        _inst: any;
-        _values: any;
-        _refs: any;
-        importObject: any;
-        exited: any;
-        _callbackShutdown: any;
-        _exitPromise: any;
-        _resolveExitPromise: any;
-        _pendingEvent: any;
-        _scheduledTimeouts: any;
         constructor() {
-            this.argv = ['js'];
-            this.env = {};
-            this.exit = (code: any) => {
+            (this as any).argv = ['js'];
+            (this as any).env = {};
+            (this as any).exit = (code: number) => {
                 if (code !== 0) {
                     console.warn('exit code:', code);
                 }
             };
-            this._exitPromise = new Promise(resolve => {
-                this._resolveExitPromise = resolve;
+            (this as any)._exitPromise = new Promise(resolve => {
+                (this as any)._resolveExitPromise = resolve;
             });
-            this._pendingEvent = null;
-            this._scheduledTimeouts = new Map();
-            this._nextCallbackTimeoutID = 1;
+            (this as any)._pendingEvent = null;
+            (this as any)._scheduledTimeouts = new Map();
+            (this as any)._nextCallbackTimeoutID = 1;
 
             const mem = () => {
                 // The buffer may change when requesting more memory.
-                return new DataView(this._inst.exports.mem.buffer);
+                return new DataView((this as any)._inst.exports.mem.buffer);
             };
 
-            const setInt64 = (addr: any, v: any) => {
+            const setInt64 = (addr: number, v: number) => {
                 mem().setUint32(addr + 0, v, true);
                 mem().setUint32(addr + 4, Math.floor(v / 4294967296), true);
             };
 
-            const getInt64 = (addr: any) => {
+            const getInt64 = (addr: number) => {
                 const low = mem().getUint32(addr + 0, true);
                 const high = mem().getInt32(addr + 4, true);
                 return low + high * 4294967296;
             };
 
-            const loadValue = (addr: any) => {
+            const loadValue = (addr: number) => {
                 const f = mem().getFloat64(addr, true);
                 if (f === 0) {
                     return undefined;
@@ -136,10 +153,10 @@
                 }
 
                 const id = mem().getUint32(addr, true);
-                return this._values[id];
+                return (this as any)._values[id];
             };
 
-            const storeValue = (addr: number, v: any) => {
+            const storeValue = (addr: number, v: string | number | Uint8Array | boolean) => {
                 const nanHead = 0x7ff80000;
 
                 if (typeof v === 'number') {
@@ -175,11 +192,11 @@
                         return;
                 }
 
-                let ref = this._refs.get(v);
+                let ref = (this as any)._refs.get(v);
                 if (ref === undefined) {
-                    ref = this._values.length;
-                    this._values.push(v);
-                    this._refs.set(v, ref);
+                    ref = (this as any)._values.length;
+                    (this as any)._values.push(v);
+                    (this as any)._refs.set(v, ref);
                 }
                 let typeFlag = 0;
                 switch (typeof v) {
@@ -200,7 +217,7 @@
             const loadSlice = (addr: number) => {
                 const array = getInt64(addr + 0);
                 const len = getInt64(addr + 8);
-                return new Uint8Array(this._inst.exports.mem.buffer, array, len);
+                return new Uint8Array((this as any)._inst.exports.mem.buffer, array, len);
             };
 
             const loadSliceOfValues = (addr: number) => {
@@ -216,11 +233,11 @@
             const loadString = (addr: number) => {
                 const saddr = getInt64(addr + 0);
                 const len = getInt64(addr + 8);
-                return decoder.decode(new DataView(this._inst.exports.mem.buffer, saddr, len));
+                return decoder.decode(new DataView((this as any)._inst.exports.mem.buffer, saddr, len));
             };
 
             const timeOrigin = Date.now() - performance.now();
-            this.importObject = {
+            (this as any).importObject = {
                 go: {
                     // Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
                     // may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
@@ -230,11 +247,11 @@
                     // func wasmExit(code int32)
                     'runtime.wasmExit': (sp: number) => {
                         const code = mem().getInt32(sp + 8, true);
-                        this.exited = true;
-                        delete this._inst;
-                        delete this._values;
-                        delete this._refs;
-                        this.exit(code);
+                        (this as any).exited = true;
+                        delete (this as any)._inst;
+                        delete (this as any)._values;
+                        delete (this as any)._refs;
+                        (this as any).exit(code);
                     },
 
                     // func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
@@ -242,7 +259,7 @@
                         const fd = getInt64(sp + 8);
                         const p = getInt64(sp + 16);
                         const n = mem().getInt32(sp + 24, true);
-                        (global as any).fs.writeSync(fd, new Uint8Array(this._inst.exports.mem.buffer, p, n));
+                        (global as any).fs.writeSync(fd, new Uint8Array((this as any)._inst.exports.mem.buffer, p, n));
                     },
 
                     // func nanotime() int64
@@ -259,13 +276,19 @@
 
                     // func scheduleTimeoutEvent(delay int64) int32
                     'runtime.scheduleTimeoutEvent': (sp: number) => {
-                        const id = this._nextCallbackTimeoutID;
-                        this._nextCallbackTimeoutID++;
-                        this._scheduledTimeouts.set(
+                        const id = (this as any)._nextCallbackTimeoutID;
+                        (this as any)._nextCallbackTimeoutID++;
+                        (this as any)._scheduledTimeouts.set(
                             id,
                             setTimeout(
                                 () => {
-                                    this._resume();
+                                    (this as any)._resume();
+                                    while ((this as any)._scheduledTimeouts.has(id)) {
+                                        // for some reason Go failed to register the timeout event, log and try again
+                                        // (temporary workaround for https://github.com/golang/go/issues/28975)
+                                        console.warn('scheduleTimeoutEvent: missed timeout event');
+                                        (this as any)._resume();
+                                    }
                                 },
                                 getInt64(sp + 8) + 1, // setTimeout has been seen to fire up to 1 millisecond early
                             ),
@@ -276,8 +299,8 @@
                     // func clearTimeoutEvent(id int32)
                     'runtime.clearTimeoutEvent': (sp: number) => {
                         const id = mem().getInt32(sp + 8, true);
-                        clearTimeout(this._scheduledTimeouts.get(id));
-                        this._scheduledTimeouts.delete(id);
+                        clearTimeout((this as any)._scheduledTimeouts.get(id));
+                        (this as any)._scheduledTimeouts.delete(id);
                     },
 
                     // func getRandomData(r []byte)
@@ -293,7 +316,7 @@
                     // func valueGet(v ref, p string) ref
                     'syscall/js.valueGet': (sp: number) => {
                         const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16));
-                        sp = this._inst.exports.getsp(); // see comment above
+                        sp = (this as any)._inst.exports.getsp(); // see comment above
                         storeValue(sp + 32, result);
                     },
 
@@ -319,7 +342,7 @@
                             const m = Reflect.get(v, loadString(sp + 16));
                             const args = loadSliceOfValues(sp + 32);
                             const result = Reflect.apply(m, v, args);
-                            sp = this._inst.exports.getsp(); // see comment above
+                            sp = (this as any)._inst.exports.getsp(); // see comment above
                             storeValue(sp + 56, result);
                             mem().setUint8(sp + 64, 1);
                         } catch (err) {
@@ -334,7 +357,7 @@
                             const v = loadValue(sp + 8);
                             const args = loadSliceOfValues(sp + 16);
                             const result = Reflect.apply(v, undefined, args);
-                            sp = this._inst.exports.getsp(); // see comment above
+                            sp = (this as any)._inst.exports.getsp(); // see comment above
                             storeValue(sp + 40, result);
                             mem().setUint8(sp + 48, 1);
                         } catch (err) {
@@ -349,7 +372,7 @@
                             const v = loadValue(sp + 8);
                             const args = loadSliceOfValues(sp + 16);
                             const result = Reflect.construct(v, args);
-                            sp = this._inst.exports.getsp(); // see comment above
+                            sp = (this as any)._inst.exports.getsp(); // see comment above
                             storeValue(sp + 40, result);
                             mem().setUint8(sp + 48, 1);
                         } catch (err) {
@@ -378,7 +401,35 @@
 
                     // func valueInstanceOf(v ref, t ref) bool
                     'syscall/js.valueInstanceOf': (sp: number) => {
-                        (mem() as any).setUint8(sp + 24, loadValue(sp + 8) instanceof loadValue(sp + 16));
+                        mem().setUint8(sp + 24, loadValue(sp + 8) instanceof loadValue(sp + 16) ? 0 : 1);
+                    },
+
+                    // func copyBytesToGo(dst []byte, src ref) (int, bool)
+                    'syscall/js.copyBytesToGo': (sp: number) => {
+                        const dst = loadSlice(sp + 8);
+                        const src = loadValue(sp + 32);
+                        if (!(src instanceof Uint8Array)) {
+                            mem().setUint8(sp + 48, 0);
+                            return;
+                        }
+                        const toCopy = src.subarray(0, dst.length);
+                        dst.set(toCopy);
+                        setInt64(sp + 40, toCopy.length);
+                        mem().setUint8(sp + 48, 1);
+                    },
+
+                    // func copyBytesToJS(dst ref, src []byte) (int, bool)
+                    'syscall/js.copyBytesToJS': (sp: number) => {
+                        const dst = loadValue(sp + 8);
+                        const src = loadSlice(sp + 16);
+                        if (!(dst instanceof Uint8Array)) {
+                            mem().setUint8(sp + 48, 0);
+                            return;
+                        }
+                        const toCopy = src.subarray(0, dst.length);
+                        dst.set(toCopy);
+                        setInt64(sp + 40, toCopy.length);
+                        mem().setUint8(sp + 48, 1);
                     },
 
                     debug: (value: any) => {
@@ -389,8 +440,8 @@
         }
 
         async run(instance: any) {
-            this._inst = instance;
-            this._values = [
+            (this as any)._inst = instance;
+            (this as any)._values = [
                 // TODO: garbage collection
                 NaN,
                 0,
@@ -398,35 +449,38 @@
                 true,
                 false,
                 global,
-                this._inst.exports.mem,
                 this,
             ];
-            this._refs = new Map();
-            this.exited = false;
+            (this as any)._refs = new Map();
+            (this as any).exited = false;
 
-            const mem = new DataView(this._inst.exports.mem.buffer);
+            const mem = new DataView((this as any)._inst.exports.mem.buffer);
 
             // Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
             let offset = 4096;
 
             const strPtr = (str: string) => {
-                let ptr = offset;
-                new Uint8Array(mem.buffer, offset, str.length + 1).set(encoder.encode(str + '\0'));
-                offset += str.length + (8 - (str.length % 8));
+                const ptr = offset;
+                const bytes = encoder.encode(str + '\0');
+                new Uint8Array(mem.buffer, offset, bytes.length).set(bytes);
+                offset += bytes.length;
+                if (offset % 8 !== 0) {
+                    offset += 8 - (offset % 8);
+                }
                 return ptr;
             };
 
-            const argc = this.argv.length;
+            const argc = (this as any).argv.length;
 
             const argvPtrs = [];
-            this.argv.forEach((arg: any) => {
+            (this as any).argv.forEach((arg: any) => {
                 argvPtrs.push(strPtr(arg));
             });
 
-            const keys = Object.keys(this.env).sort();
+            const keys = Object.keys((this as any).env).sort();
             argvPtrs.push(keys.length);
             keys.forEach(key => {
-                argvPtrs.push(strPtr(`${key}=${this.env[key]}`));
+                argvPtrs.push(strPtr(`${key}=${(this as any).env[key]}`));
             });
 
             const argv = offset;
@@ -436,55 +490,72 @@
                 offset += 8;
             });
 
-            this._inst.exports.run(argc, argv);
-            if (this.exited) {
-                this._resolveExitPromise();
+            (this as any)._inst.exports.run(argc, argv);
+            if ((this as any).exited) {
+                (this as any)._resolveExitPromise();
             }
-            await this._exitPromise;
+            await (this as any)._exitPromise;
         }
 
         _resume() {
-            if (this.exited) {
+            if ((this as any).exited) {
                 throw new Error('Go program has already exited');
             }
-            this._inst.exports.resume();
-            if (this.exited) {
-                this._resolveExitPromise();
+            (this as any)._inst.exports.resume();
+            if ((this as any).exited) {
+                (this as any)._resolveExitPromise();
             }
         }
 
         _makeFuncWrapper(id: any) {
             const go = this;
             return function() {
-                const event = { id: id, this: go, args: arguments };
-                go._pendingEvent = event;
+                // Original version was:
+                //
+                //     const event = { id: id, this: this, args: arguments };
+                //
+                // TypeScript compiler complained about `this: this`. I think
+                // in this context, `this` is undefined. TODO(albrow): Look into
+                // this more. It might be a bug.
+                const event = { id: id, this: undefined, args: arguments };
+                (go as any)._pendingEvent = event;
                 go._resume();
                 return (event as any).result;
             };
         }
     };
 
-    // if (isNodeJS) {
-    // 	if (process.argv.length < 3) {
-    // 		process.stderr.write("usage: go_js_wasm_exec [wasm binary] [arguments]\n");
-    // 		process.exit(1);
-    // 	}
+    // if (
+    //     (global as any).require &&
+    //     (global as any).require.main === module &&
+    //     global.process &&
+    //     global.process.versions &&
+    //     !(global.process.versions as any).electron
+    // ) {
+    //     if (process.argv.length < 3) {
+    //         console.error('usage: go_js_wasm_exec [wasm binary] [arguments]');
+    //         process.exit(1);
+    //     }
 
-    // 	const go = new Go();
-    // 	go.argv = process.argv.slice(2);
-    // 	go.env = Object.assign({ TMPDIR: require("os").tmpdir() }, process.env);
-    // 	go.exit = process.exit;
-    // 	WebAssembly.instantiate(fs.readFileSync(process.argv[2]), go.importObject).then((result) => {
-    // 		process.on("exit", (code) => { // Node.js exits if no event handler is pending
-    // 			if (code === 0 && !go.exited) {
-    // 				// deadlock, make Go print error and stack traces
-    // 				go._pendingEvent = { id: 0 };
-    // 				go._resume();
-    // 			}
-    // 		});
-    // 		return go.run(result.instance);
-    // 	}).catch((err) => {
-    // 		throw err;
-    // 	});
+    //     const go: any = new Go();
+    //     go.argv = process.argv.slice(2);
+    //     go.env = Object.assign({ TMPDIR: require('os').tmpdir() }, process.env);
+    //     go.exit = process.exit;
+    //     WebAssembly.instantiate((global as any).fs.readFileSync(process.argv[2]), go.importObject)
+    //         .then(result => {
+    //             process.on('exit', code => {
+    //                 // Node.js exits if no event handler is pending
+    //                 if (code === 0 && !go.exited) {
+    //                     // deadlock, make Go print error and stack traces
+    //                     go._pendingEvent = { id: 0 };
+    //                     go._resume();
+    //                 }
+    //             });
+    //             return go.run(result.instance);
+    //         })
+    //         .catch(err => {
+    //             console.error(err);
+    //             process.exit(1);
+    //         });
     // }
 })();

--- a/core/message_handler_test.go
+++ b/core/message_handler_test.go
@@ -37,6 +37,7 @@ var serialTestsEnabled bool
 
 func init() {
 	flag.BoolVar(&serialTestsEnabled, "serial", false, "enable serial tests")
+	testing.Init()
 	flag.Parse()
 
 	var err error

--- a/dockerfiles/mesh-bootstrap/Dockerfile
+++ b/dockerfiles/mesh-bootstrap/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # mesh-builder produces a statically linked binary
-FROM golang:1.12.13-alpine3.9 as mesh-builder
+FROM golang:1.13.4-alpine3.10 as mesh-builder
 
 
 RUN apk update && apk add ca-certificates nodejs-current npm make git dep gcc build-base musl linux-headers

--- a/dockerfiles/mesh/Dockerfile
+++ b/dockerfiles/mesh/Dockerfile
@@ -4,7 +4,7 @@
 #
 
 # mesh-builder produces a statically linked binary
-FROM golang:1.12.13-alpine3.9 as mesh-builder
+FROM golang:1.13.4-alpine3.10 as mesh-builder
 
 
 RUN apk update && apk add ca-certificates nodejs-current npm make git dep gcc build-base musl linux-headers

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/0xProject/0x-mesh
 
-go 1.12
+go 1.13
 
 replace (
 	github.com/ethereum/go-ethereum => github.com/0xProject/go-ethereum v1.8.8-0.20200121231321-1510563ddd1f

--- a/integration-tests/utils.go
+++ b/integration-tests/utils.go
@@ -34,6 +34,7 @@ var nodeCount int32
 
 func init() {
 	flag.BoolVar(&browserIntegrationTestsEnabled, "enable-browser-integration-tests", false, "enable browser integration tests")
+	testing.Init()
 	flag.Parse()
 }
 

--- a/zeroex/ordervalidator/order_validator_test.go
+++ b/zeroex/ordervalidator/order_validator_test.go
@@ -60,6 +60,7 @@ var serialTestsEnabled bool
 
 func init() {
 	flag.BoolVar(&serialTestsEnabled, "serial", false, "enable serial tests")
+	testing.Init()
 	flag.Parse()
 }
 

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -69,6 +69,7 @@ var serialTestsEnabled bool
 
 func init() {
 	flag.BoolVar(&serialTestsEnabled, "serial", false, "enable serial tests")
+	testing.Init()
 	flag.Parse()
 }
 


### PR DESCRIPTION
Fixes #480. This will help us include some small but important optimizations (especially in the browser) and keep up with the Go ecosystem. libp2p has already switched to 1.13.