### PR TITLE
Increase timing tolerance in rate_limiter_test.go

### DIFF
--- a/ethereum/ratelimit/rate_limiter_test.go
+++ b/ethereum/ratelimit/rate_limiter_test.go
@@ -23,7 +23,7 @@ const (
 	// grantTimingTolerance is the maximum allowed difference between the expected
 	// time for a request to be granted and the actual time it is granted. Used
 	// throughout these tests to account for subtle timing differences.
-	grantTimingTolerance = 20 * time.Millisecond
+	grantTimingTolerance = 50 * time.Millisecond
 )
 
 // Scenario1: If the 24 hour limit has *not* been hit, requests should be


### PR DESCRIPTION
I was still noticing some CI failures due to timing differences, especially when running tests in a headless browser. You can find a recent example here: https://app.circleci.com/jobs/github/0xProject/0x-mesh/2515.