### PR TITLE
Only log warning about outdated miniheaders on startup

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -315,6 +315,17 @@ func New(config Config) (*App, error) {
 	// 2. There's still a chance there are old MiniHeaders in the database (e.g. due to a sudden
 	//    unexpected shut down).
 	//
+	totalMiniHeaders, err := meshDB.MiniHeaders.Count()
+	if err != nil {
+		return nil, err
+	}
+	miniHeadersToRemove := totalMiniHeaders - meshDB.MiniHeaderRetentionLimit
+	if miniHeadersToRemove > 0 {
+		log.WithFields(log.Fields{
+			"numHeadersToRemove": miniHeadersToRemove,
+			"totalHeadersStored": totalMiniHeaders,
+		}).Warn("Removing outdated block headers in database (this can take a while)")
+	}
 	err = meshDB.PruneMiniHeadersAboveRetentionLimit()
 	if err != nil {
 		return nil, err

--- a/meshdb/meshdb.go
+++ b/meshdb/meshdb.go
@@ -340,11 +340,6 @@ func (m *MeshDB) PruneMiniHeadersAboveRetentionLimit() error {
 	if totalMiniHeaders, err := m.MiniHeaders.Count(); err != nil {
 		return err
 	} else if totalMiniHeaders > m.MiniHeaderRetentionLimit {
-		miniHeadersToRemove := totalMiniHeaders - m.MiniHeaderRetentionLimit
-		log.WithFields(log.Fields{
-			"numHeadersToRemove": miniHeadersToRemove,
-			"totalHeadersStored": totalMiniHeaders,
-		}).Warn("Removing outdated block headers in database (this can take a while)")
 		latestMiniHeader, err := m.FindLatestMiniHeader()
 		if err != nil {
 			return err


### PR DESCRIPTION
Previously we were logging this warning every time we removed miniheaders from the database, which is not necessary. We only need to warn when there are extra miniheaders in the database _on startup_, since that is not expected.