### PR TITLE
Backport Release 7.1.0-beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       BASH_ENV: ~/.nvm/nvm.sh
     docker:
       - image: circleci/golang:1.12.13-browsers
-      - image: 0xorg/ganache-cli:latest
+      - image: 0xorg/ganache-cli:4.3.0
         environment:
             VERSION: 4.3.3
     resource_class: large

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v7.1.0-beta
+
+### Features ✅
+
+ - Reduce startup time for Mesh node by only waiting for a block to be processed if Mesh isn't already sync'ed up to the latest block. ([#622](https://github.com/0xProject/0x-mesh/pull/622))
+ - Developers can now override the contract addresses for any testnet using the `CUSTOM_CONTRACT_ADDRESSES` env config ([#640](https://github.com/0xProject/0x-mesh/pull/640)).
+  - Add `getOrdersForPageAsync` method to `@0x/mesh-rpc-client` WS client interface so that clients can paginate through the retrieved orders themselves ([#642](https://github.com/0xProject/0x-mesh/pull/642)).
+
+### Bug fixes 🐞
+
+ - Fixed a bug where we attempted to update the same order multiple times in a single DB txn, causing the later update to noop. ([#623](https://github.com/0xProject/0x-mesh/pull/623)).
+- Fixed a bug which could cause Mesh to exit if a re-org condition occurs causing a block to be added and removed within the same block sync operation. ([#614](https://github.com/0xProject/0x-mesh/pull/614)).
+ - Fix bug where we attempted to update the same order multiple times in a single DB txn, causing the later update to noop. ([#623](https://github.com/0xProject/0x-mesh/pull/623))
+
 ## v7.0.0-beta
 
 ### Breaking changes 🛠 

--- a/core/core.go
+++ b/core/core.go
@@ -126,14 +126,15 @@ type Config struct {
 	// is typically only needed for testing on custom chains/networks. The given
 	// addresses are added to the default list of addresses for known chains/networks and
 	// overriding any contract addresses for known chains/networks is not allowed. The
-	// addresses for exchange, devUtils, erc20Proxy, and erc721Proxy are required
+	// addresses for exchange, devUtils, erc20Proxy, erc721Proxy and erc1155Proxy are required
 	// for each chain/network. For example:
 	//
 	//    {
 	//        "exchange":"0x48bacb9266a570d521063ef5dd96e61686dbe788",
 	//        "devUtils": "0x38ef19fdf8e8415f18c307ed71967e19aac28ba1",
 	//        "erc20Proxy": "0x1dc4c1cefef38a777b15aa20260a54e584b16c48",
-	//        "erc721Proxy": "0x1d7022f5b17d2f8b695918fb48fa1089c9f85401"
+	//        "erc721Proxy": "0x1d7022f5b17d2f8b695918fb48fa1089c9f85401",
+	//        "erc1155Proxy": "0x64517fa2b480ba3678a2a3c0cf08ef7fd4fad36f"
 	//    }
 	//
 	CustomContractAddresses string `envvar:"CUSTOM_CONTRACT_ADDRESSES" default:""`

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -9,10 +10,19 @@ import (
 )
 
 var (
-	ErrDiscarded             = errors.New("transaction has already been discarded")
-	ErrCommitted             = errors.New("transaction has already been committed")
-	ErrConflictingOperations = errors.New("cannot perform more than one operation (insert/delete/update) on the same model within a transaction")
+	ErrDiscarded = errors.New("transaction has already been discarded")
+	ErrCommitted = errors.New("transaction has already been committed")
 )
+
+// ConflictingOperationsError is returned when two conflicting operations are attempted within the same
+// transaction
+type ConflictingOperationsError struct {
+	operation string
+}
+
+func (e ConflictingOperationsError) Error() string {
+	return fmt.Sprintf("cannot perform more than one operation (%s) on the same model within a transaction", e.operation)
+}
 
 // Transaction is an atomic database transaction for a single collection which
 // can be used to guarantee consistency.
@@ -139,7 +149,7 @@ func (txn *Transaction) Insert(model Model) error {
 		return err
 	}
 	if txn.affectedIDs.Contains(string(model.ID())) {
-		return ErrConflictingOperations
+		return ConflictingOperationsError{operation: "insert"}
 	}
 	if err := insertWithTransaction(txn.colInfo, txn.readWriter, model); err != nil {
 		return err
@@ -159,7 +169,7 @@ func (txn *Transaction) Update(model Model) error {
 		return err
 	}
 	if txn.affectedIDs.Contains(string(model.ID())) {
-		return ErrConflictingOperations
+		return ConflictingOperationsError{operation: "update"}
 	}
 	if err := updateWithTransaction(txn.colInfo, txn.readWriter, model); err != nil {
 		return err
@@ -178,7 +188,7 @@ func (txn *Transaction) Delete(id []byte) error {
 		return err
 	}
 	if txn.affectedIDs.Contains(string(id)) {
-		return ErrConflictingOperations
+		return ConflictingOperationsError{operation: "delete"}
 	}
 	if err := deleteWithTransaction(txn.colInfo, txn.readWriter, id); err != nil {
 		return err

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -21,7 +21,7 @@ type ConflictingOperationsError struct {
 }
 
 func (e ConflictingOperationsError) Error() string {
-	return fmt.Sprintf("cannot perform more than one operation (%s) on the same model within a transaction", e.operation)
+	return fmt.Sprintf("error on %s: cannot perform more than one operation on the same model within a transaction", e.operation)
 }
 
 // Transaction is an atomic database transaction for a single collection which

--- a/db/transaction_test.go
+++ b/db/transaction_test.go
@@ -284,7 +284,7 @@ func TestTransactionDeleteThenInsertSameModel(t *testing.T) {
 	require.NoError(t, txn.Delete(model.ID()))
 	err = txn.Insert(model)
 	assert.Error(t, err)
-	assert.Equal(t, ErrConflictingOperations, err, "wrong error")
+	assert.Equal(t, ConflictingOperationsError{operation: "insert"}, err, "wrong error")
 }
 
 func TestTransactionInsertThenDeleteSameModel(t *testing.T) {
@@ -309,7 +309,7 @@ func TestTransactionInsertThenDeleteSameModel(t *testing.T) {
 	require.NoError(t, txn.Insert(model))
 	err = txn.Delete(model.ID())
 	assert.Error(t, err)
-	assert.Equal(t, ErrConflictingOperations, err, "wrong error")
+	assert.Equal(t, ConflictingOperationsError{operation: "delete"}, err, "wrong error")
 }
 
 func TestTransactionInsertThenInsertSameModel(t *testing.T) {
@@ -334,7 +334,7 @@ func TestTransactionInsertThenInsertSameModel(t *testing.T) {
 	require.NoError(t, txn.Insert(model))
 	err = txn.Insert(model)
 	assert.Error(t, err)
-	assert.Equal(t, ErrConflictingOperations, err, "wrong error")
+	assert.Equal(t, ConflictingOperationsError{operation: "insert"}, err, "wrong error")
 }
 
 func TestTransactionDeleteThenDeleteSameModel(t *testing.T) {
@@ -360,7 +360,7 @@ func TestTransactionDeleteThenDeleteSameModel(t *testing.T) {
 	require.NoError(t, txn.Delete(model.ID()))
 	err = txn.Delete(model.ID())
 	assert.Error(t, err)
-	assert.Equal(t, ErrConflictingOperations, err, "wrong error")
+	assert.Equal(t, ConflictingOperationsError{operation: "delete"}, err, "wrong error")
 }
 
 func TestTransactionInsertThenUpdateSameModel(t *testing.T) {
@@ -385,5 +385,5 @@ func TestTransactionInsertThenUpdateSameModel(t *testing.T) {
 	require.NoError(t, txn.Insert(model))
 	err = txn.Update(model)
 	assert.Error(t, err)
-	assert.Equal(t, ErrConflictingOperations, err, "wrong error")
+	assert.Equal(t, ConflictingOperationsError{operation: "update"}, err, "wrong error")
 }

--- a/ethereum/blockchain_lifecycle.go
+++ b/ethereum/blockchain_lifecycle.go
@@ -46,6 +46,9 @@ func (b *BlockchainLifecycle) Revert(t *testing.T) {
 }
 
 // Mine force-mines a block with the specified block timestamp
+// WARNING(fabio): Using this method will brick `eth_getLogs` such that it always
+// returns the logs for the latest block, even if a specific blockHash is specified
+// Source: https://github.com/trufflesuite/ganache-cli/issues/708
 func (b *BlockchainLifecycle) Mine(t *testing.T, blockTimestamp time.Time) {
 	var didForceMine string
 	err := b.rpcClient.Call(&didForceMine, "evm_mine", blockTimestamp.Unix())

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -17,8 +17,8 @@ func GetContractAddressesForChainID(chainID int) (ContractAddresses, error) {
 }
 
 func AddContractAddressesForChainID(chainID int, addresses ContractAddresses) error {
-	if _, alreadExists := ChainIDToContractAddresses[chainID]; alreadExists {
-		return fmt.Errorf("cannot add contract addresses for chain ID %d: addresses for this chain id are already defined", chainID)
+	if _, alreadExists := ChainIDToContractAddresses[chainID]; alreadExists && chainID == 1 {
+		return fmt.Errorf("cannot add contract addresses for chain ID %d: addresses for this chain id are hard-coded", chainID)
 	}
 	if addresses.Exchange == constants.NullAddress {
 		return fmt.Errorf("cannot add contract addresses for chain ID %d: Exchange address is required", chainID)

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -103,7 +103,7 @@ var ChainIDToContractAddresses = map[int]ContractAddresses{
 		Exchange:            common.HexToAddress("0x30589010550762d2f0d06f650d8e8b6ade6dbf4b"),
 		Coordinator:         common.HexToAddress("0x2ba02e03ee0029311e0f43715307870a3e701b53"),
 		CoordinatorRegistry: common.HexToAddress("0x09fb99968c016a3ff537bf58fb3d9fe55a7975d5"),
-		DevUtils:            common.HexToAddress("0x09a379ef7218bcfd8913faa8b281ebc5a2e0bc04"),
+		DevUtils:            common.HexToAddress("0x80101f90446d9e19a80109ac2767c8c957debb29"),
 		WETH9:               common.HexToAddress("0xd0a1e359811322d97991e03f863a0c30c2cf029c"),
 		ZRXToken:            common.HexToAddress("0x2002d3812f58e35f0ea1ffbf80a75a38c32175fa"),
 	},

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -103,7 +103,7 @@ var ChainIDToContractAddresses = map[int]ContractAddresses{
 		Exchange:            common.HexToAddress("0x30589010550762d2f0d06f650d8e8b6ade6dbf4b"),
 		Coordinator:         common.HexToAddress("0x2ba02e03ee0029311e0f43715307870a3e701b53"),
 		CoordinatorRegistry: common.HexToAddress("0x09fb99968c016a3ff537bf58fb3d9fe55a7975d5"),
-		DevUtils:            common.HexToAddress("0x1e3616bc5144362f95d72de41874395567697e93"),
+		DevUtils:            common.HexToAddress("0x09a379ef7218bcfd8913faa8b281ebc5a2e0bc04"),
 		WETH9:               common.HexToAddress("0xd0a1e359811322d97991e03f863a0c30c2cf029c"),
 		ZRXToken:            common.HexToAddress("0x2002d3812f58e35f0ea1ffbf80a75a38c32175fa"),
 	},

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -17,8 +17,8 @@ func GetContractAddressesForChainID(chainID int) (ContractAddresses, error) {
 }
 
 func AddContractAddressesForChainID(chainID int, addresses ContractAddresses) error {
-	if _, alreadExists := ChainIDToContractAddresses[chainID]; alreadExists && chainID == 1 {
-		return fmt.Errorf("cannot add contract addresses for chain ID %d: addresses for this chain id are hard-coded", chainID)
+	if chainID == 1 {
+		return fmt.Errorf("cannot add contract addresses for chainID 1: addresses for mainnet are hard-coded and cannot be changed")
 	}
 	if addresses.Exchange == constants.NullAddress {
 		return fmt.Errorf("cannot add contract addresses for chain ID %d: Exchange address is required", chainID)

--- a/rpc/clients/typescript/src/ws_client.ts
+++ b/rpc/clients/typescript/src/ws_client.ts
@@ -293,27 +293,23 @@ export class WSClient {
         let snapshotID = ''; // New snapshot
 
         let page = 0;
-        const rawGetOrdersResponse: RawGetOrdersResponse = await this._wsProvider.send('mesh_getOrders', [
-            page,
-            perPage,
-            snapshotID,
-        ]);
-        let getOrdersResponse = WSClient._convertRawGetOrdersResponse(rawGetOrdersResponse);
-        snapshotID = rawGetOrdersResponse.snapshotID;
-        let rawOrdersInfos = rawGetOrdersResponse.ordersInfos;
+        let getOrdersResponse = await this.getOrdersForPageAsync(page, perPage, snapshotID);
+        snapshotID = getOrdersResponse.snapshotID;
+        let ordersInfos = getOrdersResponse.ordersInfos;
 
-        let allRawOrderInfos: RawOrderInfo[] = [];
+        let allOrderInfos: OrderInfo[] = [];
+
         do {
-            allRawOrderInfos = [...allRawOrderInfos, ...rawOrdersInfos];
+            allOrderInfos = [...allOrderInfos, ...ordersInfos];
             page++;
-            rawOrdersInfos = (await this._wsProvider.send('mesh_getOrders', [page, perPage, snapshotID])).ordersInfos;
-        } while (rawOrdersInfos.length > 0);
+            getOrdersResponse = await this.getOrdersForPageAsync(page, perPage, snapshotID);
+            ordersInfos = getOrdersResponse.ordersInfos;
+        } while (ordersInfos.length > 0);
 
-        const orderInfos = WSClient._convertRawOrderInfos(allRawOrderInfos);
         getOrdersResponse = {
             snapshotID,
             snapshotTimestamp: getOrdersResponse.snapshotTimestamp,
-            ordersInfos: orderInfos,
+            ordersInfos: allOrderInfos,
         };
         return getOrdersResponse;
     }

--- a/rpc/clients/typescript/src/ws_client.ts
+++ b/rpc/clients/typescript/src/ws_client.ts
@@ -287,7 +287,7 @@ export class WSClient {
     /**
      * Get all 0x signed orders currently stored in the Mesh node
      * @param perPage number of signedOrders to fetch per paginated request
-     * @returns all orders, their hash and their fillableTakerAssetAmount
+     * @returns the snapshotID, snapshotTimestamp and all orders, their hashes and fillableTakerAssetAmounts
      */
     public async getOrdersAsync(perPage: number = 200): Promise<GetOrdersResponse> {
         let snapshotID = ''; // New snapshot

--- a/rpc/clients/typescript/src/ws_client.ts
+++ b/rpc/clients/typescript/src/ws_client.ts
@@ -318,6 +318,24 @@ export class WSClient {
         return getOrdersResponse;
     }
     /**
+     * Get page of 0x signed orders stored on the Mesh node at the specified snapshot
+     * @param page Page index at which to retrieve orders
+     * @param perPage number of signedOrders to fetch per paginated request
+     * @param snapshotID The DB snapshot at which to fetch orders. If omitted, a new snapshot is created
+     * @returns the snapshotID, snapshotTimestamp and all orders, their hashes and fillableTakerAssetAmounts
+     */
+    public async getOrdersForPageAsync(page: number, perPage: number = 200, snapshotID?: string): Promise<GetOrdersResponse> {
+        const finalSnapshotID = snapshotID === undefined ? '' : snapshotID;
+
+        const rawGetOrdersResponse: RawGetOrdersResponse = await this._wsProvider.send('mesh_getOrders', [
+            page,
+            perPage,
+            finalSnapshotID,
+        ]);
+        const getOrdersResponse = WSClient._convertRawGetOrdersResponse(rawGetOrdersResponse);
+        return getOrdersResponse;
+    }
+    /**
      * Subscribe to the 'orders' topic and receive order events from Mesh. This method returns a
      * subscriptionId that can be used to `unsubscribe()` from this subscription.
      * @param   cb   callback function where you'd like to get notified about order events

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -342,6 +342,10 @@ func (w *Watcher) removedCheckerLoop(ctx context.Context) error {
 	}
 }
 
+// handleOrderExpirations takes care of generating expired and unexpired order events for orders that do not require re-validation.
+// Since expiry is now done according to block timestamp, we can figure out which orders have expired/unexpired statically. We do not
+// process blocks that require re-validation, since the validation process will already emit the necessary events and we cannot make
+// multiple updates to an order within a single DB transaction.
 func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlockTimestamp, previousLatestBlockTimestamp time.Time, ordersToRevalidate map[common.Hash]*meshdb.Order) ([]*zeroex.OrderEvent, error) {
 	orderEvents := []*zeroex.OrderEvent{}
 	var defaultTime time.Time

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1037,28 +1037,20 @@ func (w *Watcher) updateBlockHeadersStoredInDB(miniHeadersColTxn *db.Transaction
 
 	for _, blockHeader := range blocksToAdd {
 		if err := miniHeadersColTxn.Insert(blockHeader); err != nil {
-			if _, ok := err.(db.ConflictingOperationsError); ok {
-				logger.WithFields(logger.Fields{
-					"error":  err.Error(),
-					"hash":   blockHeader.Hash,
-					"number": blockHeader.Number,
-				}).Error("Failed to update miniHeaders")
-			} else {
-				return err
-			}
+			logger.WithFields(logger.Fields{
+				"error":  err.Error(),
+				"hash":   blockHeader.Hash,
+				"number": blockHeader.Number,
+			}).Error("Failed to delete miniHeaders")
 		}
 	}
 	for _, blockHeader := range blocksToRemove {
 		if err := miniHeadersColTxn.Delete(blockHeader.ID()); err != nil {
-			if _, ok := err.(db.ConflictingOperationsError); ok {
-				logger.WithFields(logger.Fields{
-					"error":  err.Error(),
-					"hash":   blockHeader.Hash,
-					"number": blockHeader.Number,
-				}).Error("Failed to delete miniHeaders")
-			} else {
-				return err
-			}
+			logger.WithFields(logger.Fields{
+				"error":  err.Error(),
+				"hash":   blockHeader.Hash,
+				"number": blockHeader.Number,
+			}).Error("Failed to delete miniHeaders")
 		}
 	}
 

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1505,10 +1505,6 @@ func (w *Watcher) permanentlyDeleteOrder(deleter orderDeleter, order *meshdb.Ord
 			return nil
 		}
 		if _, ok := err.(db.NotFoundError); ok {
-			logger.WithFields(logger.Fields{
-				"error": err.Error(),
-				"order": order,
-			}).Warn("Attempted to delete order that no longer exists")
 			return nil // Already deleted. Noop.
 		}
 		return err

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1006,7 +1006,7 @@ func (w *Watcher) trimOrdersAndGenerateEvents() ([]*zeroex.OrderEvent, error) {
 }
 
 // updateBlockHeadersStoredInDB updates the block headers stored in the DB. Since our DB txns don't support
-// multiple operations involving the same entry, we make sure we only perform either an insert or a deletion
+// multiple operations involving the same entry, we make sure we only perform either an insertion or a deletion
 // for each block in this method.
 func (w *Watcher) updateBlockHeadersStoredInDB(miniHeadersColTxn *db.Transaction, events []*blockwatch.Event) error {
 	blocksToAdd := map[common.Hash]*miniheader.MiniHeader{}

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -342,7 +342,7 @@ func (w *Watcher) removedCheckerLoop(ctx context.Context) error {
 	}
 }
 
-func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlockTimestamp time.Time, previousLatestBlockTimestamp time.Time) ([]*zeroex.OrderEvent, error) {
+func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlockTimestamp, previousLatestBlockTimestamp time.Time, ordersToRevalidate map[common.Hash]*meshdb.Order) ([]*zeroex.OrderEvent, error) {
 	orderEvents := []*zeroex.OrderEvent{}
 	var defaultTime time.Time
 
@@ -350,6 +350,11 @@ func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlo
 		expiredOrders := w.expirationWatcher.Prune(latestBlockTimestamp)
 		for _, expiredOrder := range expiredOrders {
 			orderHash := common.HexToHash(expiredOrder.ID)
+			// If we will re-validate this order, the revalidation process will discover that
+			// it's expired, and an appropriate event will already be emitted
+			if _, ok := ordersToRevalidate[orderHash]; ok {
+				continue
+			}
 			order := &meshdb.Order{}
 			err := w.meshDB.Orders.FindByID(orderHash.Bytes(), order)
 			if err != nil {
@@ -381,6 +386,11 @@ func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlo
 		for _, order := range removedOrders {
 			// Orders removed due to expiration have non-zero FillableTakerAssetAmounts
 			if order.FillableTakerAssetAmount.Cmp(big.NewInt(0)) == 0 {
+				continue
+			}
+			// If we will re-validate this order, the revalidation process will discover that
+			// it's unexpired, and an appropriate event will already be emitted
+			if _, ok := ordersToRevalidate[order.Hash]; ok {
 				continue
 			}
 			expiration := time.Unix(order.SignedOrder.ExpirationTimeSeconds.Int64(), 0)
@@ -435,13 +445,10 @@ func (w *Watcher) handleBlockEvents(
 	}
 	latestBlockNumber, latestBlockTimestamp := w.getBlockchainState(events)
 
-	expirationOrderEvents, err := w.handleOrderExpirations(ordersColTxn, latestBlockTimestamp, previousLatestBlockTimestamp)
-	
 	err = updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
 	if err != nil {
 		return err
 	}
-
 	orderHashToDBOrder := map[common.Hash]*meshdb.Order{}
 	orderHashToEvents := map[common.Hash][]*zeroex.ContractEvent{}
 	for _, event := range events {
@@ -738,6 +745,11 @@ func (w *Watcher) handleBlockEvents(
 				}
 			}
 		}
+	}
+
+	expirationOrderEvents, err := w.handleOrderExpirations(ordersColTxn, latestBlockTimestamp, previousLatestBlockTimestamp, orderHashToDBOrder)
+	if err != nil {
+		return err
 	}
 
 	// This timeout of 1min is for limiting how long this call should block at the ETH RPC rate limiter
@@ -1175,35 +1187,52 @@ func (w *Watcher) generateOrderEventsIfChanged(
 				ContractEvents:           orderHashToEvents[order.Hash],
 			}
 			orderEvents = append(orderEvents, orderEvent)
-		} else if oldFillableAmount.Cmp(newFillableAmount) == 0 {
-			// No important state-change happened
-		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && oldAmountIsMoreThenNewAmount {
-			// Order was filled, emit event and update order in DB
-			order.FillableTakerAssetAmount = newFillableAmount
-			w.updateOrderDBEntry(ordersColTxn, order)
-			orderEvent := &zeroex.OrderEvent{
-				Timestamp:                validationBlockTimestamp,
-				OrderHash:                acceptedOrderInfo.OrderHash,
-				SignedOrder:              order.SignedOrder,
-				EndState:                 zeroex.ESOrderFilled,
-				FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
-				ContractEvents:           orderHashToEvents[order.Hash],
+		} else {
+			// If order was previously expired, check if it has become unexpired
+			if order.IsRemoved && oldFillableAmount.Cmp(big.NewInt(0)) != 0 {
+				expiration := time.Unix(order.SignedOrder.ExpirationTimeSeconds.Int64(), 0)
+				if validationBlockTimestamp.Before(expiration) {
+					w.rewatchOrder(ordersColTxn, order, order.FillableTakerAssetAmount)
+					orderEvent := &zeroex.OrderEvent{
+						Timestamp:                validationBlockTimestamp,
+						OrderHash:                order.Hash,
+						SignedOrder:              order.SignedOrder,
+						FillableTakerAssetAmount: order.FillableTakerAssetAmount,
+						EndState:                 zeroex.ESOrderUnexpired,
+					}
+					orderEvents = append(orderEvents, orderEvent)
+				}
 			}
-			orderEvents = append(orderEvents, orderEvent)
-		} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && !oldAmountIsMoreThenNewAmount {
-			// The order is now fillable for more then it was before. E.g.: A fill txn reverted (block-reorg)
-			// Update order in DB and emit event
-			order.FillableTakerAssetAmount = newFillableAmount
-			w.updateOrderDBEntry(ordersColTxn, order)
-			orderEvent := &zeroex.OrderEvent{
-				Timestamp:                validationBlockTimestamp,
-				OrderHash:                acceptedOrderInfo.OrderHash,
-				SignedOrder:              order.SignedOrder,
-				EndState:                 zeroex.ESOrderFillabilityIncreased,
-				FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
-				ContractEvents:           orderHashToEvents[order.Hash],
+			if oldFillableAmount.Cmp(newFillableAmount) == 0 {
+				// No important state-change happened
+			} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && oldAmountIsMoreThenNewAmount {
+				// Order was filled, emit event and update order in DB
+				order.FillableTakerAssetAmount = newFillableAmount
+				w.updateOrderDBEntry(ordersColTxn, order)
+				orderEvent := &zeroex.OrderEvent{
+					Timestamp:                validationBlockTimestamp,
+					OrderHash:                acceptedOrderInfo.OrderHash,
+					SignedOrder:              order.SignedOrder,
+					EndState:                 zeroex.ESOrderFilled,
+					FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
+					ContractEvents:           orderHashToEvents[order.Hash],
+				}
+				orderEvents = append(orderEvents, orderEvent)
+			} else if oldFillableAmount.Cmp(big.NewInt(0)) == 1 && !oldAmountIsMoreThenNewAmount {
+				// The order is now fillable for more then it was before. E.g.: A fill txn reverted (block-reorg)
+				// Update order in DB and emit event
+				order.FillableTakerAssetAmount = newFillableAmount
+				w.updateOrderDBEntry(ordersColTxn, order)
+				orderEvent := &zeroex.OrderEvent{
+					Timestamp:                validationBlockTimestamp,
+					OrderHash:                acceptedOrderInfo.OrderHash,
+					SignedOrder:              order.SignedOrder,
+					EndState:                 zeroex.ESOrderFillabilityIncreased,
+					FillableTakerAssetAmount: acceptedOrderInfo.FillableTakerAssetAmount,
+					ContractEvents:           orderHashToEvents[order.Hash],
+				}
+				orderEvents = append(orderEvents, orderEvent)
 			}
-			orderEvents = append(orderEvents, orderEvent)
 		}
 	}
 	for _, rejectedOrderInfo := range validationResults.Rejected {

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -1502,6 +1502,7 @@ func (w *Watcher) permanentlyDeleteOrder(deleter orderDeleter, order *meshdb.Ord
 				"error": err.Error(),
 				"order": order,
 			}).Error("Failed to permanently delete order")
+			return nil
 		}
 		if _, ok := err.(db.NotFoundError); ok {
 			logger.WithFields(logger.Fields{

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -346,6 +346,9 @@ func (w *Watcher) removedCheckerLoop(ctx context.Context) error {
 // Since expiry is now done according to block timestamp, we can figure out which orders have expired/unexpired statically. We do not
 // process blocks that require re-validation, since the validation process will already emit the necessary events and we cannot make
 // multiple updates to an order within a single DB transaction.
+// latestBlockTimestamp is the latest block timestamp Mesh knows about
+// previousLatestBlockTimestamp is the previous latest block timestamp Mesh knew about
+// ordersToRevalidate contains all the orders Mesh needs to re-validate given the events emitted by the blocks processed
 func (w *Watcher) handleOrderExpirations(ordersColTxn *db.Transaction, latestBlockTimestamp, previousLatestBlockTimestamp time.Time, ordersToRevalidate map[common.Hash]*meshdb.Order) ([]*zeroex.OrderEvent, error) {
 	orderEvents := []*zeroex.OrderEvent{}
 	var defaultTime time.Time

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -437,7 +437,7 @@ func (w *Watcher) handleBlockEvents(
 
 	expirationOrderEvents, err := w.handleOrderExpirations(ordersColTxn, latestBlockTimestamp, previousLatestBlockTimestamp)
 	
-	err = w.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	err = updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
 	if err != nil {
 		return err
 	}
@@ -1008,7 +1008,7 @@ func (w *Watcher) trimOrdersAndGenerateEvents() ([]*zeroex.OrderEvent, error) {
 // updateBlockHeadersStoredInDB updates the block headers stored in the DB. Since our DB txns don't support
 // multiple operations involving the same entry, we make sure we only perform either an insertion or a deletion
 // for each block in this method.
-func (w *Watcher) updateBlockHeadersStoredInDB(miniHeadersColTxn *db.Transaction, events []*blockwatch.Event) error {
+func updateBlockHeadersStoredInDB(miniHeadersColTxn *db.Transaction, events []*blockwatch.Event) error {
 	blocksToAdd := map[common.Hash]*miniheader.MiniHeader{}
 	blocksToRemove := map[common.Hash]*miniheader.MiniHeader{}
 	for _, event := range events {

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -448,12 +448,28 @@ func (w *Watcher) handleBlockEvents(
 		case blockwatch.Added:
 			err = miniHeadersColTxn.Insert(blockHeader)
 			if err != nil {
-				return err
+				if _, ok := err.(db.ConflictingOperationsError); ok {
+					logger.WithFields(logger.Fields{
+						"error":  err.Error(),
+						"hash":   blockHeader.Hash,
+						"number": blockHeader.Number,
+					}).Error("Failed to update miniHeaders")
+				} else {
+					return err
+				}
 			}
 		case blockwatch.Removed:
 			err = miniHeadersColTxn.Delete(blockHeader.ID())
 			if err != nil {
-				return err
+				if _, ok := err.(db.ConflictingOperationsError); ok {
+					logger.WithFields(logger.Fields{
+						"error":  err.Error(),
+						"hash":   blockHeader.Hash,
+						"number": blockHeader.Number,
+					}).Error("Failed to update miniHeaders")
+				} else {
+					return err
+				}
 			}
 		default:
 			return fmt.Errorf("Unrecognized block event type encountered: %d", event.Type)
@@ -931,6 +947,13 @@ func (w *Watcher) add(orderInfo *ordervalidator.AcceptedOrderInfo, validationBlo
 		if _, ok := err.(db.AlreadyExistsError); ok {
 			// If we're already watching the order, that's fine in this case. Don't
 			// return an error.
+			return orderEvents, nil
+		}
+		if _, ok := err.(db.ConflictingOperationsError); ok {
+			logger.WithFields(logger.Fields{
+				"error": err.Error(),
+				"order": order,
+			}).Error("Failed to insert order into DB")
 			return orderEvents, nil
 		}
 		return orderEvents, err
@@ -1451,16 +1474,20 @@ type orderDeleter interface {
 func (w *Watcher) permanentlyDeleteOrder(deleter orderDeleter, order *meshdb.Order) error {
 	err := deleter.Delete(order.Hash.Bytes())
 	if err != nil {
-		logger.WithFields(logger.Fields{
-			"error": err.Error(),
-			"order": order,
-		}).Warn("Attempted to delete order that no longer exists")
-		// TODO(fabio): With the current way the OrderWatcher is written, it is possible for multiple
-		// events to trigger logic that updates the orders in the DB simultaneously. This is mostly
-		// benign but is a waste of computation, and causes processes to try and delete orders the
-		// have already been deleted. In order to fix this, we need to re-write the event handling logic
-		// to queue the processing of events so that they happen sequentially rather then in parallel.
-		return nil // Already deleted. Noop.
+		if _, ok := err.(db.ConflictingOperationsError); ok {
+			logger.WithFields(logger.Fields{
+				"error": err.Error(),
+				"order": order,
+			}).Error("Failed to permanently delete order")
+		}
+		if _, ok := err.(db.NotFoundError); ok {
+			logger.WithFields(logger.Fields{
+				"error": err.Error(),
+				"order": order,
+			}).Warn("Attempted to delete order that no longer exists")
+			return nil // Already deleted. Noop.
+		}
+		return err
 	}
 
 	// After permanently deleting an order, we also remove it's assetData from the Decoder

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -983,35 +983,30 @@ func TestOrderWatcherCleanup(t *testing.T) {
 	}
 }
 
-func TestOrderWatcherUpdateBlockHeadersStoredInDB(t *testing.T) {
-	if !serialTestsEnabled {
-		t.Skip("Serial tests (tests which cannot run in parallel) are disabled. You can enable them with the --serial flag")
-	}
-
-	teardownSubTest := setupSubTest(t)
-	defer teardownSubTest(t)
-
+// Scenario 1: Header 1 exists in DB. Get's removed and then re-added.
+func TestOrderWatcherUpdateBlockHeadersStoredInDBScenario1(t *testing.T) {
 	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
 	require.NoError(t, err)
 
-	ctx, cancelFn := context.WithCancel(context.Background())
-	defer cancelFn()
-	_, orderWatcher := setupOrderWatcher(ctx, t, ethRPCClient, meshDB)
-
-	// Scenario 1: Header 1 exists in DB. Get's removed and then re-added.
+	headerOne := &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now().UTC(),
+	}
+	err = meshDB.MiniHeaders.Insert(headerOne)
+	require.NoError(t, err)
 
 	miniHeaders := []*miniheader.MiniHeader{}
 	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
 	require.NoError(t, err)
 	assert.Len(t, miniHeaders, 1)
-	headerOne := miniHeaders[0]
 
 	miniHeadersColTxn := meshDB.MiniHeaders.OpenTransaction()
 	defer func() {
 		_ = miniHeadersColTxn.Discard()
 	}()
 
-	// Scenario 2: Header 1 exists in DB. Get's removed and then re-added.
 	events := []*blockwatch.Event{
 		&blockwatch.Event{
 			Type:        blockwatch.Removed,
@@ -1022,7 +1017,7 @@ func TestOrderWatcherUpdateBlockHeadersStoredInDB(t *testing.T) {
 			BlockHeader: headerOne,
 		},
 	}
-	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	err = updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
 	require.NoError(t, err)
 
 	err = miniHeadersColTxn.Commit()
@@ -1031,13 +1026,110 @@ func TestOrderWatcherUpdateBlockHeadersStoredInDB(t *testing.T) {
 	miniHeaders = []*miniheader.MiniHeader{}
 	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
 	require.NoError(t, err)
-
 	assert.Len(t, miniHeaders, 1)
 	assert.Equal(t, headerOne, miniHeaders[0])
+}
 
-	// Scenario 3: Header doesn't exist, get's added and then removed
+// Scenario 2: Header doesn't exist, get's added and then removed
+func TestOrderWatcherUpdateBlockHeadersStoredInDBScenario2(t *testing.T) {
+	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
+	require.NoError(t, err)
 
-	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
+	miniHeadersColTxn := meshDB.MiniHeaders.OpenTransaction()
+	defer func() {
+		_ = miniHeadersColTxn.Discard()
+	}()
+
+	headerOne := &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now().UTC(),
+	}
+	events := []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerOne,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerOne,
+		},
+	}
+	err = updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	require.NoError(t, err)
+
+	err = miniHeadersColTxn.Commit()
+	require.NoError(t, err)
+
+	miniHeaders := []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+	assert.Len(t, miniHeaders, 0)
+}
+
+// Scenario 3: Header added, removed then re-added
+func TestOrderWatcherUpdateBlockHeadersStoredInDBScenario3(t *testing.T) {
+	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
+	require.NoError(t, err)
+
+	miniHeadersColTxn := meshDB.MiniHeaders.OpenTransaction()
+	defer func() {
+		_ = miniHeadersColTxn.Discard()
+	}()
+
+	headerOne := &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now(),
+	}
+	events := []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerOne,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerOne,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerOne,
+		},
+	}
+	err = updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	require.NoError(t, err)
+
+	err = miniHeadersColTxn.Commit()
+	require.NoError(t, err)
+
+	miniHeaders := []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+	assert.Len(t, miniHeaders, 1)
+}
+
+// Scenario 4: Header removed, added then removed again
+func TestOrderWatcherUpdateBlockHeadersStoredInDBScenario4(t *testing.T) {
+	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
+	require.NoError(t, err)
+
+	headerOne := &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now().UTC(),
+	}
+	err = meshDB.MiniHeaders.Insert(headerOne)
+	require.NoError(t, err)
+
+	miniHeaders := []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+	assert.Len(t, miniHeaders, 1)
+
+	miniHeadersColTxn := meshDB.MiniHeaders.OpenTransaction()
 	defer func() {
 		_ = miniHeadersColTxn.Discard()
 	}()
@@ -1048,7 +1140,11 @@ func TestOrderWatcherUpdateBlockHeadersStoredInDB(t *testing.T) {
 		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
 		Timestamp: time.Now(),
 	}
-	events = []*blockwatch.Event{
+	events := []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerTwo,
+		},
 		&blockwatch.Event{
 			Type:        blockwatch.Added,
 			BlockHeader: headerTwo,
@@ -1058,7 +1154,7 @@ func TestOrderWatcherUpdateBlockHeadersStoredInDB(t *testing.T) {
 			BlockHeader: headerTwo,
 		},
 	}
-	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	err = updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
 	require.NoError(t, err)
 
 	err = miniHeadersColTxn.Commit()
@@ -1067,137 +1163,78 @@ func TestOrderWatcherUpdateBlockHeadersStoredInDB(t *testing.T) {
 	miniHeaders = []*miniheader.MiniHeader{}
 	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
 	require.NoError(t, err)
+	assert.Len(t, miniHeaders, 0)
+}
 
+// Scenario 5: Call added twice for the same block
+func TestOrderWatcherUpdateBlockHeadersStoredInDBScenario5(t *testing.T) {
+	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
+	require.NoError(t, err)
+
+	miniHeadersColTxn := meshDB.MiniHeaders.OpenTransaction()
+	defer func() {
+		_ = miniHeadersColTxn.Discard()
+	}()
+
+	headerOne := &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now(),
+	}
+	events := []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerOne,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerOne,
+		},
+	}
+	err = updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	require.NoError(t, err)
+
+	err = miniHeadersColTxn.Commit()
+	require.NoError(t, err)
+
+	miniHeaders := []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
 	assert.Len(t, miniHeaders, 1)
-	assert.Equal(t, headerOne, miniHeaders[0])
+}
 
-	// Scenario 4: Header added, removed then re-added
+// Scenario 6: Call removed twice for the same block
+func TestOrderWatcherUpdateBlockHeadersStoredInDBScenario6(t *testing.T) {
+	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
+	require.NoError(t, err)
 
-	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
-	defer func() {
-		_ = miniHeadersColTxn.Discard()
-	}()
-
-	headerTwo = &miniheader.MiniHeader{
+	headerOne := &miniheader.MiniHeader{
 		Number:    big.NewInt(5),
 		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
 		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
-		Timestamp: time.Now(),
+		Timestamp: time.Now().UTC(),
 	}
-	events = []*blockwatch.Event{
-		&blockwatch.Event{
-			Type:        blockwatch.Added,
-			BlockHeader: headerTwo,
-		},
-		&blockwatch.Event{
-			Type:        blockwatch.Removed,
-			BlockHeader: headerTwo,
-		},
-		&blockwatch.Event{
-			Type:        blockwatch.Added,
-			BlockHeader: headerTwo,
-		},
-	}
-	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	err = meshDB.MiniHeaders.Insert(headerOne)
 	require.NoError(t, err)
 
-	err = miniHeadersColTxn.Commit()
-	require.NoError(t, err)
-
-	miniHeaders = []*miniheader.MiniHeader{}
+	miniHeaders := []*miniheader.MiniHeader{}
 	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
 	require.NoError(t, err)
-
-	assert.Len(t, miniHeaders, 2)
-
-	// Scenario 5: Header removed, added then removed again
-
-	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
-	defer func() {
-		_ = miniHeadersColTxn.Discard()
-	}()
-
-	headerTwo = &miniheader.MiniHeader{
-		Number:    big.NewInt(5),
-		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
-		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
-		Timestamp: time.Now(),
-	}
-	events = []*blockwatch.Event{
-		&blockwatch.Event{
-			Type:        blockwatch.Removed,
-			BlockHeader: headerTwo,
-		},
-		&blockwatch.Event{
-			Type:        blockwatch.Added,
-			BlockHeader: headerTwo,
-		},
-		&blockwatch.Event{
-			Type:        blockwatch.Removed,
-			BlockHeader: headerTwo,
-		},
-	}
-	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
-	require.NoError(t, err)
-
-	err = miniHeadersColTxn.Commit()
-	require.NoError(t, err)
-
-	miniHeaders = []*miniheader.MiniHeader{}
-	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
-	require.NoError(t, err)
-
 	assert.Len(t, miniHeaders, 1)
 
-	// Scenario 6: Call added twice for the same block
-
-	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
+	miniHeadersColTxn := meshDB.MiniHeaders.OpenTransaction()
 	defer func() {
 		_ = miniHeadersColTxn.Discard()
 	}()
 
-	headerTwo = &miniheader.MiniHeader{
+	headerTwo := &miniheader.MiniHeader{
 		Number:    big.NewInt(5),
 		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
 		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
 		Timestamp: time.Now(),
 	}
-	events = []*blockwatch.Event{
-		&blockwatch.Event{
-			Type:        blockwatch.Added,
-			BlockHeader: headerTwo,
-		},
-		&blockwatch.Event{
-			Type:        blockwatch.Added,
-			BlockHeader: headerTwo,
-		},
-	}
-	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
-	require.NoError(t, err)
-
-	err = miniHeadersColTxn.Commit()
-	require.NoError(t, err)
-
-	miniHeaders = []*miniheader.MiniHeader{}
-	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
-	require.NoError(t, err)
-
-	assert.Len(t, miniHeaders, 2)
-
-	// Scenario 7: Call removed twice for the same block
-
-	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
-	defer func() {
-		_ = miniHeadersColTxn.Discard()
-	}()
-
-	headerTwo = &miniheader.MiniHeader{
-		Number:    big.NewInt(5),
-		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
-		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
-		Timestamp: time.Now(),
-	}
-	events = []*blockwatch.Event{
+	events := []*blockwatch.Event{
 		&blockwatch.Event{
 			Type:        blockwatch.Removed,
 			BlockHeader: headerTwo,
@@ -1207,7 +1244,7 @@ func TestOrderWatcherUpdateBlockHeadersStoredInDB(t *testing.T) {
 			BlockHeader: headerTwo,
 		},
 	}
-	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	err = updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
 	require.NoError(t, err)
 
 	err = miniHeadersColTxn.Commit()
@@ -1216,8 +1253,7 @@ func TestOrderWatcherUpdateBlockHeadersStoredInDB(t *testing.T) {
 	miniHeaders = []*miniheader.MiniHeader{}
 	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
 	require.NoError(t, err)
-
-	assert.Len(t, miniHeaders, 1)
+	assert.Len(t, miniHeaders, 0)
 }
 
 func setupOrderWatcherScenario(ctx context.Context, t *testing.T, ethClient *ethclient.Client, meshDB *meshdb.MeshDB, signedOrder *zeroex.SignedOrder) (*blockwatch.Watcher, chan []*zeroex.OrderEvent) {

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -983,6 +983,243 @@ func TestOrderWatcherCleanup(t *testing.T) {
 	}
 }
 
+func TestOrderWatcherUpdateBlockHeadersStoredInDB(t *testing.T) {
+	if !serialTestsEnabled {
+		t.Skip("Serial tests (tests which cannot run in parallel) are disabled. You can enable them with the --serial flag")
+	}
+
+	teardownSubTest := setupSubTest(t)
+	defer teardownSubTest(t)
+
+	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
+	require.NoError(t, err)
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+	_, orderWatcher := setupOrderWatcher(ctx, t, ethRPCClient, meshDB)
+
+	// Scenario 1: Header 1 exists in DB. Get's removed and then re-added.
+
+	miniHeaders := []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+	assert.Len(t, miniHeaders, 1)
+	headerOne := miniHeaders[0]
+
+	miniHeadersColTxn := meshDB.MiniHeaders.OpenTransaction()
+	defer func() {
+		_ = miniHeadersColTxn.Discard()
+	}()
+
+	// Scenario 2: Header 1 exists in DB. Get's removed and then re-added.
+	events := []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerOne,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerOne,
+		},
+	}
+	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	require.NoError(t, err)
+
+	err = miniHeadersColTxn.Commit()
+	require.NoError(t, err)
+
+	miniHeaders = []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+
+	assert.Len(t, miniHeaders, 1)
+	assert.Equal(t, headerOne, miniHeaders[0])
+
+	// Scenario 3: Header doesn't exist, get's added and then removed
+
+	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
+	defer func() {
+		_ = miniHeadersColTxn.Discard()
+	}()
+
+	headerTwo := &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now(),
+	}
+	events = []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerTwo,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerTwo,
+		},
+	}
+	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	require.NoError(t, err)
+
+	err = miniHeadersColTxn.Commit()
+	require.NoError(t, err)
+
+	miniHeaders = []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+
+	assert.Len(t, miniHeaders, 1)
+	assert.Equal(t, headerOne, miniHeaders[0])
+
+	// Scenario 4: Header added, removed then re-added
+
+	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
+	defer func() {
+		_ = miniHeadersColTxn.Discard()
+	}()
+
+	headerTwo = &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now(),
+	}
+	events = []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerTwo,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerTwo,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerTwo,
+		},
+	}
+	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	require.NoError(t, err)
+
+	err = miniHeadersColTxn.Commit()
+	require.NoError(t, err)
+
+	miniHeaders = []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+
+	assert.Len(t, miniHeaders, 2)
+
+	// Scenario 5: Header removed, added then removed again
+
+	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
+	defer func() {
+		_ = miniHeadersColTxn.Discard()
+	}()
+
+	headerTwo = &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now(),
+	}
+	events = []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerTwo,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerTwo,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerTwo,
+		},
+	}
+	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	require.NoError(t, err)
+
+	err = miniHeadersColTxn.Commit()
+	require.NoError(t, err)
+
+	miniHeaders = []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+
+	assert.Len(t, miniHeaders, 1)
+
+	// Scenario 6: Call added twice for the same block
+
+	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
+	defer func() {
+		_ = miniHeadersColTxn.Discard()
+	}()
+
+	headerTwo = &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now(),
+	}
+	events = []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerTwo,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerTwo,
+		},
+	}
+	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	require.NoError(t, err)
+
+	err = miniHeadersColTxn.Commit()
+	require.NoError(t, err)
+
+	miniHeaders = []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+
+	assert.Len(t, miniHeaders, 2)
+
+	// Scenario 7: Call removed twice for the same block
+
+	miniHeadersColTxn = meshDB.MiniHeaders.OpenTransaction()
+	defer func() {
+		_ = miniHeadersColTxn.Discard()
+	}()
+
+	headerTwo = &miniheader.MiniHeader{
+		Number:    big.NewInt(5),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now(),
+	}
+	events = []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerTwo,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Removed,
+			BlockHeader: headerTwo,
+		},
+	}
+	err = orderWatcher.updateBlockHeadersStoredInDB(miniHeadersColTxn, events)
+	require.NoError(t, err)
+
+	err = miniHeadersColTxn.Commit()
+	require.NoError(t, err)
+
+	miniHeaders = []*miniheader.MiniHeader{}
+	err = meshDB.MiniHeaders.FindAll(&miniHeaders)
+	require.NoError(t, err)
+
+	assert.Len(t, miniHeaders, 1)
+}
+
 func setupOrderWatcherScenario(ctx context.Context, t *testing.T, ethClient *ethclient.Client, meshDB *meshdb.MeshDB, signedOrder *zeroex.SignedOrder) (*blockwatch.Watcher, chan []*zeroex.OrderEvent) {
 	blockWatcher, orderWatcher := setupOrderWatcher(ctx, t, ethRPCClient, meshDB)
 


### PR DESCRIPTION
This backports a bunch of recent fixes needed by TokenTrove who is still running a 0x V2 node alongside their 0x V3 node. See CHANGELOG entry for full list.