### PR TITLE
Periodically rerun ordersync instead of running it only once on startup

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -67,7 +67,7 @@ const (
 	// ordersyncApproxDelay is the approximate amount of time to wait between each
 	// run of the ordersync protocol (as a requester). We always request orders
 	// immediately on startup. This delay only applies to subsequent runs.
-	ordersyncApproxDelay         = 5 * time.Minute
+	ordersyncApproxDelay         = 1 * time.Hour
 	paginationSubprotocolPerPage = 500
 )
 

--- a/core/core.go
+++ b/core/core.go
@@ -662,6 +662,12 @@ func (app *App) Start(ctx context.Context) error {
 		defer func() {
 			log.Debug("closing ordersync service")
 		}()
+		log.WithFields(map[string]interface{}{
+			"approxDelay":  ordersyncApproxDelay,
+			"perPage":      paginationSubprotocolPerPage,
+			"subprotocols": []string{"FilteredPaginationSubProtocol"},
+		}).Info("starting ordersync service")
+
 		if err := app.ordersyncService.PeriodicallyGetOrders(innerCtx, ordersyncMinPeers, ordersyncApproxDelay); err != nil {
 			orderSyncErrChan <- err
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -63,7 +63,11 @@ const (
 	version          = "development"
 	// ordersyncMinPeers is the minimum amount of peers to receive orders from
 	// before considering the ordersync process finished.
-	ordersyncMinPeers            = 5
+	ordersyncMinPeers = 5
+	// ordersyncMinDelay is the amount of time to wait between each run of the
+	// ordersync protocol (as a requester). We always request orders immediately
+	// on startup. This delay only applies to subsequent runs.
+	ordersyncMinDelay            = 5 * time.Minute
 	paginationSubprotocolPerPage = 500
 )
 
@@ -658,7 +662,7 @@ func (app *App) Start(ctx context.Context) error {
 		defer func() {
 			log.Debug("closing ordersync service")
 		}()
-		if err := app.ordersyncService.GetOrders(innerCtx, ordersyncMinPeers); err != nil {
+		if err := app.ordersyncService.PeriodicallyGetOrders(innerCtx, ordersyncMinPeers, ordersyncMinDelay); err != nil {
 			orderSyncErrChan <- err
 		}
 	}()

--- a/core/core.go
+++ b/core/core.go
@@ -64,10 +64,10 @@ const (
 	// ordersyncMinPeers is the minimum amount of peers to receive orders from
 	// before considering the ordersync process finished.
 	ordersyncMinPeers = 5
-	// ordersyncMinDelay is the amount of time to wait between each run of the
-	// ordersync protocol (as a requester). We always request orders immediately
-	// on startup. This delay only applies to subsequent runs.
-	ordersyncMinDelay            = 5 * time.Minute
+	// ordersyncApproxDelay is the approximate amount of time to wait between each
+	// run of the ordersync protocol (as a requester). We always request orders
+	// immediately on startup. This delay only applies to subsequent runs.
+	ordersyncApproxDelay         = 5 * time.Minute
 	paginationSubprotocolPerPage = 500
 )
 
@@ -662,7 +662,7 @@ func (app *App) Start(ctx context.Context) error {
 		defer func() {
 			log.Debug("closing ordersync service")
 		}()
-		if err := app.ordersyncService.PeriodicallyGetOrders(innerCtx, ordersyncMinPeers, ordersyncMinDelay); err != nil {
+		if err := app.ordersyncService.PeriodicallyGetOrders(innerCtx, ordersyncMinPeers, ordersyncApproxDelay); err != nil {
 			orderSyncErrChan <- err
 		}
 	}()

--- a/core/ordersync/ordersync.go
+++ b/core/ordersync/ordersync.go
@@ -42,7 +42,7 @@ const (
 	// ordersyncJitterAmount is the amount of random jitter to add to the delay before
 	// each run of ordersync in PeriodicallyGetOrders. It is bound by:
 	//
-	//    (approxDelay - approxDelay * jitter) <= actualDelay <= (approxDelay + approxDelay * jitter)
+	//    approxDelay * (1 - jitter) <= actualDelay < approxDelay * (1 + jitter)
 	//
 	ordersyncJitterAmount = 0.1
 )

--- a/core/ordersync/ordersync.go
+++ b/core/ordersync/ordersync.go
@@ -39,6 +39,12 @@ const (
 	maxRequestsPerSecond = 30
 	// requestsBurst is the maximum number of requests to allow at once.
 	requestsBurst = 10
+	// ordersyncJitterAmount is the amount of random jitter to add to the delay before
+	// each run of ordersync in PeriodicallyGetOrders. It is bound by:
+	//
+	//    (approxDelay - approxDelay * jitter) <= actualDelay <= (approxDelay + approxDelay * jitter)
+	//
+	ordersyncJitterAmount = 0.1
 )
 
 var (
@@ -341,9 +347,9 @@ func (s *Service) GetOrders(ctx context.Context, minPeers int) error {
 }
 
 // PeriodicallyGetOrders periodically calls GetOrders. It waits a minimum of
-// minDelay between each call. It will block until there is a critical error or
-// the given context is canceled.
-func (s *Service) PeriodicallyGetOrders(ctx context.Context, minPeers int, minDelay time.Duration) error {
+// approxDelay (with some random jitter) between each call. It will block until
+// there is a critical error or the given context is canceled.
+func (s *Service) PeriodicallyGetOrders(ctx context.Context, minPeers int, approxDelay time.Duration) error {
 	for {
 		select {
 		case <-ctx.Done():
@@ -355,12 +361,22 @@ func (s *Service) PeriodicallyGetOrders(ctx context.Context, minPeers int, minDe
 			return err
 		}
 
+		// Note(albrow): The random jitter here helps smooth out the frequency of ordersync
+		// requests and helps prevent a situation where a large number of nodes are requesting
+		// orders at the same time.
+		delay := calculateDelayWithJitter(approxDelay, ordersyncJitterAmount)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(minDelay):
+		case <-time.After(delay):
 		}
 	}
+}
+
+func calculateDelayWithJitter(approxDelay time.Duration, jitterAmount float64) time.Duration {
+	jitterBounds := int(float64(approxDelay) * jitterAmount * 2)
+	delta := rand.Intn(jitterBounds) - jitterBounds/2
+	return approxDelay + time.Duration(delta)
 }
 
 func handleRequestWithSubprotocol(ctx context.Context, subprotocol Subprotocol, requesterID peer.ID, rawReq *rawRequest) (*Response, error) {

--- a/core/ordersync/ordersync_test.go
+++ b/core/ordersync/ordersync_test.go
@@ -1,0 +1,20 @@
+package ordersync
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateDelayWithJitters(t *testing.T) {
+	numCalls := 100
+	approxDelay := 10 * time.Second
+	jitterAmount := 0.1
+	for i := 0; i < numCalls; i++ {
+		actualDelay := calculateDelayWithJitter(approxDelay, jitterAmount)
+		// 0.1 * 10 seconds is 1 second. So we assert that the actual delay is within 1 second
+		// of the approximate delay.
+		assert.InDelta(t, approxDelay, actualDelay, float64(1*time.Second), "actualDelay: %s", actualDelay)
+	}
+}


### PR DESCRIPTION
This PR adds a new method to the ordersync service called `PeriodicallyGetOrders` which simply calls `GetOrders` on a regular interval (~~currently set to 5 minutes~~). Update: now set to 1 hour. See [comment below](https://github.com/0xProject/0x-mesh/pull/764#issuecomment-601440504).

This accounts for situations where we receive an order which is not valid now but may be valid in the future. There are a couple scenarios where this could happen. Here's just a few examples:

1. A block re-org causes filled or cancelled orders to be fillable again. While we do account for this kind of re-org by marking existing orders as removed before we ultimately delete them from the database, that doesn't account for orders that were unfillable _the first time_ we saw them. Those orders are currently never stored at all.
2. The maker may not have the appropriate balance/allowance when we first see the order, but that may change in a subsequent block. It is not uncommon for nodes in the network to be behind or ahead of each other by 1-2 blocks.
3. The maximum expiration time may be decreased, which means some orders that were previously considered invalid because they expire too far in the future would now be valid.