### PR TITLE
Add support for passing in a Web3 Provider in the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This changelog is a work in progress and may contain notes for versions which ha
 - Added `getOrdersForPageAsync` method to `@0x/mesh-rpc-client` WS client interface so that clients can paginate through the retrieved orders themselves ([#642](https://github.com/0xProject/0x-mesh/pull/642)).
 - Added `getStatsAsync` to the `@0x/mesh-browser` package. ([#654](https://github.com/0xProject/0x-mesh/pull/654)).
 - Added `getOrdersAsync` and `getOrdersForPageAsync` to the `@0x/mesh-browser` package. ([#655](https://github.com/0xProject/0x-mesh/pull/655)).
+- Added support for passing in your own Web3 provider when using the `@0x/mesh-browser` package. ([#665](https://github.com/0xProject/0x-mesh/pull/665)).
+
 
 ## v8.1.2
 

--- a/browser/go/ethprovider/ethprovider.go
+++ b/browser/go/ethprovider/ethprovider.go
@@ -1,0 +1,42 @@
+// +build js,wasm
+
+package ethprovider
+
+import (
+	"context"
+	"errors"
+	"syscall/js"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var _ ethclient.RPCClient = &RPCClient{}
+
+type RPCClient struct {
+	// provider is the underlying Web3 provider which will be used for sending
+	// requests.
+	provider js.Value
+}
+
+func NewRPCClient(provider js.Value) *RPCClient {
+	return &RPCClient{
+		provider: provider,
+	}
+}
+
+func (c *RPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
+	return errors.New("CallContext not yet implemented")
+}
+
+func (c *RPCClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	return errors.New("BatchCallContext not yet implemented")
+}
+
+func (c *RPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
+	return nil, errors.New("EthSubscribe not yet implemented")
+}
+
+func (c *RPCClient) Close() {
+	// no-op for now.
+}

--- a/browser/go/jsutil/jsutil.go
+++ b/browser/go/jsutil/jsutil.go
@@ -1,0 +1,70 @@
+// +build js,wasm
+
+// Package jsutil contains various utility functions for working with
+// JavaScript and WebAssemblysysa
+package jsutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"syscall/js"
+)
+
+// ErrorToJS converts a Go error to a JavaScript Error.
+func ErrorToJS(err error) js.Value {
+	return js.Global().Get("Error").New(err.Error())
+}
+
+func IsNullOrUndefined(value js.Value) bool {
+	return value == js.Null() || value == js.Undefined()
+}
+
+// WrapInPromise converts a potentially blocking Go function to a non-blocking
+// JavaScript Promise. If the function returns an error, the promise will reject
+// with that error. Otherwise, the promise will resolve with the first return
+// value.
+func WrapInPromise(f func() (interface{}, error)) js.Value {
+	var executor js.Func
+	executor = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		resolve := args[0]
+		reject := args[1]
+		go func() {
+			defer executor.Release()
+			if result, err := f(); err != nil {
+				reject.Invoke(ErrorToJS(err))
+			} else {
+				resolve.Invoke(result)
+			}
+		}()
+		return nil
+	})
+	return js.Global().Get("Promise").New(executor)
+}
+
+func InefficientlyConvertToJS(value interface{}) (js.Value, error) {
+	var jsValue interface{}
+	buf := bytes.Buffer{}
+	if err := json.NewEncoder(&buf).Encode(value); err != nil {
+		return js.Undefined(), err
+	}
+	if err := json.NewDecoder(&buf).Decode(&jsValue); err != nil {
+		return js.Undefined(), err
+	}
+	return js.ValueOf(jsValue), nil
+}
+
+func InefficientlyConvertFromJS(jsValue js.Value, value interface{}) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			switch e := e.(type) {
+			case error:
+				err = e
+			default:
+				err = fmt.Errorf("unexpected error: (%T) %s", e, e)
+			}
+		}
+	}()
+	jsonString := js.Global().Get("JSON").Call("stringify", jsValue)
+	return json.Unmarshal([]byte(jsonString.String()), value)
+}

--- a/browser/go/jsutil/jsutil.go
+++ b/browser/go/jsutil/jsutil.go
@@ -1,7 +1,7 @@
 // +build js,wasm
 
 // Package jsutil contains various utility functions for working with
-// JavaScript and WebAssemblysysa
+// JavaScript and WebAssembly
 package jsutil
 
 import (
@@ -16,6 +16,8 @@ func ErrorToJS(err error) js.Value {
 	return js.Global().Get("Error").New(err.Error())
 }
 
+// IsNullOrUndefined returns true if the given JavaScript value is either null
+// or undefined.
 func IsNullOrUndefined(value js.Value) bool {
 	return value == js.Null() || value == js.Undefined()
 }
@@ -42,6 +44,9 @@ func WrapInPromise(f func() (interface{}, error)) js.Value {
 	return js.Global().Get("Promise").New(executor)
 }
 
+// InefficientlyConvertToJS converts the given Go value to a JS value by
+// encoding to JSON and then decoding it. This function is not very efficient
+// and its use should be phased out over time as much as possible.
 func InefficientlyConvertToJS(value interface{}) (js.Value, error) {
 	var jsValue interface{}
 	buf := bytes.Buffer{}
@@ -54,6 +59,9 @@ func InefficientlyConvertToJS(value interface{}) (js.Value, error) {
 	return js.ValueOf(jsValue), nil
 }
 
+// InefficientlyConvertFromJS converts the given JS value to a Go value and sets
+// it. This function is not very efficient and its use should be phased out over
+// time as much as possible.
 func InefficientlyConvertFromJS(jsValue js.Value, value interface{}) (err error) {
 	defer func() {
 		if e := recover(); e != nil {

--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -97,11 +97,6 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 	}
 
 	// Required config options
-	if ethereumRPCURL := jsConfig.Get("ethereumRPCURL"); isNullOrUndefined(ethereumRPCURL) || ethereumRPCURL.String() == "" {
-		return core.Config{}, errors.New("ethereumRPCURL is required")
-	} else {
-		config.EthereumRPCURL = ethereumRPCURL.String()
-	}
 	if ethereumChainID := jsConfig.Get("ethereumChainID"); isNullOrUndefined(ethereumChainID) {
 		return core.Config{}, errors.New("ethereumChainID is required")
 	} else {
@@ -142,7 +137,10 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 	if customOrderFilter := jsConfig.Get("customOrderFilter"); !isNullOrUndefined(customOrderFilter) {
 		config.CustomOrderFilter = customOrderFilter.String()
 	}
-	if web3Provider := jsConfig.Get("web3Provider"); isNullOrUndefined(web3Provider) {
+	if ethereumRPCURL := jsConfig.Get("ethereumRPCURL"); !isNullOrUndefined(ethereumRPCURL) && ethereumRPCURL.String() != "" {
+		config.EthereumRPCURL = ethereumRPCURL.String()
+	}
+	if web3Provider := jsConfig.Get("web3Provider"); !isNullOrUndefined(web3Provider) {
 		config.EthereumRPCClient = providerwrapper.NewRPCClient(web3Provider)
 	}
 

--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -9,6 +9,8 @@ import (
 	"syscall/js"
 	"time"
 
+	"github.com/0xProject/0x-mesh/browser/go/jsutil"
+
 	"github.com/0xProject/0x-mesh/browser/go/providerwrapper"
 	"github.com/0xProject/0x-mesh/core"
 	"github.com/0xProject/0x-mesh/orderfilter"
@@ -40,7 +42,7 @@ func setGlobals() {
 	zeroexMesh := map[string]interface{}{
 		// newWrapperAsync(config: Config): Promise<MeshWrapper>;
 		"newWrapperAsync": js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-			return wrapInPromise(func() (interface{}, error) {
+			return jsutil.WrapInPromise(func() (interface{}, error) {
 				config, err := convertConfig(args[0])
 				if err != nil {
 					return nil, err
@@ -76,7 +78,7 @@ type MeshWrapper struct {
 // convertConfig converts a JavaScript config object into a core.Config. It also
 // adds default values for any that are missing in the JavaScript object.
 func convertConfig(jsConfig js.Value) (core.Config, error) {
-	if isNullOrUndefined(jsConfig) {
+	if jsutil.IsNullOrUndefined(jsConfig) {
 		return core.Config{}, errors.New("config is required")
 	}
 
@@ -97,50 +99,50 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 	}
 
 	// Required config options
-	if ethereumChainID := jsConfig.Get("ethereumChainID"); isNullOrUndefined(ethereumChainID) {
+	if ethereumChainID := jsConfig.Get("ethereumChainID"); jsutil.IsNullOrUndefined(ethereumChainID) {
 		return core.Config{}, errors.New("ethereumChainID is required")
 	} else {
 		config.EthereumChainID = ethereumChainID.Int()
 	}
 
 	// Optional config options
-	if verbosity := jsConfig.Get("verbosity"); !isNullOrUndefined(verbosity) {
+	if verbosity := jsConfig.Get("verbosity"); !jsutil.IsNullOrUndefined(verbosity) {
 		config.Verbosity = verbosity.Int()
 	}
-	if useBootstrapList := jsConfig.Get("useBootstrapList"); !isNullOrUndefined(useBootstrapList) {
+	if useBootstrapList := jsConfig.Get("useBootstrapList"); !jsutil.IsNullOrUndefined(useBootstrapList) {
 		config.UseBootstrapList = useBootstrapList.Bool()
 	}
-	if bootstrapList := jsConfig.Get("bootstrapList"); !isNullOrUndefined(bootstrapList) {
+	if bootstrapList := jsConfig.Get("bootstrapList"); !jsutil.IsNullOrUndefined(bootstrapList) {
 		config.BootstrapList = bootstrapList.String()
 	}
-	if blockPollingIntervalSeconds := jsConfig.Get("blockPollingIntervalSeconds"); !isNullOrUndefined(blockPollingIntervalSeconds) {
+	if blockPollingIntervalSeconds := jsConfig.Get("blockPollingIntervalSeconds"); !jsutil.IsNullOrUndefined(blockPollingIntervalSeconds) {
 		config.BlockPollingInterval = time.Duration(blockPollingIntervalSeconds.Int()) * time.Second
 	}
-	if ethereumRPCMaxContentLength := jsConfig.Get("ethereumRPCMaxContentLength"); !isNullOrUndefined(ethereumRPCMaxContentLength) {
+	if ethereumRPCMaxContentLength := jsConfig.Get("ethereumRPCMaxContentLength"); !jsutil.IsNullOrUndefined(ethereumRPCMaxContentLength) {
 		config.EthereumRPCMaxContentLength = ethereumRPCMaxContentLength.Int()
 	}
-	if ethereumRPCMaxRequestsPer24HrUTC := jsConfig.Get("ethereumRPCMaxRequestsPer24HrUTC"); !isNullOrUndefined(ethereumRPCMaxRequestsPer24HrUTC) {
+	if ethereumRPCMaxRequestsPer24HrUTC := jsConfig.Get("ethereumRPCMaxRequestsPer24HrUTC"); !jsutil.IsNullOrUndefined(ethereumRPCMaxRequestsPer24HrUTC) {
 		config.EthereumRPCMaxRequestsPer24HrUTC = ethereumRPCMaxRequestsPer24HrUTC.Int()
 	}
-	if ethereumRPCMaxRequestsPerSecond := jsConfig.Get("ethereumRPCMaxRequestsPerSecond"); !isNullOrUndefined(ethereumRPCMaxRequestsPerSecond) {
+	if ethereumRPCMaxRequestsPerSecond := jsConfig.Get("ethereumRPCMaxRequestsPerSecond"); !jsutil.IsNullOrUndefined(ethereumRPCMaxRequestsPerSecond) {
 		config.EthereumRPCMaxRequestsPerSecond = ethereumRPCMaxRequestsPerSecond.Float()
 	}
-	if enableEthereumRPCRateLimiting := jsConfig.Get("enableEthereumRPCRateLimiting"); !isNullOrUndefined(enableEthereumRPCRateLimiting) {
+	if enableEthereumRPCRateLimiting := jsConfig.Get("enableEthereumRPCRateLimiting"); !jsutil.IsNullOrUndefined(enableEthereumRPCRateLimiting) {
 		config.EnableEthereumRPCRateLimiting = enableEthereumRPCRateLimiting.Bool()
 	}
-	if customContractAddresses := jsConfig.Get("customContractAddresses"); !isNullOrUndefined(customContractAddresses) {
+	if customContractAddresses := jsConfig.Get("customContractAddresses"); !jsutil.IsNullOrUndefined(customContractAddresses) {
 		config.CustomContractAddresses = customContractAddresses.String()
 	}
-	if maxOrdersInStorage := jsConfig.Get("maxOrdersInStorage"); !isNullOrUndefined(maxOrdersInStorage) {
+	if maxOrdersInStorage := jsConfig.Get("maxOrdersInStorage"); !jsutil.IsNullOrUndefined(maxOrdersInStorage) {
 		config.MaxOrdersInStorage = maxOrdersInStorage.Int()
 	}
-	if customOrderFilter := jsConfig.Get("customOrderFilter"); !isNullOrUndefined(customOrderFilter) {
+	if customOrderFilter := jsConfig.Get("customOrderFilter"); !jsutil.IsNullOrUndefined(customOrderFilter) {
 		config.CustomOrderFilter = customOrderFilter.String()
 	}
-	if ethereumRPCURL := jsConfig.Get("ethereumRPCURL"); !isNullOrUndefined(ethereumRPCURL) && ethereumRPCURL.String() != "" {
+	if ethereumRPCURL := jsConfig.Get("ethereumRPCURL"); !jsutil.IsNullOrUndefined(ethereumRPCURL) && ethereumRPCURL.String() != "" {
 		config.EthereumRPCURL = ethereumRPCURL.String()
 	}
-	if web3Provider := jsConfig.Get("web3Provider"); !isNullOrUndefined(web3Provider) {
+	if web3Provider := jsConfig.Get("web3Provider"); !jsutil.IsNullOrUndefined(web3Provider) {
 		config.EthereumRPCClient = providerwrapper.NewRPCClient(web3Provider)
 	}
 
@@ -192,13 +194,13 @@ func (cw *MeshWrapper) Start() error {
 			select {
 			case err := <-cw.errChan:
 				// core.App exited with an error. Call errHandler.
-				if !isNullOrUndefined(cw.errHandler) {
-					cw.errHandler.Invoke(errorToJS(err))
+				if !jsutil.IsNullOrUndefined(cw.errHandler) {
+					cw.errHandler.Invoke(jsutil.ErrorToJS(err))
 				}
 			case <-cw.ctx.Done():
 				return
 			case events := <-cw.orderEvents:
-				if !isNullOrUndefined(cw.orderEventsHandler) {
+				if !jsutil.IsNullOrUndefined(cw.orderEventsHandler) {
 					eventsJS := make([]interface{}, len(events))
 					for i, event := range events {
 						eventsJS[i] = event.JSValue()
@@ -260,7 +262,7 @@ func (cw *MeshWrapper) JSValue() js.Value {
 	return js.ValueOf(map[string]interface{}{
 		// startAsync(): Promise<void>;
 		"startAsync": js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-			return wrapInPromise(func() (interface{}, error) {
+			return jsutil.WrapInPromise(func() (interface{}, error) {
 				return nil, cw.Start()
 			})
 		}),
@@ -278,17 +280,17 @@ func (cw *MeshWrapper) JSValue() js.Value {
 		}),
 		// getStatsAsync(): Promise<Stats>
 		"getStatsAsync": js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-			return wrapInPromise(func() (interface{}, error) {
+			return jsutil.WrapInPromise(func() (interface{}, error) {
 				return cw.GetStats()
 			})
 		}),
 		// getOrdersForPageAsync(page: number, perPage: number, snapshotID?: string): Promise<GetOrdersResponse>
 		"getOrdersForPageAsync": js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-			return wrapInPromise(func() (interface{}, error) {
+			return jsutil.WrapInPromise(func() (interface{}, error) {
 				// snapshotID is optional in the JavaScript function. Check if it is
 				// null or undefined.
 				snapshotID := ""
-				if !isNullOrUndefined(args[2]) {
+				if !jsutil.IsNullOrUndefined(args[2]) {
 					snapshotID = args[2].String()
 				}
 				return cw.GetOrders(args[0].Int(), args[1].Int(), snapshotID)
@@ -296,40 +298,9 @@ func (cw *MeshWrapper) JSValue() js.Value {
 		}),
 		// addOrdersAsync(orders: Array<SignedOrder>): Promise<ValidationResults>
 		"addOrdersAsync": js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-			return wrapInPromise(func() (interface{}, error) {
+			return jsutil.WrapInPromise(func() (interface{}, error) {
 				return cw.AddOrders(args[0], args[1].Bool())
 			})
 		}),
 	})
-}
-
-// errorToJS converts a Go error to a JavaScript Error.
-func errorToJS(err error) js.Value {
-	return js.Global().Get("Error").New(err.Error())
-}
-
-func isNullOrUndefined(value js.Value) bool {
-	return value == js.Null() || value == js.Undefined()
-}
-
-// wrapInPromise converts a potentially blocking Go function to a non-blocking
-// JavaScript Promise. If the function returns an error, the promise will reject
-// with that error. Otherwise, the promise will resolve with the first return
-// value.
-func wrapInPromise(f func() (interface{}, error)) js.Value {
-	var executor js.Func
-	executor = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		resolve := args[0]
-		reject := args[1]
-		go func() {
-			defer executor.Release()
-			if result, err := f(); err != nil {
-				reject.Invoke(errorToJS(err))
-			} else {
-				resolve.Invoke(result)
-			}
-		}()
-		return nil
-	})
-	return js.Global().Get("Promise").New(executor)
 }

--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/0xProject/0x-mesh/browser/go/jsutil"
-
 	"github.com/0xProject/0x-mesh/browser/go/providerwrapper"
 	"github.com/0xProject/0x-mesh/core"
 	"github.com/0xProject/0x-mesh/orderfilter"

--- a/browser/go/main.go
+++ b/browser/go/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall/js"
 	"time"
 
+	"github.com/0xProject/0x-mesh/browser/go/providerwrapper"
 	"github.com/0xProject/0x-mesh/core"
 	"github.com/0xProject/0x-mesh/orderfilter"
 	"github.com/0xProject/0x-mesh/zeroex"
@@ -140,6 +141,9 @@ func convertConfig(jsConfig js.Value) (core.Config, error) {
 	}
 	if customOrderFilter := jsConfig.Get("customOrderFilter"); !isNullOrUndefined(customOrderFilter) {
 		config.CustomOrderFilter = customOrderFilter.String()
+	}
+	if web3Provider := jsConfig.Get("web3Provider"); isNullOrUndefined(web3Provider) {
+		config.EthereumRPCClient = providerwrapper.NewRPCClient(web3Provider)
 	}
 
 	return config, nil

--- a/browser/go/providerwrapper/providerwrapper.go
+++ b/browser/go/providerwrapper/providerwrapper.go
@@ -15,6 +15,7 @@ import (
 	"github.com/0xProject/0x-mesh/browser/go/jsutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
+	log "github.com/sirupsen/logrus"
 )
 
 var _ ethclient.RPCClient = &RPCClient{}
@@ -100,6 +101,7 @@ func (c *RPCClient) CallContext(ctx context.Context, result interface{}, method 
 	case err := <-errChan:
 		return err
 	case jsResult := <-resultChan:
+		// TOOD(albrow): Handle jsResult.error?
 		if err := jsutil.InefficientlyConvertFromJS(jsResult.Get("result"), result); err != nil {
 			return fmt.Errorf("could not decode JSON RPC response: %s", err.Error())
 		}
@@ -108,10 +110,12 @@ func (c *RPCClient) CallContext(ctx context.Context, result interface{}, method 
 }
 
 func (c *RPCClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	log.WithField("batch", b).Error("BatchCallContext was unexpectedly called in the browser")
 	return errors.New("BatchCallContext not yet implemented")
 }
 
 func (c *RPCClient) EthSubscribe(ctx context.Context, channel interface{}, args ...interface{}) (*rpc.ClientSubscription, error) {
+	log.WithField("args", args).Error("EthSubscribe was unexpectedly called in the browser")
 	return nil, errors.New("EthSubscribe not yet implemented")
 }
 

--- a/browser/go/providerwrapper/providerwrapper.go
+++ b/browser/go/providerwrapper/providerwrapper.go
@@ -156,28 +156,28 @@ func (c *RPCClient) Close() {
 	// no-op for now.
 }
 
+// rpcError is an implementation of rpc.Error from the go-ethereum/rpc package.
+type rpcError struct {
+	Message string
+	Code    int
+}
+
 var _ rpc.Error = &rpcError{}
 
-type rpcError struct {
-	message string
-	code    int
-}
-
-func (e rpcError) Message() string {
-	return e.message
-}
-
 func (e rpcError) Error() string {
-	return fmt.Sprintf("Web3Provider returned RPC error (code %d): %s", e.code, e.message)
+	if e.Message == "" {
+		return fmt.Sprintf("json-rpc error %d", e.Code)
+	}
+	return e.Message
 }
 
 func (e rpcError) ErrorCode() int {
-	return e.code
+	return e.Code
 }
 
 func jsErrorToRPCError(jsError js.Value) rpc.Error {
 	return &rpcError{
-		message: jsError.Get("message").String(),
-		code:    jsError.Get("code").Int(),
+		Message: jsError.Get("message").String(),
+		Code:    jsError.Get("code").Int(),
 	}
 }

--- a/browser/go/providerwrapper/providerwrapper.go
+++ b/browser/go/providerwrapper/providerwrapper.go
@@ -7,8 +7,12 @@ package providerwrapper
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math"
+	"math/rand"
 	"syscall/js"
 
+	"github.com/0xProject/0x-mesh/browser/go/jsutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -28,7 +32,79 @@ func NewRPCClient(provider js.Value) *RPCClient {
 }
 
 func (c *RPCClient) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
-	return errors.New("CallContext not yet implemented")
+	// Notable type definitions from Web3:
+	//
+	//     interface JSONRPCRequestPayload {
+	//         params: any[];
+	//         method: string;
+	//         id: number;
+	//         jsonrpc: string;
+	//     }
+	//
+	//     type JSONRPCErrorCallback = (err: Error | null, result?: JSONRPCResponsePayload) => void;
+	//
+	//     sendAsync(payload: JSONRPCRequestPayload, callback: JSONRPCErrorCallback): void;
+	//
+
+	// Set up payload
+	payload := map[string]interface{}{
+		"jsonrpc": "2.0",
+		// TODO(albrow): Do we need to do something special for the id here?
+		"id":     rand.Intn(math.MaxInt32),
+		"method": method,
+	}
+	if len(args) > 0 {
+		// Convert args to a value that is compatible with syscall/js. Since we don't
+		// know the underlying type of args, the only reliable way to do this is to
+		// convert to and from JSON.
+		convertedParams, err := jsutil.InefficientlyConvertToJS(args)
+		if err != nil {
+			return fmt.Errorf("invalid args for JSON payload: %s", err.Error())
+		}
+		payload["params"] = convertedParams
+	}
+
+	// Set up the callback function
+	resultChan := make(chan js.Value, 1)
+	errChan := make(chan error, 1)
+	var callback js.Func
+	callback = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		defer callback.Release()
+		go func() {
+			if len(args) == 0 {
+				errChan <- errors.New("JSONRPCErrorCallback called with no arguments")
+				return
+			}
+			jsError := args[0]
+			if !jsutil.IsNullOrUndefined(jsError) {
+				errChan <- js.Error{
+					Value: jsError,
+				}
+				return
+			}
+			if len(args) < 2 {
+				errChan <- errors.New("JSONRPCErrorCallback called with null/undefined error but no results")
+				return
+			}
+			resultChan <- args[1]
+			return
+		}()
+		return nil
+	})
+
+	// Call sendAsync and use select to wait for the results.
+	c.provider.Call("sendAsync", payload, callback)
+	select {
+	case <-ctx.Done():
+		return context.Canceled
+	case err := <-errChan:
+		return err
+	case jsResult := <-resultChan:
+		if err := jsutil.InefficientlyConvertFromJS(jsResult.Get("result"), result); err != nil {
+			return fmt.Errorf("could not decode JSON RPC response: %s", err.Error())
+		}
+		return nil
+	}
 }
 
 func (c *RPCClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {

--- a/browser/go/providerwrapper/providerwrapper.go
+++ b/browser/go/providerwrapper/providerwrapper.go
@@ -1,6 +1,8 @@
 // +build js,wasm
 
-package ethprovider
+// Package providerwrapper wraps a web3 provider in order to implement the
+// RPCClient interface.
+package providerwrapper
 
 import (
 	"context"

--- a/browser/go/providerwrapper/providerwrapper.go
+++ b/browser/go/providerwrapper/providerwrapper.go
@@ -68,9 +68,8 @@ func (c *RPCClient) CallContext(ctx context.Context, result interface{}, method 
 	// Set up payload
 	payload := map[string]interface{}{
 		"jsonrpc": "2.0",
-		// TODO(albrow): Do we need to do something special for the id here?
-		"id":     rand.Intn(math.MaxInt32),
-		"method": method,
+		"id":      rand.Intn(math.MaxInt32),
+		"method":  method,
 	}
 	if len(args) > 0 {
 		// Convert args to a value that is compatible with syscall/js. Since we don't

--- a/browser/package.json
+++ b/browser/package.json
@@ -26,6 +26,7 @@
         "@0x/order-utils": "^10.0.1",
         "@0x/utils": "^5.1.2",
         "base64-arraybuffer": "^0.2.0",
-        "browserfs": "^1.4.3"
+        "browserfs": "^1.4.3",
+        "ethereum-types": "^3.0.0"
     }
 }

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -1,12 +1,14 @@
 import { SignedOrder } from '@0x/order-utils';
 import { BigNumber } from '@0x/utils';
 import * as BrowserFS from 'browserfs';
+import { Provider } from 'ethereum-types';
 
 import { wasmBuffer } from './generated/wasm_buffer';
 import './wasm_exec';
 
 export { SignedOrder } from '@0x/order-utils';
 export { BigNumber } from '@0x/utils';
+export { Provider } from 'ethereum-types';
 
 // The Go code sets certain global values and this is our only way of
 // interacting with it. Define those values and their types here.
@@ -199,6 +201,9 @@ export interface Config {
     // all the required fields) are automatically included. For more information
     // on JSON Schemas, see https://json-schema.org/
     customOrderFilter?: JsonSchema;
+    // Offers the ability to use your own web3 provider for all Ethereum RPC
+    // requests instead of the default.
+    web3Provider?: Provider;
 }
 
 export interface ContractAddresses {
@@ -318,6 +323,7 @@ interface WrapperConfig {
     customContractAddresses?: string; // json-encoded string instead of Object.
     maxOrdersInStorage?: number;
     customOrderFilter?: string; // json-encoded string instead of Object
+    web3Provider?: Provider;
 }
 
 // The type for signed orders exposed by MeshWrapper. Unlike other types, the

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -113,7 +113,7 @@ export interface Config {
     verbosity?: Verbosity;
     // The URL of an Ethereum node which supports the Ethereum JSON RPC API.
     // Used to validate and watch orders.
-    ethereumRPCURL: string;
+    ethereumRPCURL?: string;
     // EthereumChainID is the chain ID specifying which Ethereum chain you wish to
     // run your Mesh node for
     ethereumChainID: number;
@@ -311,7 +311,7 @@ interface MeshWrapper {
 // The type for configuration exposed by MeshWrapper.
 interface WrapperConfig {
     verbosity?: number;
-    ethereumRPCURL: string;
+    ethereumRPCURL?: string;
     ethereumChainID: number;
     useBootstrapList?: boolean;
     bootstrapList?: string; // comma-separated string instead of an array of strings.

--- a/browser/ts/index.ts
+++ b/browser/ts/index.ts
@@ -1,14 +1,14 @@
 import { SignedOrder } from '@0x/order-utils';
-import { BigNumber } from '@0x/utils';
+import { BigNumber, providerUtils } from '@0x/utils';
 import * as BrowserFS from 'browserfs';
-import { Provider } from 'ethereum-types';
+import { SupportedProvider, ZeroExProvider } from 'ethereum-types';
 
 import { wasmBuffer } from './generated/wasm_buffer';
 import './wasm_exec';
 
 export { SignedOrder } from '@0x/order-utils';
 export { BigNumber } from '@0x/utils';
-export { Provider } from 'ethereum-types';
+export { SupportedProvider } from 'ethereum-types';
 
 // The Go code sets certain global values and this is our only way of
 // interacting with it. Define those values and their types here.
@@ -203,7 +203,7 @@ export interface Config {
     customOrderFilter?: JsonSchema;
     // Offers the ability to use your own web3 provider for all Ethereum RPC
     // requests instead of the default.
-    web3Provider?: Provider;
+    web3Provider?: SupportedProvider;
 }
 
 export interface ContractAddresses {
@@ -323,7 +323,7 @@ interface WrapperConfig {
     customContractAddresses?: string; // json-encoded string instead of Object.
     maxOrdersInStorage?: number;
     customOrderFilter?: string; // json-encoded string instead of Object
-    web3Provider?: Provider;
+    web3Provider?: ZeroExProvider; // Standardized ZeroExProvider instead the more permissive SupportedProvider interface
 }
 
 // The type for signed orders exposed by MeshWrapper. Unlike other types, the
@@ -900,11 +900,14 @@ function configToWrapperConfig(config: Config): WrapperConfig {
     const customContractAddresses =
         config.customContractAddresses == null ? undefined : JSON.stringify(config.customContractAddresses);
     const customOrderFilter = config.customOrderFilter == null ? undefined : JSON.stringify(config.customOrderFilter);
+    const standardizedProvider =
+        config.web3Provider == null ? undefined : providerUtils.standardizeOrThrow(config.web3Provider);
     return {
         ...config,
         bootstrapList,
         customContractAddresses,
         customOrderFilter,
+        web3Provider: standardizedProvider,
     };
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -169,7 +169,7 @@ type Config struct {
 	// EthereumRPCClient is the client to use for all Ethereum RPC reuqests. It is only
 	// settable in browsers and cannot be set via environment variable. If
 	// provided, EthereumRPCURL will be ignored.
-	EthereumRPCClient ethclient.RPCClient
+	EthereumRPCClient ethclient.RPCClient `envvar:"-"`
 }
 
 type snapshotInfo struct {

--- a/examples/browser/src/index.ts
+++ b/examples/browser/src/index.ts
@@ -1,10 +1,11 @@
-import { Mesh, OrderEvent, SignedOrder, BigNumber } from '@0x/mesh-browser';
+import { Mesh, OrderEvent, SignedOrder, BigNumber, Provider } from '@0x/mesh-browser';
 
 (async () => {
     // Configure Mesh to use mainnet and Infura.
     const mesh = new Mesh({
-        ethereumRPCURL: 'https://mainnet.infura.io/v3/af2e590be00f463fbfd0b546784065ad',
+        verbosity: 4,
         ethereumChainID: 1,
+        web3Provider: (window as any).web3.currentProvider as Provider,
     });
 
     // This handler will be called whenver there is a critical error.

--- a/examples/browser/src/index.ts
+++ b/examples/browser/src/index.ts
@@ -1,11 +1,11 @@
-import { Mesh, OrderEvent, SignedOrder, BigNumber, Provider } from '@0x/mesh-browser';
+import { Mesh, OrderEvent, SignedOrder, BigNumber, SupportedProvider } from '@0x/mesh-browser';
 
 (async () => {
-    // Configure Mesh to use mainnet and Infura.
+    // Configure Mesh to use web3.currentProvider (e.g. provided by MetaMask).
     const mesh = new Mesh({
         verbosity: 4,
         ethereumChainID: 1,
-        web3Provider: (window as any).web3.currentProvider as Provider,
+        web3Provider: (window as any).web3.currentProvider as SupportedProvider,
     });
 
     // This handler will be called whenver there is a critical error.
@@ -24,8 +24,9 @@ import { Mesh, OrderEvent, SignedOrder, BigNumber, Provider } from '@0x/mesh-bro
     // Start Mesh *after* we set up the handlers.
     await mesh.startAsync();
 
-    // This order is for demonstration purposes only and is invalid. It will be
-    // rejected by Mesh. You can replace it with a valid order.
+    // This order is for demonstration purposes only and will likely be expired
+    // by the time you run this example. If so, it will be rejected by Mesh. You
+    // can replace it with a valid order.
     const order: SignedOrder = {
         signature:
             '0x1c68eb1e2577e9f51776bdb06ec51fcec9aec0ea1565eca5e243917cecaafaa46b3b9590ff6575bf1c048d0b4ec5773a2e3a8df3bf117e1613e2a7b57d6f95c95a02',

--- a/examples/browser/src/index.ts
+++ b/examples/browser/src/index.ts
@@ -27,24 +27,24 @@ import { Mesh, OrderEvent, SignedOrder, BigNumber, Provider } from '@0x/mesh-bro
     // This order is for demonstration purposes only and is invalid. It will be
     // rejected by Mesh. You can replace it with a valid order.
     const order: SignedOrder = {
-        chainId: 1,
-        makerAddress: '0xa3eCE5D5B6319Fa785EfC10D3112769a46C6E149',
-        makerAssetData: '0xf47261b0000000000000000000000000e41d2489571d322189246dafa5ebde1f4699f498',
-        makerAssetAmount: new BigNumber('1000000000000000000'),
-        makerFee: new BigNumber('0'),
-        makerFeeAssetData: '0x',
-        takerAddress: '0x0000000000000000000000000000000000000000',
-        takerAssetData: '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-        takerAssetAmount: new BigNumber('10000000000000000000000'),
-        takerFee: new BigNumber('0'),
-        takerFeeAssetData: '0x',
-        senderAddress: '0x0000000000000000000000000000000000000000',
-        exchangeAddress: '0x080bf510FCbF18b91105470639e9561022937712',
-        feeRecipientAddress: '0x0000000000000000000000000000000000000000',
-        expirationTimeSeconds: new BigNumber('1586340602'),
-        salt: new BigNumber('41253767178111694375645046549067933145709740457131351457334397888365956743955'),
         signature:
-            '0x1c0827552a3bde2c72560362950a69f581ae7a1e6fa8c160bb437f3a61002bb96c22b646edd3b103b976db4aa4840a11c13306b2a02a0bb6ce647806c858c238ec03',
+            '0x1c68eb1e2577e9f51776bdb06ec51fcec9aec0ea1565eca5e243917cecaafaa46b3b9590ff6575bf1c048d0b4ec5773a2e3a8df3bf117e1613e2a7b57d6f95c95a02',
+        senderAddress: '0x0000000000000000000000000000000000000000',
+        makerAddress: '0x4418755f710468e223797a006603e29937e825bc',
+        takerAddress: '0x0000000000000000000000000000000000000000',
+        makerFee: new BigNumber('0'),
+        takerFee: new BigNumber('0'),
+        makerAssetAmount: new BigNumber('3000000000'),
+        takerAssetAmount: new BigNumber('19500000000000000000'),
+        makerAssetData: '0xf47261b0000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        takerAssetData: '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        salt: new BigNumber('1579725034907'),
+        exchangeAddress: '0x61935cbdd02287b511119ddb11aeb42f1593b7ef',
+        feeRecipientAddress: '0xa258b39954cef5cb142fd567a46cddb31a670124',
+        expirationTimeSeconds: new BigNumber('1580329834'),
+        makerFeeAssetData: '0x',
+        chainId: 1,
+        takerFeeAssetData: '0x',
     };
 
     // Add the order and log the result.

--- a/examples/browser/yarn.lock
+++ b/examples/browser/yarn.lock
@@ -69,6 +69,7 @@
     "@0x/utils" "^5.1.2"
     base64-arraybuffer "^0.2.0"
     browserfs "^1.4.3"
+    ethereum-types "^3.0.0"
 
 "@0x/order-utils@^10.0.1":
   version "10.1.0"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/0xProject/0x-mesh
 go 1.12
 
 replace (
-	github.com/ethereum/go-ethereum => github.com/0xProject/go-ethereum v1.8.8-0.20191104224527-9d5c202240be
+	github.com/ethereum/go-ethereum => github.com/0xProject/go-ethereum v1.8.8-0.20200121231321-1510563ddd1f
 	github.com/libp2p/go-flow-metrics => github.com/libp2p/go-flow-metrics v0.0.3
 	github.com/libp2p/go-ws-transport => github.com/libp2p/go-ws-transport v0.0.0-20191008032742-3098bba549e8
 	github.com/syndtr/goleveldb => github.com/0xProject/goleveldb v1.0.1-0.20191115232649-6a187a47701c

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace (
 	github.com/ethereum/go-ethereum => github.com/0xProject/go-ethereum v1.8.8-0.20200121231321-1510563ddd1f
 	github.com/libp2p/go-flow-metrics => github.com/libp2p/go-flow-metrics v0.0.3
 	github.com/libp2p/go-ws-transport => github.com/libp2p/go-ws-transport v0.0.0-20191008032742-3098bba549e8
+	github.com/plaid/go-envvar => github.com/albrow/go-envvar v1.1.1-0.20200123010345-a6ece4436cb7
 	github.com/syndtr/goleveldb => github.com/0xProject/goleveldb v1.0.1-0.20191115232649-6a187a47701c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/0xProject/go-ethereum v1.8.8-0.20191104224527-9d5c202240be h1:48+Xt5qtLvEUOJJD2pxM4qVbF3eoTsYmHthq2+zT8M4=
 github.com/0xProject/go-ethereum v1.8.8-0.20191104224527-9d5c202240be/go.mod h1:GCj8W8G7wxclyZu5dgA4vru0iUU4DK6pUE/FSPRd4Rg=
+github.com/0xProject/go-ethereum v1.8.8-0.20200121231321-1510563ddd1f h1:3V/XMVlgBlSh+Q1G0kg8e4dEh3UxsTpce9Ix1dDyRiU=
+github.com/0xProject/go-ethereum v1.8.8-0.20200121231321-1510563ddd1f/go.mod h1:GCj8W8G7wxclyZu5dgA4vru0iUU4DK6pUE/FSPRd4Rg=
 github.com/0xProject/goleveldb v1.0.1-0.20191115232649-6a187a47701c h1:sMhvadadLwwpHsq4hDRAd+lcmQHJYpn44Oe9f7sFTmA=
 github.com/0xProject/goleveldb v1.0.1-0.20191115232649-6a187a47701c/go.mod h1:vCim/erjgVmww+K+tF4+tf/zs63CPRiOtgdXqLgTM1Q=
 github.com/0xProject/qunit v0.0.0-20190730000255-81c18fdf7752/go.mod h1:Onz5mS+Tpffz0tyRWdHDrqKcQ1ZFNeRhYHrNAkaMgeQ=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
+github.com/albrow/go-envvar v1.1.1-0.20200123010345-a6ece4436cb7 h1:KyGi2bFjYJwahVfEJT1T5YvHTrEEYAqIZkIuxTAYRPY=
+github.com/albrow/go-envvar v1.1.1-0.20200123010345-a6ece4436cb7/go.mod h1:jGxERjkVawmx7yWrFUix71jtSXm1ZtUai96wBHTwkPo=
 github.com/albrow/stringset v2.1.0+incompatible h1:P90SSV7fle22yLbhDSLRC8Jtec0tCE3A8hJihfxf25E=
 github.com/albrow/stringset v2.1.0+incompatible/go.mod h1:ltP0XRz96SPEM8ofD1BaE4IpTR2uCGSk6Z2VRfh1Llw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/integration-tests/browser/src/index.ts
+++ b/integration-tests/browser/src/index.ts
@@ -5,6 +5,7 @@ import { signatureUtils, Order, orderHashUtils } from '@0x/order-utils';
 
 const ethereumRPCURL = 'http://localhost:8545';
 
+// Set up a Web3 Provider that uses the RPC endpoint
 const provider = new Web3ProviderEngine();
 provider.addProvider(new RPCSubprovider(ethereumRPCURL));
 provider.start();
@@ -46,12 +47,12 @@ provider.start();
     // node.
     const mesh = new Mesh({
         verbosity: Verbosity.Debug,
-        ethereumRPCURL,
         ethereumChainID: 1337,
         bootstrapList: ['/ip4/127.0.0.1/tcp/60500/ws/ipfs/16Uiu2HAmGd949LwaV4KNvK2WDSiMVy7xEmW983VH75CMmefmMpP7'],
         customOrderFilter: {
             properties: { makerAddress: { const: '0x6ecbe1db9ef729cbe972c83fb886247691fb6beb' } },
         },
+        web3Provider: provider,
     });
 
     // This handler will be called whenver there is a critical error.

--- a/integration-tests/browser/yarn.lock
+++ b/integration-tests/browser/yarn.lock
@@ -69,6 +69,7 @@
     "@0x/utils" "^5.1.2"
     base64-arraybuffer "^0.2.0"
     browserfs "^1.4.3"
+    ethereum-types "^3.0.0"
 
 "@0x/order-utils@^10.0.1":
   version "10.0.1"

--- a/zeroex/ordervalidator/order_validator_test.go
+++ b/zeroex/ordervalidator/order_validator_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -150,7 +151,9 @@ func TestBatchValidateOffChainCases(t *testing.T) {
 	for _, testCase := range testCases {
 
 		rateLimiter := ratelimit.NewUnlimited()
-		ethClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
+		rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+		require.NoError(t, err)
+		ethClient, err := ethrpcclient.New(rpcClient, defaultEthRPCTimeout, rateLimiter)
 		require.NoError(t, err)
 
 		signedOrders := []*zeroex.SignedOrder{
@@ -185,7 +188,9 @@ func TestBatchValidateAValidOrder(t *testing.T) {
 	}
 
 	rateLimiter := ratelimit.NewUnlimited()
-	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+	ethRPCClient, err := ethrpcclient.New(rpcClient, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
 	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength)
@@ -215,7 +220,9 @@ func TestBatchValidateSignatureInvalid(t *testing.T) {
 	}
 
 	rateLimiter := ratelimit.NewUnlimited()
-	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+	ethRPCClient, err := ethrpcclient.New(rpcClient, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
 	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength)
@@ -246,7 +253,9 @@ func TestBatchValidateUnregisteredCoordinatorSoftCancels(t *testing.T) {
 	}
 
 	rateLimiter := ratelimit.NewUnlimited()
-	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+	ethRPCClient, err := ethrpcclient.New(rpcClient, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
 	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength)
@@ -280,7 +289,9 @@ func TestBatchValidateCoordinatorSoftCancels(t *testing.T) {
 	}
 
 	rateLimiter := ratelimit.NewUnlimited()
-	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+	ethRPCClient, err := ethrpcclient.New(rpcClient, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
 	orderValidator, err := New(ethRPCClient, constants.TestChainID, constants.TestMaxContentLength)
@@ -334,7 +345,9 @@ func TestComputeOptimalChunkSizesMaxContentLengthTooLow(t *testing.T) {
 	require.NoError(t, err)
 
 	rateLimiter := ratelimit.NewUnlimited()
-	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+	ethRPCClient, err := ethrpcclient.New(rpcClient, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
 	maxContentLength := singleOrderPayloadSize - 10
@@ -352,7 +365,9 @@ func TestComputeOptimalChunkSizes(t *testing.T) {
 	require.NoError(t, err)
 
 	rateLimiter := ratelimit.NewUnlimited()
-	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+	ethRPCClient, err := ethrpcclient.New(rpcClient, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
 	maxContentLength := singleOrderPayloadSize * 3
@@ -393,7 +408,9 @@ func TestComputeOptimalChunkSizesMultiAssetOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	rateLimiter := ratelimit.NewUnlimited()
-	ethRPCClient, err := ethrpcclient.New(constants.GanacheEndpoint, defaultEthRPCTimeout, rateLimiter)
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	require.NoError(t, err)
+	ethRPCClient, err := ethrpcclient.New(rpcClient, defaultEthRPCTimeout, rateLimiter)
 	require.NoError(t, err)
 
 	maxContentLength := singleOrderPayloadSize * 3

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -78,7 +79,11 @@ func init() {
 		panic(err)
 	}
 	rateLimiter := ratelimit.NewUnlimited()
-	ethRPCClient, err = ethrpcclient.New(constants.GanacheEndpoint, ethereumRPCRequestTimeout, rateLimiter)
+	rpcClient, err := rpc.Dial(constants.GanacheEndpoint)
+	if err != nil {
+		panic(err)
+	}
+	ethRPCClient, err = ethrpcclient.New(rpcClient, ethereumRPCRequestTimeout, rateLimiter)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes #581.

This PR adds the ability to use a Web3 Provider in the browser, which takes the place of `config.EthereumRPCURL` and will be used for all Ethereum RPC requests.

Most of the magic is in the new `providerwrapper` package. This package implements `ethclient.RPCClient` by wrapping a Web3 provider and calling `sendAsync`.

I also updated the integration tests to use a Web3 Provider. This is the bare minimum we can do for testing. After https://github.com/0xProject/0x-mesh/pull/649 is merged we should plan on adding more unit tests for a lot of the conversion code in this PR.

This PR depends on some changes to two separate dependencies:

1. For `go-ethereum`, I [refactored `ethclient.RPCClient` into an interface](https://github.com/0xProject/go-ethereum/commits/wasm_signer_core_3).
2. For `plaid/go-envvar`, I added [support for ignoring struct fields](https://github.com/plaid/go-envvar/pull/17).

I updated our __go.mod__ file to use our forks of these dependencies for now.