### PR TITLE
drone: Fix Github Release task

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -95,7 +95,6 @@ steps:
       api_key:
         from_secret: github_public_repo
       files:
-        - *
       note: RELEASE_CHANGELOG.md
       when:
         event: tag


### PR DESCRIPTION
Drone is broken because of a previous misguided fix.