### PR TITLE
Increase maximum peers for browser nodes

### DIFF
--- a/p2p/opts_js.go
+++ b/p2p/opts_js.go
@@ -19,11 +19,11 @@ const (
 	// maxShareBatch is the maximum number of messages to share at once.
 	maxShareBatch = 50
 	// peerCountLow is the target number of peers to connect to at any given time.
-	peerCountLow = 10
+	peerCountLow = 50
 	// peerCountHigh is the maximum number of peers to be connected to. If the
 	// number of connections exceeds this number, we will prune connections until
 	// we reach peerCountLow.
-	peerCountHigh = 12
+	peerCountHigh = 60
 )
 
 func getHostOptions(ctx context.Context, config Config) ([]libp2p.Option, error) {


### PR DESCRIPTION
We have more performance headroom since implementing #692. Increasing the max number of peers will help each node find the right peers (e.g. those using the same topic) faster and make the network healthier in general. Of course, there is still room for further improvement for finding the right peers faster (see #582).