### PR TITLE
orderwatch: Batch process multiple block event arrays at once

### DIFF
--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -294,13 +294,13 @@ func (w *Watcher) mainLoop(ctx context.Context) error {
 
 func drainBlockEventsChan(blockEventsChan chan []*blockwatch.Event) []*blockwatch.Event {
 	allEvents := []*blockwatch.Event{}
-L:
+Loop:
 	for {
 		select {
 		case moreEvents := <-blockEventsChan:
 			allEvents = append(allEvents, moreEvents...)
 		default:
-			break L
+			break Loop
 		}
 	}
 	return allEvents

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -284,7 +284,7 @@ func (w *Watcher) mainLoop(ctx context.Context) error {
 		case events := <-w.blockEventsChan:
 			// Instead of simply processing the first array of events in the blockEventsChan,
 			// we might as well process _all_ events in the channel.
-			drainedEvents := drainBlockEventsChan(w.blockEventsChan)
+			drainedEvents := drainBlockEventsChan(w.blockEventsChan, maxBlockEventsToHandle)
 			events = append(events, drainedEvents...)
 			w.handleBlockEventsMu.Lock()
 			if err := w.handleBlockEvents(ctx, events); err != nil {
@@ -296,14 +296,14 @@ func (w *Watcher) mainLoop(ctx context.Context) error {
 	}
 }
 
-func drainBlockEventsChan(blockEventsChan chan []*blockwatch.Event) []*blockwatch.Event {
+func drainBlockEventsChan(blockEventsChan chan []*blockwatch.Event, max int) []*blockwatch.Event {
 	allEvents := []*blockwatch.Event{}
 Loop:
 	for {
 		select {
 		case moreEvents := <-blockEventsChan:
 			allEvents = append(allEvents, moreEvents...)
-			if len(allEvents) >= maxBlockEventsToHandle {
+			if len(allEvents) >= max {
 				break Loop
 			}
 		default:

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -62,6 +62,10 @@ const (
 	// increase the max expiration time.
 	maxExpirationTimeCheckInterval = 30 * time.Second
 
+	// maxBlockEventsToHandle is the max number of block events we want to process in a single
+	// call to `handleBlockEvents`
+	maxBlockEventsToHandle = 500
+
 	// configuration options for the SlowCounter used for increasing max
 	// expiration time. Effectively, we will increase every 5 minutes as long as
 	// there is enough space in the database for orders. The first increase will
@@ -300,7 +304,7 @@ Loop:
 		case moreEvents := <-blockEventsChan:
 			allEvents = append(allEvents, moreEvents...)
 			if len(allEvents) >= maxBlockEventsToHandle {
-			    break L
+				break Loop
 			}
 		default:
 			break Loop

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -1449,6 +1449,41 @@ func TestConvertValidationResultsIntoOrderEventsUnexpired(t *testing.T) {
 	assert.Equal(t, false, orderTwo.IsRemoved)
 }
 
+func TestDrainAllBlockEventsChan(t *testing.T) {
+	blockEventsChan := make(chan []*blockwatch.Event, 100)
+	ts := time.Now().Add(1 * time.Hour)
+	blockEventsOne := []*blockwatch.Event{
+		&blockwatch.Event{
+			Type: blockwatch.Added,
+			BlockHeader: &miniheader.MiniHeader{
+				Parent:    common.HexToHash("0x0"),
+				Hash:      common.HexToHash("0x1"),
+				Number:    big.NewInt(1),
+				Timestamp: ts,
+			},
+		},
+	}
+	blockEventsChan <- blockEventsOne
+
+	blockEventsTwo := []*blockwatch.Event{
+		&blockwatch.Event{
+			Type: blockwatch.Added,
+			BlockHeader: &miniheader.MiniHeader{
+				Parent:    common.HexToHash("0x1"),
+				Hash:      common.HexToHash("0x2"),
+				Number:    big.NewInt(2),
+				Timestamp: ts.Add(1 * time.Second),
+			},
+		},
+	}
+	blockEventsChan <- blockEventsTwo
+
+	allEvents := drainBlockEventsChan(blockEventsChan)
+	assert.Len(t, allEvents, 2)
+	require.Equal(t, allEvents[0], blockEventsOne[0])
+	require.Equal(t, allEvents[1], blockEventsTwo[0])
+}
+
 func setupOrderWatcherScenario(ctx context.Context, t *testing.T, ethClient *ethclient.Client, meshDB *meshdb.MeshDB, signedOrder *zeroex.SignedOrder) (*blockwatch.Watcher, chan []*zeroex.OrderEvent) {
 	blockWatcher, orderWatcher := setupOrderWatcher(ctx, t, ethRPCClient, meshDB)
 

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -1478,10 +1478,20 @@ func TestDrainAllBlockEventsChan(t *testing.T) {
 	}
 	blockEventsChan <- blockEventsTwo
 
-	allEvents := drainBlockEventsChan(blockEventsChan)
-	assert.Len(t, allEvents, 2)
+	max := 2 // enough
+	allEvents := drainBlockEventsChan(blockEventsChan, max)
+	assert.Len(t, allEvents, 2, "Two events should be drained from the channel")
 	require.Equal(t, allEvents[0], blockEventsOne[0])
 	require.Equal(t, allEvents[1], blockEventsTwo[0])
+
+	// Test case where more than max events in channel
+	blockEventsChan <- blockEventsOne
+	blockEventsChan <- blockEventsTwo
+
+	max = 1
+	allEvents = drainBlockEventsChan(blockEventsChan, max)
+	assert.Len(t, allEvents, 1, "Only max number of events should be drained from the channel, even if more than max events are present")
+	require.Equal(t, allEvents[0], blockEventsOne[0])
 }
 
 func setupOrderWatcherScenario(ctx context.Context, t *testing.T, ethClient *ethclient.Client, meshDB *meshdb.MeshDB, signedOrder *zeroex.SignedOrder) (*blockwatch.Watcher, chan []*zeroex.OrderEvent) {


### PR DESCRIPTION
I discovered this inefficiency while bench-marking the performance of the OrderWatcher. It is  possible that multiple blockEvents are queued up within the `blockEventsChan` and we _could_ process them all at once but weren't. It is possible that the events in these array would lead to the same order being re-validated, and so combining them leads to fewer RPC calls and lowers the latency after which we emit relevant order events.