### PR TITLE
Fix a race condition in ethereum/ratelimit

### DIFF
--- a/ethereum/ratelimit/rate_limiter.go
+++ b/ethereum/ratelimit/rate_limiter.go
@@ -93,8 +93,8 @@ func (r *rateLimiter) Start(ctx context.Context, checkpointInterval time.Duratio
 
 	// Start 24hr UTC accrued grants resetter
 	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 		for {
 			now := r.aClock.Now()


### PR DESCRIPTION
This should fix a [race condition that sometimes shows up in CI](https://app.circleci.com/jobs/github/0xProject/0x-mesh/2653). `wg.Add` should be called outside of the goroutine. 
