### PR TITLE
Make order watcher exit as soon as context is canceled

### DIFF
--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -294,13 +294,13 @@ func (w *Watcher) cleanupLoop(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
-		default:
+		case <-time.After(minCleanupInterval - time.Since(start)):
+			// Wait minCleanupInterval before calling cleanup again. Since
+			// we only start sleeping _after_ cleanup completes, we will never
+			// have multiple calls to cleanup running in parallel
+			break
 		}
 
-		// Wait minCleanupInterval before calling cleanup again. Since
-		// we only start sleeping _after_ cleanup completes, we will never
-		// have multiple calls to cleanup running in parallel
-		time.Sleep(minCleanupInterval - time.Since(start))
 		start = time.Now()
 		if err := w.Cleanup(ctx, defaultLastUpdatedBuffer); err != nil {
 			return err


### PR DESCRIPTION
This PR fixes a small bug in the order watcher cleanup loop that prevents `core.App` from properly shutting down when the main context is canceled. Namely, the old version of the cleanup loop had a `time.Sleep` statement that existed outside of `select`. So if the context was canceled, we would still wait for `time.Sleep` to finish. This was causing difficulties in understanding test failures on #692.
