### PR TITLE
Decrease max bytes/s from 100 MiB to 1 MiB

### DIFF
--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -119,7 +119,8 @@ type Config struct {
 	// we reach PeerCountLow. Defaults to 110.
 	PeerCountHigh int `envvar:"PEER_COUNT_HIGH" default:"110"`
 	// MaxBytesPerSecond is the maximum number of bytes per second that a peer is
-	// allowed to send before failing the bandwidth check. Defaults to 1 MiB.
+	// allowed to send before failing the bandwidth check. Defaults to 1 MiB, which
+	// is roughly 100x expected usage based on real world measurements.
 	MaxBytesPerSecond float64 `envvar:"MAX_BYTES_PER_SECOND" default:"1048576"`
 }
 

--- a/cmd/mesh-bootstrap/main.go
+++ b/cmd/mesh-bootstrap/main.go
@@ -119,10 +119,8 @@ type Config struct {
 	// we reach PeerCountLow. Defaults to 110.
 	PeerCountHigh int `envvar:"PEER_COUNT_HIGH" default:"110"`
 	// MaxBytesPerSecond is the maximum number of bytes per second that a peer is
-	// allowed to send before failing the bandwidth check.
-	// TODO(albrow): Reduce this limit once we have a better picture of what real
-	// world bandwidth should be. Defaults to 100 MiB.
-	MaxBytesPerSecond float64 `envvar:"MAX_BYTES_PER_SECOND" default:"104857600"`
+	// allowed to send before failing the bandwidth check. Defaults to 1 MiB.
+	MaxBytesPerSecond float64 `envvar:"MAX_BYTES_PER_SECOND" default:"1048576"`
 }
 
 func init() {

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -68,9 +68,7 @@ const (
 	chanceToCheckBandwidthUsage = 0.1
 	// defaultMaxBytesPerSecond is the maximum number of bytes per second that a
 	// peer is allowed to send before failing the bandwidth check.
-	// TODO(albrow): Reduce this limit once we have a better picture of what
-	// real world bandwidth should be.
-	defaultMaxBytesPerSecond = 104857600 // 100 MiB.
+	defaultMaxBytesPerSecond = 1048576 // 1 MiB.
 	// defaultGlobalPubSubMessageLimit is the default value for
 	// GlobalPubSubMessageLimit. This is an approximation based on a theoretical
 	// case where 1000 peers are sending maxShareBatch messages per second. It may

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -67,7 +67,8 @@ const (
 	// a bandwidth check.
 	chanceToCheckBandwidthUsage = 0.1
 	// defaultMaxBytesPerSecond is the maximum number of bytes per second that a
-	// peer is allowed to send before failing the bandwidth check.
+	// peer is allowed to send before failing the bandwidth check. It's set to
+	// roughly 100x expected usage based on real world measurements.
 	defaultMaxBytesPerSecond = 1048576 // 1 MiB.
 	// defaultGlobalPubSubMessageLimit is the default value for
 	// GlobalPubSubMessageLimit. This is an approximation based on a theoretical


### PR DESCRIPTION
Since https://github.com/0xProject/0x-mesh/pull/692 was implemented we have been seeing vastly reduced bandwidth usage. We can now safely reduce the per-IP bandwidth limits.