### PR TITLE
drone: Fix Github release artifacts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -95,7 +95,7 @@ steps:
       api_key:
         from_secret: github_public_repo
       files:
-        - /
+        - *
       note: RELEASE_CHANGELOG.md
       when:
         event: tag


### PR DESCRIPTION
Fix drone build failure by using a glob instead of a directory for the "files" field.

Docs: http://plugins.drone.io/drone-plugins/drone-github-release/

<!-- 

Please read our contribution guide before opening your PR: https://github.com/0xProject/0x-mesh/blob/master/CONTRIBUTING.md.
All PRs should be based on the development branch.


-->
