### PR TITLE
blockwatch: Demote blockwatcher recoverable errors to warnings

### DIFF
--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -171,7 +171,7 @@ func (w *Watcher) Watch(ctx context.Context) error {
 			// return an error.
 			return err
 		}
-		log.WithError(err).Error("blockwatch.Watcher error encountered")
+		log.WithError(err).Warn("blockwatch.Watcher error encountered")
 	}
 
 	ticker := time.NewTicker(w.pollingInterval)
@@ -198,7 +198,7 @@ func (w *Watcher) Watch(ctx context.Context) error {
 					ticker.Stop()
 					return err
 				}
-				log.WithError(err).Error("blockwatch.Watcher error encountered")
+				log.WithError(err).Warn("blockwatch.Watcher error encountered")
 			}
 		}
 	}

--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -180,10 +180,11 @@ func (w *Watcher) Watch(ctx context.Context) error {
 			// return an error.
 			return err
 		}
+		logMessage := "blockwatch.Watcher error encountered"
 		if isWarning(err) {
-			log.WithError(err).Warn("blockwatch.Watcher error encountered")
+			log.WithError(err).Warn(logMessage)
 		} else {
-			log.WithError(err).Error("blockwatch.Watcher error encountered")
+			log.WithError(err).Error(logMessage)
 		}
 	}
 
@@ -211,10 +212,11 @@ func (w *Watcher) Watch(ctx context.Context) error {
 					ticker.Stop()
 					return err
 				}
+				logMessage := "blockwatch.Watcher error encountered"
 				if isWarning(err) {
-					log.WithError(err).Warn("blockwatch.Watcher error encountered")
+					log.WithError(err).Warn(logMessage)
 				} else {
-					log.WithError(err).Error("blockwatch.Watcher error encountered")
+					log.WithError(err).Error(logMessage)
 				}
 			}
 		}

--- a/ethereum/blockwatch/block_watcher_test.go
+++ b/ethereum/blockwatch/block_watcher_test.go
@@ -534,6 +534,19 @@ func TestGetLogsInBlockRange(t *testing.T) {
 	}
 }
 
+func TestIsWarning(t *testing.T) {
+	errs := map[error]bool{
+		errors.New("not found"):     true,
+		errors.New("unknown block"): true,
+		errors.New("Post https://eth-mainnet.alchemyapi.io/jsonrpc: context deadline exceeded"): true,
+		errors.New("couldn't parse parameters: blockhash"):                                      false,
+	}
+
+	for err, expected := range errs {
+		assert.Equal(t, expected, isWarning(err))
+	}
+}
+
 func aRange(from, to int) string {
 	r := fmt.Sprintf("%d-%d", from, to)
 	return r


### PR DESCRIPTION
"I think it would be amazing if every log that has an error level indicates a bug that we need to fix."
-- @jalextowle 

Towards that aim, this PR demotes the recoverable errors returned from blockwatch to warnings. Most are unavoidable and not things we can fix so it doesn't make sense to consider them errors given the above definition. To reduce the clutter, it makes sense to demote them.