### PR TITLE
Fix compiler error in core.go

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -445,7 +445,7 @@ func getPublishTopics(chainID int, contractAddresses ethereum.ContractAddresses,
 
 func (app *App) getRendezvousPoints() ([]string, error) {
 	defaultRendezvousPoint := fmt.Sprintf("/0x-mesh/network/%d/version/2", app.config.EthereumChainID)
-	defaultTopic, err := orderfilter.GetDefaultTopic(app.chainID)
+	defaultTopic, err := orderfilter.GetDefaultTopic(app.chainID, *app.contractAddresses)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It looks like a Git auto-merge created a compiler error, which unfortunately CI was not able to detect. This is a pretty rare case but if it happens more often we could look into tweaking CI so that it simulates a merge before running the tests.