### PR TITLE
Implement getStatsAsync for browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 - Implemented custom order filters, which allow users to filter out all but the orders they care about. When a custom order filter is specified, Mesh will only send and receive orders that pass the filter. ([#630](https://github.com/0xProject/0x-mesh/pull/630)).
 - Developers can now override the contract addresses for any testnet using the `CUSTOM_CONTRACT_ADDRESSES` env config ([#640](https://github.com/0xProject/0x-mesh/pull/640)).
-- Add `getOrdersForPageAsync` method to `@0x/mesh-rpc-client` WS client interface so that clients can paginate through the retrieved orders themselves ([#642](https://github.com/0xProject/0x-mesh/pull/642)).
+- Added `getOrdersForPageAsync` method to `@0x/mesh-rpc-client` WS client interface so that clients can paginate through the retrieved orders themselves ([#642](https://github.com/0xProject/0x-mesh/pull/642)).
+- Added `getStatsAsync` to the `@0x/mesh-browser` package. This exposes the `getStats` method to browser users. ([#654](https://github.com/0xProject/0x-mesh/pull/654)).
 
 
 ## v8.1.1

--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -230,6 +230,16 @@ func (cw *MeshWrapper) AddOrders(rawOrders js.Value, pinned bool) (js.Value, err
 	return resultsJS, nil
 }
 
+// GetStats calls core.GetStats, converts the result to a js.Value and returns
+// it.
+func (cw *MeshWrapper) GetStats() (js.Value, error) {
+	stats, err := cw.app.GetStats()
+	if err != nil {
+		return js.Undefined(), err
+	}
+	return js.ValueOf(stats), nil
+}
+
 // JSValue satisfies the js.Wrapper interface. The return value is a JavaScript
 // object consisting of named functions. They act like methods by capturing the
 // MeshWrapper through a closure.
@@ -252,6 +262,12 @@ func (cw *MeshWrapper) JSValue() js.Value {
 			handler := args[0]
 			cw.orderEventsHandler = handler
 			return nil
+		}),
+		// getStatsAsync(): Promise<Stats>
+		"getStatsAsync": js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+			return wrapInPromise(func() (interface{}, error) {
+				return cw.GetStats()
+			})
 		}),
 		// addOrdersAsync(orders: Array<SignedOrder>): Promise<ValidationResults>
 		"addOrdersAsync": js.FuncOf(func(this js.Value, args []js.Value) interface{} {

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -745,6 +745,10 @@ export class Mesh {
         return this._wrapper.startAsync();
     }
 
+    /**
+     * Returns various stats about Mesh, including the total number of orders
+     * and the number of peers Mesh is connected to.
+     */
     public async getStatsAsync(): Promise<Stats> {
         await waitForLoadAsync();
         if (this._wrapper === undefined) {

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -213,6 +213,45 @@ export interface ContractAddresses {
     zrxToken?: string;
 }
 
+export interface LatestBlock {
+    number: number;
+    hash: string;
+}
+
+interface WrapperStats {
+    version: string;
+    pubSubTopic: string;
+    rendezvous: string;
+    peerID: string;
+    ethereumChainID: number;
+    latestBlock: LatestBlock;
+    numPeers: number;
+    numOrders: number;
+    numOrdersIncludingRemoved: number;
+    numPinnedOrders: number;
+    maxExpirationTime: string; // string instead of BigNumber
+    startOfCurrentUTCDay: string; // string instead of Date
+    ethRPCRequestsSentInCurrentUTCDay: number;
+    ethRPCRateLimitExpiredRequests: number;
+}
+
+export interface Stats {
+    version: string;
+    pubSubTopic: string;
+    rendezvous: string;
+    peerID: string;
+    ethereumChainID: number;
+    latestBlock: LatestBlock;
+    numPeers: number;
+    numOrders: number;
+    numOrdersIncludingRemoved: number;
+    numPinnedOrders: number;
+    maxExpirationTime: BigNumber;
+    startOfCurrentUTCDay: Date;
+    ethRPCRequestsSentInCurrentUTCDay: number;
+    ethRPCRateLimitExpiredRequests: number;
+}
+
 export enum Verbosity {
     Panic = 0,
     Fatal = 1,
@@ -235,6 +274,7 @@ interface MeshWrapper {
     startAsync(): Promise<void>;
     onError(handler: (err: Error) => void): void;
     onOrderEvents(handler: (events: WrapperOrderEvent[]) => void): void;
+    getStatsAsync(): Promise<WrapperStats>;
     addOrdersAsync(orders: WrapperSignedOrder[], pinned: boolean): Promise<WrapperValidationResults>;
 }
 
@@ -705,6 +745,18 @@ export class Mesh {
         return this._wrapper.startAsync();
     }
 
+    public async getStatsAsync(): Promise<Stats> {
+        await waitForLoadAsync();
+        if (this._wrapper === undefined) {
+            // If this is called after startAsync, this._wrapper is always
+            // defined. This check is here just in case and satisfies the
+            // compiler.
+            return Promise.reject(new Error('Mesh is still loading. Try again soon.'));
+        }
+        const wrapperStats = await this._wrapper.getStatsAsync();
+        return wrapperStatsToStats(wrapperStats);
+    }
+
     /**
      * Validates and adds the given orders to Mesh. If an order is successfully
      * added, Mesh will share it with any peers in the network and start
@@ -936,6 +988,14 @@ function orderEventsHandlerToWrapperOrderEventsHandler(
     return (wrapperOrderEvents: WrapperOrderEvent[]) => {
         const orderEvents = wrapperOrderEvents.map(wrapperOrderEventToOrderEvent);
         orderEventsHandler(orderEvents);
+    };
+}
+
+function wrapperStatsToStats(wrapperStats: WrapperStats): Stats {
+    return {
+        ...wrapperStats,
+        startOfCurrentUTCDay: new Date(wrapperStats.startOfCurrentUTCDay),
+        maxExpirationTime: new BigNumber(wrapperStats.maxExpirationTime),
     };
 }
 

--- a/common/types/types_js.go
+++ b/common/types/types_js.go
@@ -1,0 +1,19 @@
+// +build js,wasm
+
+package types
+
+import (
+	"encoding/json"
+	"syscall/js"
+)
+
+func (s *Stats) JSValue() js.Value {
+	// TODO(albrow): Optimize this. Remove other uses of the JSON
+	// encoding/decoding hack.
+	encodedStats, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	statsJS := js.Global().Get("JSON").Call("parse", string(encodedStats))
+	return statsJS
+}

--- a/integration-tests/browser/src/index.ts
+++ b/integration-tests/browser/src/index.ts
@@ -83,6 +83,10 @@ provider.start();
         throw new Error('Expected no orders to be rejected but got: ' + result.rejected.length);
     }
 
+    // Call getStatsAsync and make sure it works.
+    const stats = await mesh.getStatsAsync();
+    console.log(JSON.stringify(stats));
+
     // This special #jsFinished div is used to signal the headless Chrome driver
     // that the JavaScript code is done running.
     const finishedDiv = document.createElement('div');


### PR DESCRIPTION
Fixes #576. This PR implements `getStatsAsync` for browsers.

Based on the `fix/no-rpc-in-core` branch. We need to merge #653 before this one.
