### PR TITLE
Improved RPC Server Initialization Log 

### DIFF
--- a/cmd/mesh/main.go
+++ b/cmd/mesh/main.go
@@ -66,7 +66,7 @@ func main() {
 	go func() {
 		defer wg.Done()
 		log.WithField("ws_rpc_addr", config.WSRPCAddr).Info("starting WS RPC server")
-		rpcServer := instantiateServer(ctx, app, config.WSRPCAddr)
+		rpcServer := instantiateServer(ctx, app, config.WSRPCAddr, "WS")
 		if err := rpcServer.Listen(ctx, rpc.WSHandler); err != nil {
 			wsRPCErrChan <- err
 		}
@@ -78,7 +78,7 @@ func main() {
 	go func() {
 		defer wg.Done()
 		log.WithField("http_rpc_addr", config.HTTPRPCAddr).Info("starting HTTP RPC server")
-		rpcServer := instantiateServer(ctx, app, config.HTTPRPCAddr)
+		rpcServer := instantiateServer(ctx, app, config.HTTPRPCAddr, "HTTP")
 		if err := rpcServer.Listen(ctx, rpc.HTTPHandler); err != nil {
 			httpRPCErrChan <- err
 		}

--- a/cmd/mesh/main.go
+++ b/cmd/mesh/main.go
@@ -66,7 +66,14 @@ func main() {
 	go func() {
 		defer wg.Done()
 		log.WithField("ws_rpc_addr", config.WSRPCAddr).Info("starting WS RPC server")
-		rpcServer := instantiateServer(ctx, app, config.WSRPCAddr, "WS")
+		rpcServer := instantiateServer(ctx, app, config.WSRPCAddr)
+		go func() {
+			selectedRPCAddr, err := waitForSelectedAddress(ctx, rpcServer)
+			if err != nil {
+				log.WithError(err).Warn("WS RPC server did not start")
+			}
+			log.WithField("address", selectedRPCAddr).Info("started WS RPC server")
+		}()
 		if err := rpcServer.Listen(ctx, rpc.WSHandler); err != nil {
 			wsRPCErrChan <- err
 		}
@@ -78,7 +85,14 @@ func main() {
 	go func() {
 		defer wg.Done()
 		log.WithField("http_rpc_addr", config.HTTPRPCAddr).Info("starting HTTP RPC server")
-		rpcServer := instantiateServer(ctx, app, config.HTTPRPCAddr, "HTTP")
+		rpcServer := instantiateServer(ctx, app, config.HTTPRPCAddr)
+		go func() {
+			selectedRPCAddr, err := waitForSelectedAddress(ctx, rpcServer)
+			if err != nil {
+				log.WithError(err).Warn("HTTP RPC server did not start")
+			}
+			log.WithField("address", selectedRPCAddr).Info("started HTTP RPC server")
+		}()
 		if err := rpcServer.Listen(ctx, rpc.HTTPHandler); err != nil {
 			httpRPCErrChan <- err
 		}

--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -33,7 +33,7 @@ type rpcHandler struct {
 }
 
 // instantiateServer instantiates a new RPC server with the rpcHandler.
-func instantiateServer(ctx context.Context, app *core.App, rpcAddr string) *rpc.Server {
+func instantiateServer(ctx context.Context, app *core.App, rpcAddr string, rpcServerType string) *rpc.Server {
 	// Initialize the JSON RPC WebSocket server (but don't start it yet).
 	rpcHandler := &rpcHandler{
 		app: app,
@@ -53,7 +53,7 @@ func instantiateServer(ctx context.Context, app *core.App, rpcAddr string) *rpc.
 			}
 			time.Sleep(10 * time.Millisecond)
 		}
-		log.WithField("address", rpcServer.Addr().String()).Info("started RPC server")
+		log.WithField("address", rpcServer.Addr().String()).Infof("started %s RPC server", rpcServerType)
 	}()
 	return rpcServer
 }

--- a/cmd/mesh/rpc_handler.go
+++ b/cmd/mesh/rpc_handler.go
@@ -32,8 +32,21 @@ type rpcHandler struct {
 	ctx context.Context
 }
 
+// waitForSelectedAddress wait for the server to start listening and select an address.
+func waitForSelectedAddress(ctx context.Context, rpcServer *rpc.Server) (string, error) {
+	for rpcServer.Addr() == nil {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return rpcServer.Addr().String(), nil
+}
+
 // instantiateServer instantiates a new RPC server with the rpcHandler.
-func instantiateServer(ctx context.Context, app *core.App, rpcAddr string, rpcServerType string) *rpc.Server {
+func instantiateServer(ctx context.Context, app *core.App, rpcAddr string) *rpc.Server {
 	// Initialize the JSON RPC WebSocket server (but don't start it yet).
 	rpcHandler := &rpcHandler{
 		app: app,
@@ -43,18 +56,6 @@ func instantiateServer(ctx context.Context, app *core.App, rpcAddr string, rpcSe
 	if err != nil {
 		return nil
 	}
-	go func() {
-		// Wait for the server to start listening and select an address.
-		for rpcServer.Addr() == nil {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
-		log.WithField("address", rpcServer.Addr().String()).Infof("started %s RPC server", rpcServerType)
-	}()
 	return rpcServer
 }
 

--- a/integration-tests/browser_integration_test.go
+++ b/integration-tests/browser_integration_test.go
@@ -81,9 +81,9 @@ func TestBrowserIntegration(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// Wait for the RPC server to start before sending the order.
-		_, err := waitForLogSubstring(ctx, standaloneLogMessages, "started RPC server")
-		require.NoError(t, err, "RPC server didn't start")
+		// Wait for the WS RPC server to start before sending the order.
+		_, err := waitForLogSubstring(ctx, standaloneLogMessages, "started WS RPC server")
+		require.NoError(t, err, "WS RPC server didn't start")
 		rpcClient, err := rpc.NewClient(standaloneWSRPCEndpointPrefix + strconv.Itoa(wsRPCPort+count))
 		require.NoError(t, err)
 		results, err := rpcClient.AddOrders([]*zeroex.SignedOrder{standaloneOrder})

--- a/integration-tests/rpc_integration_test.go
+++ b/integration-tests/rpc_integration_test.go
@@ -5,6 +5,7 @@ package integrationtests
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"strconv"
 	"sync"
@@ -25,14 +26,14 @@ import (
 )
 
 func TestWSAddOrdersSuccess(t *testing.T) {
-	runAddOrdersSuccessTest(t, standaloneWSRPCEndpointPrefix, wsRPCPort)
+	runAddOrdersSuccessTest(t, standaloneWSRPCEndpointPrefix, "WS", wsRPCPort)
 }
 
 func TestHTTPAddOrdersSuccess(t *testing.T) {
-	runAddOrdersSuccessTest(t, standaloneHTTPRPCEndpointPrefix, httpRPCPort)
+	runAddOrdersSuccessTest(t, standaloneHTTPRPCEndpointPrefix, "HTTP", httpRPCPort)
 }
 
-func runAddOrdersSuccessTest(t *testing.T, rpcEndpointPrefix string, rpcPort int) {
+func runAddOrdersSuccessTest(t *testing.T, rpcEndpointPrefix, rpcServerType string, rpcPort int) {
 	teardownSubTest := setupSubTest(t)
 	defer teardownSubTest(t)
 
@@ -54,8 +55,8 @@ func runAddOrdersSuccessTest(t *testing.T, rpcEndpointPrefix string, rpcPort int
 
 	// Wait until the rpc server has been started, and then create an rpc client
 	// that connects to the rpc server.
-	_, err := waitForLogSubstring(ctx, logMessages, "started RPC server")
-	require.NoError(t, err, "RPC server didn't start")
+	_, err := waitForLogSubstring(ctx, logMessages, fmt.Sprintf("started %s RPC server", rpcServerType))
+	require.NoError(t, err, fmt.Sprintf("%s RPC server didn't start", rpcServerType))
 	client, err := rpc.NewClient(rpcEndpointPrefix + strconv.Itoa(rpcPort+count))
 	require.NoError(t, err)
 
@@ -91,18 +92,18 @@ func runAddOrdersSuccessTest(t *testing.T, rpcEndpointPrefix string, rpcPort int
 }
 
 func TestWSGetOrders(t *testing.T) {
-	runGetOrdersTest(t, standaloneWSRPCEndpointPrefix, wsRPCPort)
+	runGetOrdersTest(t, standaloneWSRPCEndpointPrefix, "WS", wsRPCPort)
 }
 
 func TestHTTPGetOrders(t *testing.T) {
-	runGetOrdersTest(t, standaloneHTTPRPCEndpointPrefix, httpRPCPort)
+	runGetOrdersTest(t, standaloneHTTPRPCEndpointPrefix, "HTTP", httpRPCPort)
 }
 
 // TODO(jalextowle): Since the uuid creation process is inherently random, we
 //                   can't meaningfully sanity check the returnedSnapshotID in
 //                   this test. Unit testing should be implemented to verify that
 //                   this logic is correct, if necessary.
-func runGetOrdersTest(t *testing.T, rpcEndpointPrefix string, rpcPort int) {
+func runGetOrdersTest(t *testing.T, rpcEndpointPrefix, rpcServerType string, rpcPort int) {
 	teardownSubTest := setupSubTest(t)
 	defer teardownSubTest(t)
 
@@ -122,8 +123,8 @@ func runGetOrdersTest(t *testing.T, rpcEndpointPrefix string, rpcPort int) {
 		startStandaloneNode(t, ctx, count, "", logMessages)
 	}()
 
-	_, err := waitForLogSubstring(ctx, logMessages, "started RPC server")
-	require.NoError(t, err, "RPC server didn't start")
+	_, err := waitForLogSubstring(ctx, logMessages, fmt.Sprintf("started %s RPC server", rpcServerType))
+	require.NoError(t, err, fmt.Sprintf("%s RPC server didn't start", rpcServerType))
 
 	client, err := rpc.NewClient(rpcEndpointPrefix + strconv.Itoa(rpcPort+count))
 	require.NoError(t, err)
@@ -211,14 +212,14 @@ func runGetOrdersTest(t *testing.T, rpcEndpointPrefix string, rpcPort int) {
 }
 
 func TestWSGetStats(t *testing.T) {
-	runGetStatsTest(t, standaloneWSRPCEndpointPrefix, wsRPCPort)
+	runGetStatsTest(t, standaloneWSRPCEndpointPrefix, "WS", wsRPCPort)
 }
 
 func TestHTTPGetStats(t *testing.T) {
-	runGetStatsTest(t, standaloneHTTPRPCEndpointPrefix, httpRPCPort)
+	runGetStatsTest(t, standaloneHTTPRPCEndpointPrefix, "HTTP", httpRPCPort)
 }
 
-func runGetStatsTest(t *testing.T, rpcEndpointPrefix string, rpcPort int) {
+func runGetStatsTest(t *testing.T, rpcEndpointPrefix, rpcServerType string, rpcPort int) {
 	teardownSubTest := setupSubTest(t)
 	defer teardownSubTest(t)
 
@@ -243,8 +244,8 @@ func runGetStatsTest(t *testing.T, rpcEndpointPrefix string, rpcPort int) {
 	var jsonLog struct {
 		PeerID string `json:"myPeerID"`
 	}
-	log, err := waitForLogSubstring(ctx, logMessages, "started RPC server")
-	require.NoError(t, err, "RPC server didn't start")
+	log, err := waitForLogSubstring(ctx, logMessages, fmt.Sprintf("started %s RPC server", rpcServerType))
+	require.NoError(t, err, fmt.Sprintf("%s RPC server didn't start", rpcServerType))
 	err = json.Unmarshal([]byte(log), &jsonLog)
 	require.NoError(t, err)
 	client, err := rpc.NewClient(rpcEndpointPrefix + strconv.Itoa(rpcPort+count))
@@ -298,8 +299,8 @@ func TestOrdersSubscription(t *testing.T) {
 	}()
 
 	// Wait for the rpc server to start and then start the rpc client.
-	_, err := waitForLogSubstring(ctx, logMessages, "started RPC server")
-	require.NoError(t, err, "RPC server didn't start")
+	_, err := waitForLogSubstring(ctx, logMessages, "started WS RPC server")
+	require.NoError(t, err, "WS RPC server didn't start")
 	client, err := rpc.NewClient(standaloneWSRPCEndpointPrefix + strconv.Itoa(wsRPCPort+count))
 	require.NoError(t, err)
 
@@ -359,8 +360,8 @@ func TestHeartbeatSubscription(t *testing.T) {
 	}()
 
 	// Wait for the rpc server to start and then start the rpc client
-	_, err := waitForLogSubstring(ctx, logMessages, "started RPC server")
-	require.NoError(t, err, "RPC server didn't start")
+	_, err := waitForLogSubstring(ctx, logMessages, "started WS RPC server")
+	require.NoError(t, err, "WS RPC server didn't start")
 	client, err := rpc.NewClient(standaloneWSRPCEndpointPrefix + strconv.Itoa(wsRPCPort+count))
 	require.NoError(t, err)
 

--- a/packages/rpc-client/test/utils/ws_server.ts
+++ b/packages/rpc-client/test/utils/ws_server.ts
@@ -45,7 +45,7 @@ export async function startServerAndClientAsync(): Promise<MeshDeployment> {
     await buildBinaryAsync();
 
     const mesh = new MeshHarness();
-    const log = await mesh.waitForPatternAsync(/started RPC server/);
+    const log = await mesh.waitForPatternAsync(/started WS RPC server/);
     const peerID = JSON.parse(log.toString()).myPeerID;
     const client = new WSClient(`ws://localhost:${mesh.wsPort}`);
     return {


### PR DESCRIPTION
The `rpc_integration_test` would intermittently fail because the HTTP and WebSocket RPC Servers would log the same message when they started. The tests were designed with only one RPC server in mind, and this meant that there was a race-condition in the tests. 
