### PR TITLE
Remove MiniHeaders above retention limit on startup & after processing block events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v9.0.1
+
+### Bug fixes 🐞
+
+- Fix bug where we weren't enforcing that we never store more than `miniHeaderRetentionLimit` block headers in the DB. This caused [issue #667](https://github.com/0xProject/0x-mesh/issues/667) and also caused the Mesh node's DB storage to continuously grow over time. ([#716](https://github.com/0xProject/0x-mesh/pull/716))
+
 ## v9.0.0
 
 ### Breaking changes 🛠

--- a/core/core.go
+++ b/core/core.go
@@ -308,9 +308,13 @@ func New(config Config) (*App, error) {
 	}
 
 	// Remove any old mini headers that might be lingering in the database.
-	// HACK(albrow): This is a workaround for an issue where miniheaders are
-	// not removed from the database. This issue has been fixed and this hack
-	// should be removed after the next release.
+	// See https://github.com/0xProject/0x-mesh/issues/667 and https://github.com/0xProject/0x-mesh/pull/716
+	// We need to leave this in place becuase:
+	//
+	// 1. It is still necessary for anyone upgrading from older versions to >= 9.0.1 in the future.
+	// 2. There's still a chance there are old MiniHeaders in the database (e.g. due to a sudden
+	//    unexpected shut down).
+	//
 	err = meshDB.PruneMiniHeadersAboveRetentionLimit()
 	if err != nil {
 		return nil, err

--- a/core/core.go
+++ b/core/core.go
@@ -325,7 +325,7 @@ func New(config Config) (*App, error) {
 		if err != nil {
 			return nil, err
 		} else if latestMiniHeader != nil {
-			minBlockNumber := big.NewInt(0).Sub(latestMiniHeader.Number, big.NewInt(miniHeaderRetentionLimit))
+			minBlockNumber := big.NewInt(0).Sub(latestMiniHeader.Number, big.NewInt(miniHeaderRetentionLimit-1))
 			if err := meshDB.ClearOldMiniHeaders(minBlockNumber); err != nil {
 				return nil, err
 			}

--- a/core/core.go
+++ b/core/core.go
@@ -312,7 +312,7 @@ func New(config Config) (*App, error) {
 	// Remove any old mini headers that might be lingering in the database.
 	// HACK(albrow): This is a workaround for an issue where miniheaders are
 	// not removed from the database. This issue has been fixed and this hack
-	// should be removed in the next release.
+	// should be removed after the next release.
 	if totalMiniHeaders, err := meshDB.MiniHeaders.Count(); err != nil {
 		return nil, err
 	} else if totalMiniHeaders > miniHeaderRetentionLimit {

--- a/core/core.go
+++ b/core/core.go
@@ -343,13 +343,12 @@ func New(config Config) (*App, error) {
 
 	// Initialize order watcher (but don't start it yet).
 	orderWatcher, err := orderwatch.New(orderwatch.Config{
-		MeshDB:                   meshDB,
-		BlockWatcher:             blockWatcher,
-		OrderValidator:           orderValidator,
-		ChainID:                  config.EthereumChainID,
-		MaxOrders:                config.MaxOrdersInStorage,
-		MaxExpirationTime:        metadata.MaxExpirationTime,
-		MiniHeaderRetentionLimit: miniHeaderRetentionLimit,
+		MeshDB:            meshDB,
+		BlockWatcher:      blockWatcher,
+		OrderValidator:    orderValidator,
+		ChainID:           config.EthereumChainID,
+		MaxOrders:         config.MaxOrdersInStorage,
+		MaxExpirationTime: metadata.MaxExpirationTime,
 	})
 	if err != nil {
 		return nil, err

--- a/meshdb/meshdb.go
+++ b/meshdb/meshdb.go
@@ -328,8 +328,8 @@ func (m *MeshDB) FindMiniHeaderByBlockNumber(blockNumber *big.Int) (*miniheader.
 	return miniHeaders[0], nil
 }
 
-// UpdateMiniHeaderRetentionLimit updates the MiniHeaderRetentionLimit. This is only used by tests to
-// returns the retention limit to a manageable size
+// UpdateMiniHeaderRetentionLimit updates the MiniHeaderRetentionLimit. This is only used by tests in order
+// to set the retention limit to a smaller size, making the tests shorter in length
 func (m *MeshDB) UpdateMiniHeaderRetentionLimit(limit int) error {
 	m.MiniHeaderRetentionLimit = limit
 	return m.PruneMiniHeadersAboveRetentionLimit()

--- a/meshdb/meshdb.go
+++ b/meshdb/meshdb.go
@@ -20,7 +20,7 @@ const (
 	// The default miniHeaderRetentionLimit used by Mesh. This default only gets overwritten in tests.
 	defaultMiniHeaderRetentionLimit = 20
 	// The maximum MiniHeaders to query per page when deleting MiniHeaders
-	miniHeadersMaxPerPage = 5000
+	miniHeadersMaxPerPage = 1000
 )
 
 var ErrDBFilledWithPinnedOrders = errors.New("the database is full of pinned orders; no orders can be removed in order to make space")

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -104,13 +104,12 @@ type Watcher struct {
 }
 
 type Config struct {
-	MeshDB                   *meshdb.MeshDB
-	BlockWatcher             *blockwatch.Watcher
-	OrderValidator           *ordervalidator.OrderValidator
-	ChainID                  int
-	MaxOrders                int
-	MaxExpirationTime        *big.Int
-	MiniHeaderRetentionLimit int
+	MeshDB            *meshdb.MeshDB
+	BlockWatcher      *blockwatch.Watcher
+	OrderValidator    *ordervalidator.OrderValidator
+	ChainID           int
+	MaxOrders         int
+	MaxExpirationTime *big.Int
 }
 
 // New instantiates a new order watcher

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -816,7 +816,7 @@ func (w *Watcher) handleBlockEvents(
 	}
 	w.atLeastOneBlockProcessedMu.Unlock()
 
-	// Since we might have added MiniHeaders to the DB, we need to now prune any excess MiniHeaders stored
+	// Since we might have added MiniHeaders to the DB, we need to prune any excess MiniHeaders stored
 	// in the DB
 	err = w.meshDB.PruneMiniHeadersAboveRetentionLimit()
 	if err != nil {

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -828,7 +828,7 @@ func (w *Watcher) handleBlockEvents(
 		if err != nil {
 			return err
 		} else if latestMiniHeader != nil {
-			minBlockNumber := big.NewInt(0).Sub(latestMiniHeader.Number, big.NewInt(int64(w.miniHeaderRetentionLimit)))
+			minBlockNumber := big.NewInt(0).Sub(latestMiniHeader.Number, big.NewInt(int64(w.miniHeaderRetentionLimit-1)))
 			if err := w.meshDB.ClearOldMiniHeaders(minBlockNumber); err != nil {
 				return err
 			}

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -1380,7 +1380,6 @@ func TestOrderWatcherMaintainMiniHeaderRetentionLimit(t *testing.T) {
 		Timestamp: time.Now().UTC(),
 	}
 
-	// Simulate a block found with a timestamp past expirationTime
 	blockEvents := []*blockwatch.Event{
 		&blockwatch.Event{
 			Type:        blockwatch.Added,

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	ethereumRPCRequestTimeout   = 30 * time.Second
-	blockWatcherRetentionLimit  = 20
+	miniHeaderRetentionLimit    = 2
 	blockPollingInterval        = 1000 * time.Millisecond
 	ethereumRPCMaxContentLength = 524288
 	maxEthRPCRequestsPer24HrUTC = 1000000
@@ -1342,6 +1342,71 @@ func TestOrderWatcherHandleOrderExpirationsUnexpired(t *testing.T) {
 	assert.Equal(t, false, orderTwo.IsRemoved)
 }
 
+func TestOrderWatcherMaintainMiniHeaderRetentionLimit(t *testing.T) {
+	if !serialTestsEnabled {
+		t.Skip("Serial tests (tests which cannot run in parallel) are disabled. You can enable them with the --serial flag")
+	}
+
+	// Set up test and orderWatcher
+	teardownSubTest := setupSubTest(t)
+	defer teardownSubTest(t)
+	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer func() {
+		cancel()
+	}()
+	_, orderWatcher := setupOrderWatcher(ctx, t, ethRPCClient, meshDB)
+
+	latestMiniHeader, err := meshDB.FindLatestMiniHeader()
+	require.NoError(t, err)
+
+	headerOne := &miniheader.MiniHeader{
+		Number:    big.NewInt(0).Add(latestMiniHeader.Number, big.NewInt(1)),
+		Hash:      common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Parent:    common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
+		Timestamp: time.Now().UTC(),
+	}
+	headerTwo := &miniheader.MiniHeader{
+		Number:    big.NewInt(0).Add(headerOne.Number, big.NewInt(1)),
+		Hash:      common.HexToHash("0x72ca9481b09b8c00b2c38575e5652f2de1077f1676c6b868cf575229fcb06a96"),
+		Parent:    common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
+		Timestamp: time.Now().UTC(),
+	}
+	headerThree := &miniheader.MiniHeader{
+		Number:    big.NewInt(0).Add(headerTwo.Number, big.NewInt(1)),
+		Hash:      common.HexToHash("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
+		Parent:    common.HexToHash("0x72ca9481b09b8c00b2c38575e5652f2de1077f1676c6b868cf575229fcb06a96"),
+		Timestamp: time.Now().UTC(),
+	}
+
+	// Simulate a block found with a timestamp past expirationTime
+	blockEvents := []*blockwatch.Event{
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerOne,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerTwo,
+		},
+		&blockwatch.Event{
+			Type:        blockwatch.Added,
+			BlockHeader: headerThree,
+		},
+	}
+	err = orderWatcher.handleBlockEvents(ctx, blockEvents)
+	require.NoError(t, err)
+
+	latestMiniHeader, err = meshDB.FindLatestMiniHeader()
+	require.NoError(t, err)
+	assert.Equal(t, headerThree.Hash, latestMiniHeader.Hash)
+
+	totalMiniHeaders, err := meshDB.MiniHeaders.Count()
+	require.NoError(t, err)
+	assert.Equal(t, miniHeaderRetentionLimit, totalMiniHeaders)
+}
+
 // Scenario: Order has become unexpired and filled in the same block events processed. We test this case using
 // `convertValidationResultsIntoOrderEvents` since we cannot properly time-travel using Ganache.
 // Source: https://github.com/trufflesuite/ganache-cli/issues/708
@@ -1520,7 +1585,7 @@ func setupOrderWatcher(ctx context.Context, t *testing.T, ethRPCClient ethrpccli
 	blockWatcherClient, err := blockwatch.NewRpcClient(ethRPCClient)
 	require.NoError(t, err)
 	topics := GetRelevantTopics()
-	stack := simplestack.New(blockWatcherRetentionLimit, []*miniheader.MiniHeader{})
+	stack := simplestack.New(miniHeaderRetentionLimit, []*miniheader.MiniHeader{})
 	blockWatcherConfig := blockwatch.Config{
 		Stack:           stack,
 		PollingInterval: blockPollingInterval,
@@ -1532,12 +1597,13 @@ func setupOrderWatcher(ctx context.Context, t *testing.T, ethRPCClient ethrpccli
 	orderValidator, err := ordervalidator.New(ethRPCClient, constants.TestChainID, ethereumRPCMaxContentLength)
 	require.NoError(t, err)
 	orderWatcher, err := New(Config{
-		MeshDB:            meshDB,
-		BlockWatcher:      blockWatcher,
-		OrderValidator:    orderValidator,
-		ChainID:           constants.TestChainID,
-		MaxExpirationTime: constants.UnlimitedExpirationTime,
-		MaxOrders:         1000,
+		MeshDB:                   meshDB,
+		BlockWatcher:             blockWatcher,
+		OrderValidator:           orderValidator,
+		ChainID:                  constants.TestChainID,
+		MaxExpirationTime:        constants.UnlimitedExpirationTime,
+		MaxOrders:                1000,
+		MiniHeaderRetentionLimit: miniHeaderRetentionLimit,
 	})
 	require.NoError(t, err)
 

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -1352,7 +1352,8 @@ func TestOrderWatcherMaintainMiniHeaderRetentionLimit(t *testing.T) {
 	defer teardownSubTest(t)
 	meshDB, err := meshdb.New("/tmp/leveldb_testing/" + uuid.New().String())
 	require.NoError(t, err)
-	meshDB.UpdateMiniHeaderRetentionLimit(miniHeaderRetentionLimit)
+	err = meshDB.UpdateMiniHeaderRetentionLimit(miniHeaderRetentionLimit)
+	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer func() {
 		cancel()


### PR DESCRIPTION
Fixes: #667 

It also makes sure we delete miniHeaders from the DB after processing new block events that could cause new miniHeaders to be added to the DB, such that the number of miniHeaders stored does not exceed the retention limit.