### PR TITLE
Only set up logger once in core.New

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -201,12 +201,16 @@ type App struct {
 	started chan struct{}
 }
 
+var setupLoggerOnce = &sync.Once{}
+
 func New(config Config) (*App, error) {
 	// Configure logger
 	// TODO(albrow): Don't use global variables for log settings.
-	log.SetFormatter(&log.JSONFormatter{})
-	log.SetLevel(log.Level(config.Verbosity))
-	log.AddHook(loghooks.NewKeySuffixHook())
+	setupLoggerOnce.Do(func() {
+		log.SetFormatter(&log.JSONFormatter{})
+		log.SetLevel(log.Level(config.Verbosity))
+		log.AddHook(loghooks.NewKeySuffixHook())
+	})
 
 	// Add custom contract addresses if needed.
 	if config.CustomContractAddresses != "" {


### PR DESCRIPTION
So far, this hasn't really come up, but there's a small bug in `core.New`. If it's called multiple times in the same process (e.g. in a test) it will initialize the logger twice. This results in double type suffixes and `myPeerID` appearing in the logs twice for each log message. Using `sync.Once` fixes the issue.
