### PR TITLE
Fix a bug in the ordersync pagination subprotocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+## v9.2.1
+
+### Bug fixes 🐞
+
+- Fixed a critical bug in the ordersync protocol which resulted in only 50% of existing orders being shared when a new peer joins the network. New orders are shared separately and were unaffected. [#760](https://github.com/0xProject/0x-mesh/pull/760).
+
+
 ## v9.2.0
 
 ### Features ✅


### PR DESCRIPTION
This PR fixes a critical bug in the `FilteredPaginationSubProtocol` for ordersync. There was an off-by-one error in the for loop where we were incrementing `currentPage` _before_ checking for the end condition in each iteration of the loop. This caused every other page to be skipped, resulting in around 50% of the orders actually being shared.

I wanted to create a regression test as part of this PR but doing so has proven difficult. We need to create at least `paginationSubprotocolPerPage * 2 + 1` orders in order to see this bug in the tests. This has proven difficult for two reasons:

1. Since `paginationSubprotocolPerPage` is not configurable via an environment variable, we are stuck with the default value of 500. We don't want to make it configurable as it is too easy for users of Mesh to pick the wrong value. It's better for us to tune it over time based on results from Mesh Manager and in the real world.
2. The `scenario` package does not support creating more than one order (and the associated balances/allowances) at a time. This means that it would have to create at least 1001 orders one at a time, waiting for a new block to be mined for each order. It ends up taking way too long (more than 10 minutes). See #425.

We should add regression tests, but it's better to do that in a separate PR. This is fairly critical bug fix so we should try to get it out as quickly as possible.

I did perform an ad hoc regression test by manually changing `paginationSubprotocolPerPage` to 5, increasing the timeout for the test to 2 minutes, and creating 50 orders (10 pages). This ad hoc test fails prior to the bug fix and passes after it was implemented.