### PR TITLE
Add a polyfill for WebAssembly.instantateStreaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This changelog is a work in progress and may contain notes for versions which have not actually been released. Check the [Releases](https://github.com/0xProject/0x-mesh/releases) page to see full release notes and more information about the latest released versions.
 
+
+## v9.3.0
+
+### Bug fixes 🐞
+
+- Fixed a compatibility issue in `@0x/mesh-browser-lite` for Safari and some other browsers [#770](https://github.com/0xProject/0x-mesh/pull/770).
+
+
 ## v9.2.1
 
 ### Bug fixes 🐞

--- a/packages/browser-lite/src/index.ts
+++ b/packages/browser-lite/src/index.ts
@@ -2,9 +2,9 @@ export * from './mesh';
 
 // If needed, add a polyfill for instantiateStreaming
 if (!WebAssembly.instantiateStreaming) {
-    WebAssembly.instantiateStreaming = async (resp, importObject) => {
+    WebAssembly.instantiateStreaming = async (resp: any, importObject: any) => {
         const source = await (await resp).arrayBuffer();
-        return await WebAssembly.instantiate(source, importObject);
+        return WebAssembly.instantiate(source, importObject);
     };
 }
 

--- a/packages/browser-lite/src/index.ts
+++ b/packages/browser-lite/src/index.ts
@@ -1,5 +1,13 @@
 export * from './mesh';
 
+// If needed, add a polyfill for instantiateStreaming
+if (!WebAssembly.instantiateStreaming) {
+    WebAssembly.instantiateStreaming = async (resp, importObject) => {
+        const source = await (await resp).arrayBuffer();
+        return await WebAssembly.instantiate(source, importObject);
+    };
+}
+
 /**
  * Loads the Wasm module that is provided by fetching a url.
  * @param url The URL to query for the Wasm binary.
@@ -14,6 +22,7 @@ export async function loadMeshStreamingWithURLAsync(url: string): Promise<void> 
  */
 export async function loadMeshStreamingAsync(response: Response | Promise<Response>): Promise<void> {
     const go = new Go();
+
     const module = await WebAssembly.instantiateStreaming(response, go.importObject);
     // NOTE(jalextowle): Wrapping the `go.run(module.instance)` statement in `setImmediate`
     // prevents the statement from blocking when `await` is used with this load function.


### PR DESCRIPTION
This PR fixes a compatibility issue with Safari (and other browsers that don't support `isntantiateStreaming`). When `instantiateStreaming` is not supported, we fallback to `instantiate`.