### PR TITLE
Increase timeout for conversion tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-go: test-go-parallel test-go-serial
 
 .PHONY: test-go-parallel
 test-go-parallel:
-	go test ./... -race -timeout 30s
+	go test ./... -race -timeout 180s
 
 .PHONY: test-go-serial
 test-go-serial:

--- a/browser/go/conversion-test/conversion_test.go
+++ b/browser/go/conversion-test/conversion_test.go
@@ -35,7 +35,7 @@ var testCases []string
 func TestBrowserConversions(t *testing.T) {
 	// Declare a context that will be used for all child processes, servers, and
 	// other goroutines.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 175*time.Second)
 	ctx, _ = chromedp.NewContext(ctx, chromedp.WithErrorf(t.Errorf))
 	defer cancel()
 


### PR DESCRIPTION
The tests often fail on the first run because it takes a long time to install some dependencies. The exact time depends on your internet speed and other factors, but 180s seems safe.