### PR TITLE
Fix mesh-bootstrap drone config to point to the correct Dockerfile.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,7 @@ steps:
       from_secret: docker_username
     password:
       from_secret: docker_password
-    dockerfile: dockerfiles/mesh/Dockerfile
+    dockerfile: dockerfiles/mesh-bootstrap/Dockerfile
 node_selector:
   drone-builds: true
 ---
@@ -74,7 +74,7 @@ steps:
       from_secret: docker_username
     password:
       from_secret: docker_password
-    dockerfile: dockerfiles/mesh/Dockerfile
+    dockerfile: dockerfiles/mesh-bootstrap/Dockerfile
 trigger:
   branch:
   - development


### PR DESCRIPTION
About
===

Current `drone` configuration incorrectly builds and tags `mesh-bootstrap` images, it uses the `dockerfiles/mesh/Dockerfile` instead of `dockerfiles/mesh-bootstrap/Dockerfile`.

This PR fixes that.