### PR TITLE
Run TypeScript tests as part of make test-all

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,11 +38,11 @@ jobs:
           name: Run linters
           command: make lint
       - run:
-          name: Build the typescript monorepo
-          command: yarn install && yarn build
+          name: Build the TypeScript monorepo
+          command: yarn build
       - run:
-          name: Run TS RPC client tests
-          command: cd packages/rpc-client && yarn test
+          name: Run TypeScript tests
+          command: yarn test
       - run:
           name: Run Go tests
           command: make test-go

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ deps-ts-no-lockfile:
 
 
 .PHONY: test-all
-test-all: test-go test-wasm-node test-wasm-browser
+test-all: test-go test-wasm-node test-wasm-browser test-ts
 
 
 .PHONY: test-go
@@ -62,6 +62,11 @@ test-wasm-node:
 .PHONY: test-wasm-browser
 test-wasm-browser:
 	GOOS=js GOARCH=wasm go test -tags=browser -exec="$$GOPATH/bin/wasmbrowsertest" ./...
+
+
+.PHONY: test-ts
+test-ts:
+	yarn test
 
 
 .PHONY: lint


### PR DESCRIPTION
We should be running the TypeScript tests as part of `make test-all`. I think the fact that we weren't previously was just an oversight.