### PR TITLE
Fully Automate Document Generation

### DIFF
--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -13,39 +13,7 @@ import (
 	"github.com/plaid/go-envvar/envvar"
 )
 
-var functionDocsTemplate = `
-# Functions
-
-## loadMeshStreamingWithURLAsync
-▸ **loadMeshStreamingWithURLAsync**(` + "`" + `url` + "`" + `: ` + "`" + `string` + "`" + `): *Promise‹` + "`" + `void` + "`" + `›*
-
-*Defined in [index.ts:7](https://github.com/0xProject/0x-mesh/blob/%s/packages/browser-lite/src/index.ts#L7)*
-
-Loads the Wasm module that is provided by fetching a url.
-
-**Parameters:**
-
-Name | Type | Description |
------- | ------ | ------ |
-` + "`" + `url` + "`" + ` | ` + "`" + `string` + "`" + ` | The URL to query for the Wasm binary |
-
-<hr />
-
-## loadMeshStreamingAsync
-
-▸ **loadMeshStreamingAsync**(` + "`" + `response` + "`" + `: ` + "`" + `Response | Promise<Response>` + "`" + `): *Promise‹` + "`" + `void` + "`" + `›*
-
-*Defined in [index.ts:15](https://github.com/0xProject/0x-mesh/blob/%s/packages/browser-lite/src/index.ts#L15)*
-
-Loads the Wasm module that is provided by a response.
-
-**Parameters:**
-
-Name | Type | Description |
------- | ------ | ------ |
-` + "`" + `response` + "`" + ` | ` + "`" + `Response &#124; Promise<Response>` + "`" + ` | The Wasm response that supplies the Wasm binary |
-
-<hr />`
+var functionDocsTemplate = "\n# Functions\n\n## loadMeshStreamingForURLAsync\n▸ **loadMeshStreamingWithURLAsync**(`url`: `string`): *Promise‹`void`›*\n\n*Defined in [index.ts:7](https://github.com/0xProject/0x-mesh/blob/%s/packages/browser-lite/src/index.ts#L7)*\n\nLoads the Wasm module that is provided by fetching a url.\n\n**Parameters:**\n\nName | Type | Description |\n------ | ------ | ------ |\n`url` | `string` | The URL to query for the Wasm binary |\n\n<hr />\n\n## loadMeshStreamingAsync\n\n▸ **loadMeshStreamingAsync**(`response`: `Response | Promise<Response>`): *Promise‹`void`›*\n\n*Defined in [index.ts:15](https://github.com/0xProject/0x-mesh/blob/%s/packages/browser-lite/src/index.ts#L15)*\n\nLoads the Wasm module that is provided by a response.\n\n**Parameters:**\n\nName | Type | Description |\n------ | ------ | ------ |\n`response` | `Response &#124; Promise<Response>` | The Wasm response that supplies the Wasm binary |\n\n<hr />"
 
 type envVars struct {
 	// Version is the new release version to use

--- a/cmd/cut-release/main.go
+++ b/cmd/cut-release/main.go
@@ -13,7 +13,39 @@ import (
 	"github.com/plaid/go-envvar/envvar"
 )
 
-var functionDocsTemplate = "\n# Functions\n\n## loadMeshStreamingForURLAsync\n▸ **loadMeshStreamingWithURLAsync**(`url`: `string`): *Promise‹`void`›*\n\n*Defined in [index.ts:7](https://github.com/0xProject/0x-mesh/blob/%s/packages/browser-lite/src/index.ts#L7)*\n\nLoads the Wasm module that is provided by fetching a url.\n\n**Parameters:**\n\nName | Type | Description |\n------ | ------ | ------ |\n`url` | `string` | The URL to query for the Wasm binary |\n\n<hr />\n\n## loadMeshStreamingAsync\n\n▸ **loadMeshStreamingAsync**(`response`: `Response | Promise<Response>`): *Promise‹`void`›*\n\n*Defined in [index.ts:15](https://github.com/0xProject/0x-mesh/blob/%s/packages/browser-lite/src/index.ts#L15)*\n\nLoads the Wasm module that is provided by a response.\n\n**Parameters:**\n\nName | Type | Description |\n------ | ------ | ------ |\n`response` | `Response &#124; Promise<Response>` | The Wasm response that supplies the Wasm binary |\n\n<hr />"
+var functionDocsTemplate = `
+# Functions
+
+## loadMeshStreamingWithURLAsync
+▸ **loadMeshStreamingWithURLAsync**(` + "`" + `url` + "`" + `: ` + "`" + `string` + "`" + `): *Promise‹` + "`" + `void` + "`" + `›*
+
+*Defined in [index.ts:7](https://github.com/0xProject/0x-mesh/blob/%s/packages/browser-lite/src/index.ts#L7)*
+
+Loads the Wasm module that is provided by fetching a url.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+` + "`" + `url` + "`" + ` | ` + "`" + `string` + "`" + ` | The URL to query for the Wasm binary |
+
+<hr />
+
+## loadMeshStreamingAsync
+
+▸ **loadMeshStreamingAsync**(` + "`" + `response` + "`" + `: ` + "`" + `Response | Promise<Response>` + "`" + `): *Promise‹` + "`" + `void` + "`" + `›*
+
+*Defined in [index.ts:15](https://github.com/0xProject/0x-mesh/blob/%s/packages/browser-lite/src/index.ts#L15)*
+
+Loads the Wasm module that is provided by a response.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+` + "`" + `response` + "`" + ` | ` + "`" + `Response &#124; Promise<Response>` + "`" + ` | The Wasm response that supplies the Wasm binary |
+
+<hr />`
 
 type envVars struct {
 	// Version is the new release version to use

--- a/packages/browser-lite/src/types.ts
+++ b/packages/browser-lite/src/types.ts
@@ -6,6 +6,7 @@ export { SignedOrder } from '@0x/order-utils';
 export { BigNumber } from '@0x/utils';
 export { SupportedProvider } from 'ethereum-types';
 
+/** @ignore */
 export interface WrapperGetOrdersResponse {
     snapshotID: string;
     snapshotTimestamp: string;
@@ -18,6 +19,7 @@ export interface GetOrdersResponse {
     ordersInfos: OrderInfo[];
 }
 
+/** @ignore */
 export interface WrapperOrderInfo {
     orderHash: string;
     signedOrder: WrapperSignedOrder;
@@ -210,14 +212,20 @@ export enum Verbosity {
     Trace = 6,
 }
 
-// The global entrypoint for creating a new MeshWrapper.
+/**
+ * The global entrypoint for creating a new MeshWrapper.
+ * @ignore
+ */
 export interface ZeroExMesh {
     newWrapperAsync(config: WrapperConfig): Promise<MeshWrapper>;
 }
 
-// A direct translation of the MeshWrapper type in Go. Its API exposes only
-// simple JavaScript types like number and string, some of which will be
-// converted. For example, we will convert some strings to BigNumbers.
+/**
+ * A direct translation of the MeshWrapper type in Go. Its API exposes only
+ * simple JavaScript types like number and string, some of which will be
+ * converted. For example, we will convert some strings to BigNumbers.
+ * @ignore
+ */
 export interface MeshWrapper {
     startAsync(): Promise<void>;
     onError(handler: (err: Error) => void): void;
@@ -227,7 +235,10 @@ export interface MeshWrapper {
     addOrdersAsync(orders: WrapperSignedOrder[], pinned: boolean): Promise<WrapperValidationResults>;
 }
 
-// The type for configuration exposed by MeshWrapper.
+/**
+ * The type for configuration exposed by MeshWrapper.
+ * @ignore
+ */
 export interface WrapperConfig {
     verbosity?: number;
     ethereumRPCURL?: string;
@@ -245,9 +256,12 @@ export interface WrapperConfig {
     web3Provider?: ZeroExProvider; // Standardized ZeroExProvider instead the more permissive SupportedProvider interface
 }
 
-// The type for signed orders exposed by MeshWrapper. Unlike other types, the
-// analog isn't defined here. Instead we re-use the definition in
-// @0x/order-utils.
+/**
+ * The type for signed orders exposed by MeshWrapper. Unlike other types, the
+ * analog isn't defined here. Instead we re-use the definition in
+ * @0x/order-utils.
+ * @ignore
+ */
 export interface WrapperSignedOrder {
     makerAddress: string;
     makerAssetData: string;
@@ -274,6 +288,7 @@ export interface ERC20TransferEvent {
     value: BigNumber;
 }
 
+/** @ignore */
 export interface WrapperERC20TransferEvent {
     from: string;
     to: string;
@@ -286,6 +301,7 @@ export interface ERC20ApprovalEvent {
     value: BigNumber;
 }
 
+/** @ignore */
 export interface WrapperERC20ApprovalEvent {
     owner: string;
     spender: string;
@@ -298,6 +314,7 @@ export interface ERC721TransferEvent {
     tokenId: BigNumber;
 }
 
+/** @ignore */
 export interface WrapperERC721TransferEvent {
     from: string;
     to: string;
@@ -310,6 +327,7 @@ export interface ERC721ApprovalEvent {
     tokenId: BigNumber;
 }
 
+/** @ignore */
 export interface WrapperERC721ApprovalEvent {
     owner: string;
     approved: string;
@@ -330,6 +348,7 @@ export interface ERC1155TransferSingleEvent {
     value: BigNumber;
 }
 
+/** @ignore */
 export interface WrapperERC1155TransferSingleEvent {
     operator: string;
     from: string;
@@ -346,6 +365,7 @@ export interface ERC1155TransferBatchEvent {
     values: BigNumber[];
 }
 
+/** @ignore */
 export interface WrapperERC1155TransferBatchEvent {
     operator: string;
     from: string;
@@ -377,6 +397,7 @@ export interface ExchangeFillEvent {
     takerFeeAssetData: string;
 }
 
+/** @ignore */
 export interface WrapperExchangeFillEvent {
     makerAddress: string;
     takerAddress: string;
@@ -409,6 +430,7 @@ export interface ExchangeCancelUpToEvent {
     orderEpoch: BigNumber;
 }
 
+/** @ignore */
 export interface WrapperExchangeCancelUpToEvent {
     makerAddress: string;
     orderSenderAddress: string;
@@ -420,6 +442,7 @@ export interface WethWithdrawalEvent {
     value: BigNumber;
 }
 
+/** @ignore */
 export interface WrapperWethWithdrawalEvent {
     owner: string;
     value: string;
@@ -430,6 +453,7 @@ export interface WethDepositEvent {
     value: BigNumber;
 }
 
+/** @ignore */
 export interface WrapperWethDepositEvent {
     owner: string;
     value: string;
@@ -451,6 +475,7 @@ export enum ContractEventKind {
     WethWithdrawalEvent = 'WethWithdrawalEvent',
 }
 
+/** @ignore */
 export type WrapperContractEventParameters =
     | WrapperERC20TransferEvent
     | WrapperERC20ApprovalEvent
@@ -466,6 +491,7 @@ export type WrapperContractEventParameters =
     | WrapperERC1155TransferBatchEvent
     | ERC1155ApprovalForAllEvent;
 
+/** @ignore */
 export type ContractEventParameters =
     | ERC20TransferEvent
     | ERC20ApprovalEvent
@@ -492,7 +518,10 @@ export interface ContractEvent {
     parameters: ContractEventParameters;
 }
 
-// The type for order events exposed by MeshWrapper.
+/**
+ * The type for order events exposed by MeshWrapper.
+ * @ignore
+ */
 export interface WrapperContractEvent {
     blockHash: string;
     txHash: string;
@@ -517,6 +546,7 @@ export enum OrderEventEndState {
     StoppedWatching = 'STOPPED_WATCHING',
 }
 
+/** @ignore */
 export interface WrapperOrderEvent {
     timestamp: string;
     orderHash: string;
@@ -539,13 +569,13 @@ export interface OrderEvent {
     contractEvents: ContractEvent[];
 }
 
-// The type for validation results exposed by MeshWrapper.
+/** @ignore */
 export interface WrapperValidationResults {
     accepted: WrapperAcceptedOrderInfo[];
     rejected: WrapperRejectedOrderInfo[];
 }
 
-// The type for accepted orders exposed by MeshWrapper.
+/** @ignore */
 export interface WrapperAcceptedOrderInfo {
     orderHash: string;
     signedOrder: WrapperSignedOrder;
@@ -553,7 +583,7 @@ export interface WrapperAcceptedOrderInfo {
     isNew: boolean;
 }
 
-// The type for rejected orders exposed by MeshWrapper.
+/** @ignore */
 export interface WrapperRejectedOrderInfo {
     orderHash: string;
     signedOrder: WrapperSignedOrder;
@@ -613,6 +643,7 @@ export interface LatestBlock {
     hash: string;
 }
 
+/** @ignore */
 export interface WrapperStats {
     version: string;
     pubSubTopic: string;

--- a/packages/browser-lite/src/wasm_exec.ts
+++ b/packages/browser-lite/src/wasm_exec.ts
@@ -4,7 +4,14 @@
 // license that can be found in the GO_LICENSE file.
 
 /* tslint:disable */
+/**
+ * @hidden
+ */
 
+/**
+ * NOTE(jalextowle): This comment must be here so that typedoc knows that the above
+ * comment is a module comment
+ */
 (() => {
     // Map multiple JavaScript environments to a single common API,
     // preferring web standards over Node.js API.

--- a/packages/browser-lite/src/wrapper_conversion.ts
+++ b/packages/browser-lite/src/wrapper_conversion.ts
@@ -1,3 +1,11 @@
+/**
+ * @hidden
+ */
+
+/**
+ * NOTE(jalextowle): This comment must be here so that typedoc knows that the above
+ * comment is a module comment
+ */
 import { SignedOrder } from '@0x/order-utils';
 import { BigNumber, providerUtils } from '@0x/utils';
 


### PR DESCRIPTION
## Description
Currently document generation is a somewhat manual process because of the fact that we generate docs for all exported fields (even if they aren't exported at the package level) and because TypeDoc `v0.15.0` does not document functions. This PR fixes this by adding a small script to `cut-release`.

## Testing Instructions
```
git checkout docs/automate-doc-generation
VERSION=100.0.0 go run cmd/cut-release/main.go

# Don't actually run this :p
behold "the glory of automated doc generation"
```
