### PR TITLE
Improve peer discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v9.1.0
+
+### Features ✅
+
+- Improved speed and efficiency of peer discovery, especially when using custom order filters [#729](https://github.com/0xProject/0x-mesh/pull/729).
+
+
 ## v9.0.1
 
 ### Bug fixes 🐞

--- a/common/types/types.go
+++ b/common/types/types.go
@@ -19,6 +19,7 @@ type Stats struct {
 	Version                           string      `json:"version"`
 	PubSubTopic                       string      `json:"pubSubTopic"`
 	Rendezvous                        string      `json:"rendezvous"`
+	SecondaryRendezvous               []string    `json:"secondaryRendezvous"`
 	PeerID                            string      `json:"peerID"`
 	EthereumChainID                   int         `json:"ethereumChainID"`
 	LatestBlock                       LatestBlock `json:"latestBlock"`

--- a/common/types/types_js.go
+++ b/common/types/types_js.go
@@ -26,10 +26,15 @@ func (l LatestBlock) JSValue() js.Value {
 }
 
 func (s Stats) JSValue() js.Value {
+	secondaryRendezvous := make([]interface{}, len(s.SecondaryRendezvous))
+	for i, rendezvousPoint := range s.SecondaryRendezvous {
+		secondaryRendezvous[i] = rendezvousPoint
+	}
 	return js.ValueOf(map[string]interface{}{
 		"version":                           s.Version,
 		"pubSubTopic":                       s.PubSubTopic,
 		"rendezvous":                        s.Rendezvous,
+		"secondaryRendezvous":               secondaryRendezvous,
 		"peerID":                            s.PeerID,
 		"ethereumChainID":                   s.EthereumChainID,
 		"latestBlock":                       s.LatestBlock.JSValue(),

--- a/core/core.go
+++ b/core/core.go
@@ -1014,10 +1014,10 @@ func (app *App) GetStats() (*types.Stats, error) {
 	}
 
 	response := &types.Stats{
-		Version:     version,
-		PubSubTopic: app.orderFilter.Topic(),
-		// TOOD(albrow): Include all rendezvous points.
+		Version:                           version,
+		PubSubTopic:                       app.orderFilter.Topic(),
 		Rendezvous:                        rendezvousPoints[0],
+		SecondaryRendezvous:               rendezvousPoints[1:],
 		PeerID:                            app.peerID.String(),
 		EthereumChainID:                   app.config.EthereumChainID,
 		LatestBlock:                       latestBlock,

--- a/core/core.go
+++ b/core/core.go
@@ -434,7 +434,7 @@ func getPublishTopics(chainID int, customFilter *orderfilter.Filter) ([]string, 
 	}
 }
 
-func getRendezvous(chainID int) string {
+func getDefaultRendezvous(chainID int) string {
 	return fmt.Sprintf("/0x-mesh/network/%d/version/2", chainID)
 }
 
@@ -599,6 +599,10 @@ func (app *App) Start(ctx context.Context) error {
 	if app.config.BootstrapList != "" {
 		bootstrapList = strings.Split(app.config.BootstrapList, ",")
 	}
+	rendezvousPoints := []string{
+		app.orderFilter.Rendezvous(),
+		getDefaultRendezvous(app.config.EthereumChainID),
+	}
 	nodeConfig := p2p.Config{
 		SubscribeTopic:         app.orderFilter.Topic(),
 		PublishTopics:          publishTopics,
@@ -607,7 +611,7 @@ func (app *App) Start(ctx context.Context) error {
 		Insecure:               false,
 		PrivateKey:             app.privKey,
 		MessageHandler:         app,
-		RendezvousString:       getRendezvous(app.config.EthereumChainID),
+		RendezvousPoints:       rendezvousPoints,
 		UseBootstrapList:       app.config.UseBootstrapList,
 		BootstrapList:          bootstrapList,
 		DataDir:                filepath.Join(app.config.DataDir, "p2p"),
@@ -993,7 +997,7 @@ func (app *App) GetStats() (*types.Stats, error) {
 	response := &types.Stats{
 		Version:                           version,
 		PubSubTopic:                       app.orderFilter.Topic(),
-		Rendezvous:                        getRendezvous(app.config.EthereumChainID),
+		Rendezvous:                        getDefaultRendezvous(app.config.EthereumChainID),
 		PeerID:                            app.peerID.String(),
 		EthereumChainID:                   app.config.EthereumChainID,
 		LatestBlock:                       latestBlock,

--- a/integration-tests/rpc_integration_test.go
+++ b/integration-tests/rpc_integration_test.go
@@ -264,6 +264,7 @@ func runGetStatsTest(t *testing.T, rpcEndpointPrefix string, rpcPort int) {
 	// Ensure that the correct response was logged by "GetStats"
 	require.Equal(t, "/0x-orders/version/3/chain/1337/schema/e30=", getStatsResponse.PubSubTopic)
 	require.Equal(t, "/0x-mesh/network/1337/version/2", getStatsResponse.Rendezvous)
+	require.Equal(t, []string{}, getStatsResponse.SecondaryRendezvous)
 	require.Equal(t, jsonLog.PeerID, getStatsResponse.PeerID)
 	require.Equal(t, 1337, getStatsResponse.EthereumChainID)
 	require.Equal(t, types.LatestBlock{}, getStatsResponse.LatestBlock)

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -561,8 +561,6 @@ func (n *Node) startMessageHandler(ctx context.Context) error {
 		if mathrand.Float64() <= chanceToCheckBandwidthUsage {
 			n.banner.CheckBandwidthUsage()
 		}
-
-		return nil
 	}
 }
 

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	mathrand "math/rand"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/0xProject/0x-mesh/constants"
@@ -43,6 +44,8 @@ const (
 	// peerGraceDuration is the amount of time a newly opened connection is given
 	// before it becomes subject to pruning.
 	peerGraceDuration = 10 * time.Second
+	// peerDiscoveryInterval is how frequently to try to connect to new peers.
+	peerDiscoveryInterval = 5 * time.Second
 	// defaultNetworkTimeout is the default timeout for network requests (e.g.
 	// connecting to a new peer).
 	defaultNetworkTimeout = 10 * time.Second
@@ -121,9 +124,10 @@ type Config struct {
 	// MessageHandler is an interface responsible for validating, storing, and
 	// finding new messages to share.
 	MessageHandler MessageHandler
-	// RendezvousString is a unique identifier for the rendezvous point. This node
-	// will attempt to find peers with the same Rendezvous string.
-	RendezvousString string
+	// RendezvousPoints is a unique identifier for one or more rendezvous points
+	// (in order of priority). This node will attempt to find peers with one or
+	// more matching rendezvous points.
+	RendezvousPoints []string
 	// UseBootstrapList determines whether or not to use the list of hard-coded
 	// peers to bootstrap the DHT for peer discovery.
 	UseBootstrapList bool
@@ -172,8 +176,8 @@ func getDHTDir(datadir string) string {
 func New(ctx context.Context, config Config) (*Node, error) {
 	if config.MessageHandler == nil {
 		return nil, errors.New("config.MessageHandler is required")
-	} else if config.RendezvousString == "" {
-		return nil, errors.New("config.RendezvousString is required")
+	} else if len(config.RendezvousPoints) == 0 {
+		return nil, errors.New("config.RendezvousPoints is required")
 	}
 	if config.GlobalPubSubMessageLimit == 0 {
 		config.GlobalPubSubMessageLimit = defaultGlobalPubSubMessageLimit
@@ -391,9 +395,65 @@ func (n *Node) Start() error {
 	}
 
 	// Advertise ourselves for the purposes of peer discovery.
-	discovery.Advertise(n.ctx, n.routingDiscovery, n.config.RendezvousString, discovery.TTL(advertiseTTL))
+	for _, rendezvousPoint := range n.config.RendezvousPoints {
+		discovery.Advertise(n.ctx, n.routingDiscovery, rendezvousPoint, discovery.TTL(advertiseTTL))
+	}
 
-	return n.mainLoop()
+	// Create a child context so that we can preemptively cancel if there is an
+	// error.
+	innerCtx, cancel := context.WithCancel(n.ctx)
+	defer cancel()
+
+	// Below, we will start several independent goroutines. We use separate
+	// channels to communicate errors and a waitgroup to wait for all goroutines
+	// to exit.
+	wg := &sync.WaitGroup{}
+
+	// Start message handler loop.
+	messageHandlerErrChan := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() {
+			log.Debug("closing p2p message handler loop")
+		}()
+		messageHandlerErrChan <- n.startMessageHandler(innerCtx)
+	}()
+
+	// Start peer discovery loop.
+	peerDiscoveryErrChan := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer func() {
+			log.Debug("closing p2p peer discovery loop")
+		}()
+		peerDiscoveryErrChan <- n.startPeerDiscovery(innerCtx)
+	}()
+
+	// If any error channel returns a non-nil error, we cancel the inner context
+	// and return the error. Note that this means we only return the first error
+	// that occurs.
+	select {
+	case err := <-messageHandlerErrChan:
+		if err != nil {
+			log.WithError(err).Error("message handler loop exited with error")
+			cancel()
+			return err
+		}
+	case err := <-peerDiscoveryErrChan:
+		if err != nil {
+			log.WithError(err).Error("peer discovery loop exited with error")
+			cancel()
+			return err
+		}
+	}
+
+	// Wait for all goroutines to exit. If we reached here it means we are done
+	// and there are no errors.
+	wg.Wait()
+	log.Debug("p2p node successfully closed")
+	return nil
 }
 
 // AddPeerScore adds diff to the current score for a given peer. Tag is a unique
@@ -452,80 +512,95 @@ func (n *Node) Connect(peerInfo peer.AddrInfo, timeout time.Duration) error {
 	return nil
 }
 
-// mainLoop is where the core logic for a Node is implemented. On each iteration
-// of the loop, the node receives new messages and sends messages to its peers.
-func (n *Node) mainLoop() error {
+// startMessageHandler continuously receives and processes incoming messages
+// until there is an error or the context is canceled. It also checks bandwidth
+// usage on some iterations.
+func (n *Node) startMessageHandler(ctx context.Context) error {
 	for {
 		select {
-		case <-n.ctx.Done():
+		case <-ctx.Done():
 			return nil
 		default:
 		}
-		if err := n.runOnce(); err != nil {
+		if err := n.receiveAndHandleMessages(ctx); err != nil {
 			return err
 		}
+
+		// Check bandwidth usage non-deterministically
+		if mathrand.Float64() <= chanceToCheckBandwidthUsage {
+			n.banner.CheckBandwidthUsage()
+		}
+
+		return nil
 	}
 }
 
-// runOnce runs a single iteration of the main loop.
-func (n *Node) runOnce() error {
-	peerCount := n.connManager.GetInfo().ConnCount
-	if peerCount < peerCountLow {
-		if err := n.findNewPeers(peerCountLow - peerCount); err != nil {
-			return err
-		}
-	}
-
-	if err := n.receiveAndHandleMessages(); err != nil {
-		return err
-	}
-
-	// Check bandwidth usage non-deterministically
-	if mathrand.Float64() <= chanceToCheckBandwidthUsage {
-		n.banner.CheckBandwidthUsage()
-	}
-
-	return nil
-}
-
-func (n *Node) receiveAndHandleMessages() error {
+func (n *Node) receiveAndHandleMessages(ctx context.Context) error {
 	// Receive up to maxReceiveBatch messages.
-	incoming, err := n.receiveBatch()
+	incoming, err := n.receiveBatch(ctx)
 	if err != nil {
 		return err
 	}
-	if err := n.messageHandler.HandleMessages(n.ctx, incoming); err != nil {
+	if err := n.messageHandler.HandleMessages(ctx, incoming); err != nil {
 		return fmt.Errorf("could not validate or store messages: %s", err.Error())
 	}
 	return nil
 }
 
-func (n *Node) findNewPeers(max int) error {
-	log.WithFields(map[string]interface{}{
-		"max": max,
-	}).Trace("looking for new peers")
-	findPeersCtx, cancel := context.WithTimeout(n.ctx, defaultNetworkTimeout)
-	defer cancel()
-	peerChan, err := n.routingDiscovery.FindPeers(findPeersCtx, n.config.RendezvousString, discovery.Limit(max))
-	if err != nil {
-		return err
+// startPeerDiscovery continuously finds new peers as needed until there is an
+// error or the context is canceled.
+func (n *Node) startPeerDiscovery(ctx context.Context) error {
+	ticker := time.NewTicker(peerDiscoveryInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := n.findNewPeers(ctx); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (n *Node) findNewPeers(ctx context.Context) error {
+	for _, rendezvousPoint := range n.config.RendezvousPoints {
+		currentPeerCount := n.connManager.GetInfo().ConnCount
+		if currentPeerCount >= peerCountLow {
+			// We already have enough peers. Nothing to do.
+			return nil
+		}
+		maxNewPeers := peerCountLow - currentPeerCount
+		log.WithFields(map[string]interface{}{
+			"currentPeerCount": currentPeerCount,
+			"maxNewPeers":      maxNewPeers,
+			"rendezvousPoint":  rendezvousPoint,
+		}).Trace("looking for new peers")
+		findPeersCtx, cancel := context.WithTimeout(ctx, defaultNetworkTimeout)
+		defer cancel()
+		peerChan, err := n.routingDiscovery.FindPeers(findPeersCtx, rendezvousPoint, discovery.Limit(maxNewPeers))
+		if err != nil {
+			return err
+		}
+		connectCtx, cancel := context.WithTimeout(ctx, defaultNetworkTimeout)
+		defer cancel()
+		for peer := range peerChan {
+			if peer.ID == n.host.ID() || len(peer.Addrs) == 0 {
+				continue
+			}
+			log.WithFields(map[string]interface{}{
+				"peerInfo":        peer,
+				"rendezvousPoint": rendezvousPoint,
+			}).Trace("found peer via rendezvous")
+			if err := n.host.Connect(connectCtx, peer); err != nil {
+				// We still want to try connecting to the other peers. Log the error and
+				// keep going.
+				logPeerConnectionError(peer, err)
+			}
+		}
 	}
 
-	connectCtx, cancel := context.WithTimeout(n.ctx, defaultNetworkTimeout)
-	defer cancel()
-	for peer := range peerChan {
-		if peer.ID == n.host.ID() || len(peer.Addrs) == 0 {
-			continue
-		}
-		log.WithFields(map[string]interface{}{
-			"peerInfo": peer,
-		}).Trace("found peer via rendezvous")
-		if err := n.host.Connect(connectCtx, peer); err != nil {
-			// We still want to try connecting to the other peers. Log the error and
-			// keep going.
-			logPeerConnectionError(peer, err)
-		}
-	}
 	return nil
 }
 
@@ -562,7 +637,7 @@ func logPeerConnectionError(peerInfo peer.AddrInfo, connectionErr error) {
 
 // receiveBatch returns up to maxReceiveBatch messages which are received from
 // peers. There is no guarantee that the messages are unique.
-func (n *Node) receiveBatch() ([]*Message, error) {
+func (n *Node) receiveBatch(ctx context.Context) ([]*Message, error) {
 	messages := []*Message{}
 	for {
 		if len(messages) >= maxReceiveBatch {
@@ -570,7 +645,7 @@ func (n *Node) receiveBatch() ([]*Message, error) {
 		}
 		select {
 		// If the parent context was canceled, return.
-		case <-n.ctx.Done():
+		case <-ctx.Done():
 			return messages, nil
 		default:
 		}

--- a/packages/browser-lite/src/types.ts
+++ b/packages/browser-lite/src/types.ts
@@ -617,6 +617,7 @@ export interface WrapperStats {
     version: string;
     pubSubTopic: string;
     rendezvous: string;
+    secondaryRendezvous: string[];
     peerID: string;
     ethereumChainID: number;
     latestBlock: LatestBlock;
@@ -634,6 +635,7 @@ export interface Stats {
     version: string;
     pubSubTopic: string;
     rendezvous: string;
+    secondaryRendezvous: string[];
     peerID: string;
     ethereumChainID: number;
     latestBlock: LatestBlock;

--- a/packages/browser/conversion-tests/conversion_test.ts
+++ b/packages/browser/conversion-tests/conversion_test.ts
@@ -404,7 +404,7 @@ function testGetOrdersResponse(getOrdersResponse: WrapperGetOrdersResponse[]): v
     printer(
         'orderInfo.signedOrder.makerAssetData',
         getOrdersResponse[1].ordersInfos[0].signedOrder.makerAssetData ===
-            '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
+        '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
     );
     printer(
         'orderInfo.signedOrder.makerAssetAmount',
@@ -413,13 +413,13 @@ function testGetOrdersResponse(getOrdersResponse: WrapperGetOrdersResponse[]): v
     printer(
         'orderInfo.signedOrder.makerFeeAssetData',
         getOrdersResponse[1].ordersInfos[0].signedOrder.makerFeeAssetData ===
-            '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
+        '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
     );
     printer('orderInfo.signedOrder.makerFee', getOrdersResponse[1].ordersInfos[0].signedOrder.makerFee === '89');
     printer(
         'orderInfo.signedOrder.takerAssetData',
         getOrdersResponse[1].ordersInfos[0].signedOrder.takerAssetData ===
-            '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     );
     printer(
         'orderInfo.signedOrder.takerAssetAmount',
@@ -428,7 +428,7 @@ function testGetOrdersResponse(getOrdersResponse: WrapperGetOrdersResponse[]): v
     printer(
         'orderInfo.signedOrder.takerFeeAssetData',
         getOrdersResponse[1].ordersInfos[0].signedOrder.takerFeeAssetData ===
-            '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
+        '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
     );
     printer('orderInfo.signedOrder.takerFee', getOrdersResponse[1].ordersInfos[0].signedOrder.takerFee === '12');
     printer(
@@ -524,7 +524,7 @@ function testGetOrdersResponse(getOrdersResponse: WrapperGetOrdersResponse[]): v
     printer(
         'orderInfo.signedOrder.makerAssetData',
         getOrdersResponse[2].ordersInfos[1].signedOrder.makerAssetData ===
-            '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
+        '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
     );
     printer(
         'orderInfo.signedOrder.makerAssetAmount',
@@ -533,13 +533,13 @@ function testGetOrdersResponse(getOrdersResponse: WrapperGetOrdersResponse[]): v
     printer(
         'orderInfo.signedOrder.makerFeeAssetData',
         getOrdersResponse[2].ordersInfos[1].signedOrder.makerFeeAssetData ===
-            '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
+        '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
     );
     printer('orderInfo.signedOrder.makerFee', getOrdersResponse[2].ordersInfos[1].signedOrder.makerFee === '89');
     printer(
         'orderInfo.signedOrder.takerAssetData',
         getOrdersResponse[2].ordersInfos[1].signedOrder.takerAssetData ===
-            '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     );
     printer(
         'orderInfo.signedOrder.takerAssetAmount',
@@ -548,7 +548,7 @@ function testGetOrdersResponse(getOrdersResponse: WrapperGetOrdersResponse[]): v
     printer(
         'orderInfo.signedOrder.takerFeeAssetData',
         getOrdersResponse[2].ordersInfos[1].signedOrder.takerFeeAssetData ===
-            '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
+        '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
     );
     printer('orderInfo.signedOrder.takerFee', getOrdersResponse[2].ordersInfos[1].signedOrder.takerFee === '12');
     printer(
@@ -606,25 +606,25 @@ function testOrderEvents(orderEvents: WrapperOrderEvent[]): void {
     printer(
         'signedOrder.makerAssetData',
         orderEvents[1].signedOrder.makerAssetData ===
-            '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
+        '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
     );
     printer('signedOrder.makerAssetAmount', orderEvents[1].signedOrder.makerAssetAmount === '123456789');
     printer(
         'signedOrder.makerFeeAssetData',
         orderEvents[1].signedOrder.makerFeeAssetData ===
-            '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
+        '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
     );
     printer('signedOrder.makerFee', orderEvents[1].signedOrder.makerFee === '89');
     printer(
         'signedOrder.takerAssetData',
         orderEvents[1].signedOrder.takerAssetData ===
-            '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     );
     printer('signedOrder.takerAssetAmount', orderEvents[1].signedOrder.takerAssetAmount === '987654321');
     printer(
         'signedOrder.takerFeeAssetData',
         orderEvents[1].signedOrder.takerFeeAssetData ===
-            '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
+        '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
     );
     printer('signedOrder.takerFee', orderEvents[1].signedOrder.takerFee === '12');
     printer('signedOrder.expirationTimeSeconds', orderEvents[1].signedOrder.expirationTimeSeconds === '10000000000');
@@ -674,7 +674,7 @@ function testSignedOrders(signedOrders: WrapperSignedOrder[]): void {
     printer(
         'makerFeeAssetData',
         signedOrders[1].makerFeeAssetData ===
-            '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
+        '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
     );
     printer('makerFee', signedOrders[1].makerFee === '89');
     printer(
@@ -685,7 +685,7 @@ function testSignedOrders(signedOrders: WrapperSignedOrder[]): void {
     printer(
         'takerFeeAssetData',
         signedOrders[1].takerFeeAssetData ===
-            '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
+        '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
     );
     printer('takerFee', signedOrders[1].takerFee === '12');
     printer('expirationTimeSeconds', signedOrders[1].expirationTimeSeconds === '10000000000');
@@ -701,6 +701,7 @@ function testStats(stats: WrapperStats[]): void {
     printer('version', stats[0].version === 'development');
     printer('pubSubTopic', stats[0].pubSubTopic === 'someTopic');
     printer('rendezvous', stats[0].rendezvous === '/0x-mesh/network/1337/version/2');
+    printer('secondaryRendezvous', stats[0].secondaryRendezvous.length == 1 && stats[0].secondaryRendezvous[0] === "/0x-custom-filter-rendezvous/version/2/chain/1337/schema/someTopic");
     printer('peerID', stats[0].peerID === '16Uiu2HAmGd949LwaV4KNvK2WDSiMVy7xEmW983VH75CMmefmMpP7');
     printer('ethereumChainID', stats[0].ethereumChainID === 1337);
     printer('latestBlock | hash', stats[0].latestBlock.hash === hexUtils.leftPad('0x1', 32));
@@ -845,7 +846,7 @@ function testValidationResults(validationResults: WrapperValidationResults[]): v
     printer(
         'rejected.status.message',
         validationResults[2].rejected[0].status.message ===
-            'order makerAssetData must encode a supported assetData type',
+        'order makerAssetData must encode a supported assetData type',
     );
 
     printer = prettyPrintTestCase('validationResults', 'RealisticValidationResults');
@@ -933,7 +934,7 @@ function testValidationResults(validationResults: WrapperValidationResults[]): v
     printer(
         'accepted.signedOrder.makerAssetData',
         validationResults[3].accepted[1].signedOrder.makerAssetData ===
-            '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
+        '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
     );
     printer(
         'accepted.signedOrder.makerAssetAmount',
@@ -942,13 +943,13 @@ function testValidationResults(validationResults: WrapperValidationResults[]): v
     printer(
         'accepted.signedOrder.makerFeeAssetData',
         validationResults[3].accepted[1].signedOrder.makerFeeAssetData ===
-            '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
+        '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
     );
     printer('accepted.signedOrder.makerFee', validationResults[3].accepted[1].signedOrder.makerFee === '89');
     printer(
         'accepted.signedOrder.takerAssetData',
         validationResults[3].accepted[1].signedOrder.takerAssetData ===
-            '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     );
     printer(
         'accepted.signedOrder.takerAssetAmount',
@@ -957,7 +958,7 @@ function testValidationResults(validationResults: WrapperValidationResults[]): v
     printer(
         'accepted.signedOrder.takerFeeAssetData',
         validationResults[3].accepted[1].signedOrder.takerFeeAssetData ===
-            '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
+        '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
     );
     printer('accepted.signedOrder.takerFee', validationResults[3].accepted[1].signedOrder.takerFee === '12');
     printer(
@@ -968,7 +969,7 @@ function testValidationResults(validationResults: WrapperValidationResults[]): v
     printer(
         'accepted.signedOrder.signature',
         validationResults[3].accepted[1].signedOrder.signature ===
-            '0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33',
+        '0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33',
     );
     printer(
         'accepted.fillableTakerAssetAmount',
@@ -1002,7 +1003,7 @@ function testValidationResults(validationResults: WrapperValidationResults[]): v
     printer(
         'rejected.signedOrder.makerAssetData',
         validationResults[3].rejected[0].signedOrder.makerAssetData ===
-            '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
+        '0xf47261b0000000000000000000000000871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c',
     );
     printer(
         'rejected.signedOrder.makerAssetAmount',
@@ -1011,13 +1012,13 @@ function testValidationResults(validationResults: WrapperValidationResults[]): v
     printer(
         'rejected.signedOrder.makerFeeAssetData',
         validationResults[3].rejected[0].signedOrder.makerFeeAssetData ===
-            '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
+        '0xf47261b000000000000000000000000034d402f14d58e001d8efbe6585051bf9706aa064',
     );
     printer('rejected.signedOrder.makerFee', validationResults[3].rejected[0].signedOrder.makerFee === '89');
     printer(
         'rejected.signedOrder.takerAssetData',
         validationResults[3].rejected[0].signedOrder.takerAssetData ===
-            '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+        '0xf47261b0000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
     );
     printer(
         'rejected.signedOrder.takerAssetAmount',
@@ -1026,7 +1027,7 @@ function testValidationResults(validationResults: WrapperValidationResults[]): v
     printer(
         'rejected.signedOrder.takerFeeAssetData',
         validationResults[3].rejected[0].signedOrder.takerFeeAssetData ===
-            '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
+        '0xf47261b000000000000000000000000025b8fe1de9daf8ba351890744ff28cf7dfa8f5e3',
     );
     printer('rejected.signedOrder.takerFee', validationResults[3].rejected[0].signedOrder.takerFee === '12');
     printer(
@@ -1037,14 +1038,14 @@ function testValidationResults(validationResults: WrapperValidationResults[]): v
     printer(
         'rejected.signedOrder.signature',
         validationResults[3].rejected[0].signedOrder.signature ===
-            '0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33',
+        '0x012761a3ed31b43c8780e905a260a35faefcc527be7516aa11c0256729b5b351bc33',
     );
     printer('rejected.kind', validationResults[3].rejected[0].kind === 'MESH_ERROR');
     printer('rejected.status.code', validationResults[3].rejected[0].status.code === 'CoordinatorEndpointNotFound');
     printer(
         'rejected.status.message',
         validationResults[3].rejected[0].status.message ===
-            'corresponding coordinator endpoint not found in CoordinatorRegistry contract',
+        'corresponding coordinator endpoint not found in CoordinatorRegistry contract',
     );
 }
 

--- a/packages/browser/go/conversion-test/conversion_test.go
+++ b/packages/browser/go/conversion-test/conversion_test.go
@@ -334,6 +334,7 @@ func registerStatsTest(description string) {
 	registerStatsField(description, "version")
 	registerStatsField(description, "pubSubTopic")
 	registerStatsField(description, "rendezvous")
+	registerStatsField(description, "secondaryRendezvous")
 	registerStatsField(description, "peerID")
 	registerStatsField(description, "ethereumChainID")
 	registerStatsField(description, "latestBlock | hash")
@@ -443,8 +444,10 @@ func startBrowserInstance(t *testing.T, ctx context.Context, url string, done ch
 						if count == testLength {
 							done <- struct{}{}
 						}
-					} else if len(string(arg.Value)) > 1 {
-						t.Errorf("Unexpected test results: %s\n", string(arg.Value))
+					} else if arg.Type == runtime.TypeString && len(string(arg.Value)) > 1 {
+						t.Errorf("Unexpected extra test results: %s\n", string(arg.Value))
+					} else {
+						t.Errorf("Unexpected non-string output: %s %s\n", arg.Type, arg.Value)
 					}
 				}
 			case runtime.APITypeError:

--- a/packages/browser/go/conversion-test/main.go
+++ b/packages/browser/go/conversion-test/main.go
@@ -486,11 +486,12 @@ func setGlobals() {
 		"stats": js.FuncOf(func(this js.Value, args []js.Value) interface{} {
 			return []interface{}{
 				types.Stats{
-					Version:         "development",
-					PubSubTopic:     "someTopic",
-					Rendezvous:      "/0x-mesh/network/1337/version/2",
-					PeerID:          "16Uiu2HAmGd949LwaV4KNvK2WDSiMVy7xEmW983VH75CMmefmMpP7",
-					EthereumChainID: 1337,
+					Version:             "development",
+					PubSubTopic:         "someTopic",
+					Rendezvous:          "/0x-mesh/network/1337/version/2",
+					SecondaryRendezvous: []string{"/0x-custom-filter-rendezvous/version/2/chain/1337/schema/someTopic"},
+					PeerID:              "16Uiu2HAmGd949LwaV4KNvK2WDSiMVy7xEmW983VH75CMmefmMpP7",
+					EthereumChainID:     1337,
 					LatestBlock: types.LatestBlock{
 						Hash:   common.HexToHash("0x1"),
 						Number: 1500,

--- a/packages/rpc-client/test/ws_client_test.ts
+++ b/packages/rpc-client/test/ws_client_test.ts
@@ -147,6 +147,7 @@ blockchainTests.resets('WSClient', env => {
                     version: '',
                     pubSubTopic: '/0x-orders/version/3/chain/1337/schema/e30=',
                     rendezvous: '/0x-mesh/network/1337/version/2',
+                    secondaryRendezvous: [],
                     peerID: deployment.peerID,
                     ethereumChainID: 1337,
                     latestBlock: {
@@ -345,13 +346,13 @@ blockchainTests.resets('WSClient', env => {
         describe('#unsubscribeAsync', async () => {
             it('should unsubscribe successfully', async () => {
                 // tslint:disable-next-line:no-empty
-                const subscriptionID = await deployment.client.subscribeToOrdersAsync(() => {});
+                const subscriptionID = await deployment.client.subscribeToOrdersAsync(() => { });
                 await deployment.client.unsubscribeAsync(subscriptionID);
             });
 
             it('should throw an error after unsubscribing redundantly', async () => {
                 // tslint:disable-next-line:no-empty
-                const subscriptionID = await deployment.client.subscribeToOrdersAsync(() => {});
+                const subscriptionID = await deployment.client.subscribeToOrdersAsync(() => { });
                 await deployment.client.unsubscribeAsync(subscriptionID);
                 let thrownError: Error = new Error('');
                 try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,7 +302,7 @@
 "@0x/mesh-browser@file:packages/browser":
   version "1.0.0"
   dependencies:
-    "@0x/mesh-browser-lite" "file:../Library/Caches/Yarn/v6/npm-@0x-mesh-browser-1.0.0-921f684e-659a-46d5-b748-42da7753fe25-1582829487360/node_modules/@0x/browser-lite"
+    "@0x/mesh-browser-lite" "file:../../../Library/Caches/Yarn/v6/npm-@0x-mesh-browser-1.0.0-d880c3c1-f642-4389-8fbc-05149abbfd67-1582917634601/node_modules/@0x/browser-lite"
     base64-arraybuffer "^0.2.0"
     browserfs "^1.4.3"
     ethereum-types "^3.0.0"


### PR DESCRIPTION
Fixes #582.

This PR includes a handful of related changes which improve peer discovery, especially for those using custom order filters. In general this will make the process of finding new peers, and specifically finding the _right_ peers, much faster.

1. Created separate rendezvous points for peers using custom order filters.
2. Made peer discovery parallel so it doesn't block message handling.
3. Connect to peers on the rendezvous points before advertising ourselves.