### PR TITLE
chore: Automate Release Notes Generation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -101,5 +101,9 @@ steps:
         event: tag
         ref:
           - refs/tags/v*
+trigger:
+  event:
+    include:
+      - tag
 node_selector:
   drone-builds: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -83,3 +83,23 @@ trigger:
       - push
 node_selector:
   drone-builds: true
+---
+kind: pipeline
+type: docker
+name: mesh-publish-release-notes
+
+steps:
+  - name: publish
+    image: plugins/github-release
+    settings:
+      api_key:
+        from_secret: github_public_repo
+      files:
+        - /
+      note: RELEASE_CHANGELOG.md
+      when:
+        event: tag
+        ref:
+          - refs/tags/v*
+node_selector:
+  drone-builds: true

--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -41,7 +41,7 @@ func createReleaseChangelog(version string) {
 %s
 `, version, changelog)
 
-	err := ioutil.WriteFile("RELEASE-CHANGELOG.md", []byte(releaseChangelog), 0644)
+	err := ioutil.WriteFile("RELEASE_CHANGELOG.md", []byte(releaseChangelog), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -26,6 +26,25 @@ func main() {
 
 	generateTypescriptClientDocs()
 	generateTypescriptBrowserDocs()
+
+	createReleaseChangelog(env.Version)
+}
+
+func createReleaseChangelog(version string) {
+	regex := fmt.Sprintf(`(?ms)(## v%s\n)(.*?)(## v)`, version)
+	changelog := getFileContentsWithRegex("CHANGELOG.md", regex)
+
+	releaseChangelog := fmt.Sprintf(`- [Docker image](https://hub.docker.com/r/0xorg/mesh/tags)
+- [README](https://github.com/0xProject/0x-mesh/blob/v%s/README.md)
+
+## Summary
+%s
+`, version, changelog)
+
+	err := ioutil.WriteFile("RELEASE-CHANGELOG.md", []byte(releaseChangelog), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func generateTypescriptClientDocs() {
@@ -122,4 +141,16 @@ func updateFileWithRegex(filePath string, regex string, replacement string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func getFileContentsWithRegex(filePath string, regex string) string {
+	dat, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var re = regexp.MustCompile(regex)
+	matches := re.FindAllStringSubmatch(string(dat), -1)
+
+	return matches[0][2]
 }

--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -32,7 +33,11 @@ func main() {
 
 func createReleaseChangelog(version string) {
 	regex := fmt.Sprintf(`(?ms)(## v%s\n)(.*?)(## v)`, version)
-	changelog := getFileContentsWithRegex("CHANGELOG.md", regex)
+	changelog, err := getFileContentsWithRegex("CHANGELOG.md", regex)
+	if err != nil {
+		log.Println("No CHANGELOG entries found for version", version)
+		return // Noop
+	}
 
 	releaseChangelog := fmt.Sprintf(`- [Docker image](https://hub.docker.com/r/0xorg/mesh/tags)
 - [README](https://github.com/0xProject/0x-mesh/blob/v%s/README.md)
@@ -41,7 +46,7 @@ func createReleaseChangelog(version string) {
 %s
 `, version, changelog)
 
-	err := ioutil.WriteFile("RELEASE_CHANGELOG.md", []byte(releaseChangelog), 0644)
+	err = ioutil.WriteFile("RELEASE_CHANGELOG.md", []byte(releaseChangelog), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -143,7 +148,7 @@ func updateFileWithRegex(filePath string, regex string, replacement string) {
 	}
 }
 
-func getFileContentsWithRegex(filePath string, regex string) string {
+func getFileContentsWithRegex(filePath string, regex string) (string, error) {
 	dat, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		log.Fatal(err)
@@ -152,5 +157,9 @@ func getFileContentsWithRegex(filePath string, regex string) string {
 	var re = regexp.MustCompile(regex)
 	matches := re.FindAllStringSubmatch(string(dat), -1)
 
-	return matches[0][2]
+	if len(matches) < 1 || len(matches[0]) < 3 {
+		return "", errors.New("No contents found")
+	}
+
+	return matches[0][2], nil
 }


### PR DESCRIPTION
This PR:

- Adds to our `cut-release` script a step to generate a `RELEASE_CHANGELOG.md` file containing the contents of the release notes for this release.
- Adds a Drone job that executes when a Git release tag is pushed to our repo, and publishes the new release notes to Github.