### PR TITLE
[WIP] ChaiBridge Integration Test

### DIFF
--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -135,7 +135,7 @@ func ganacheAddresses() ContractAddresses {
 		DevUtils:            common.HexToAddress("0xb23672f74749bf7916ba6827c64111a4d6de7f11"),
 		WETH9:               common.HexToAddress("0x0b1ba0af832d7c05fd64161e0db78e85978e8082"),
 		ZRXToken:            common.HexToAddress("0x871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c"),
-		ChaiBridge:          common.HexToAddress("0x0000000000000000000000000000000000000000"),
+		ChaiBridge:          common.HexToAddress("0x2c530e4ecc573f11bd72cf5fdf580d134d25f15f"),
 		ChaiToken:           common.HexToAddress("0x0000000000000000000000000000000000000000"),
 		MaximumGasPrice:     common.HexToAddress("0x2c530e4ecc573f11bd72cf5fdf580d134d25f15f"),
 	}

--- a/ethereum/contract_addresses.go
+++ b/ethereum/contract_addresses.go
@@ -136,7 +136,10 @@ func ganacheAddresses() ContractAddresses {
 		WETH9:               common.HexToAddress("0x0b1ba0af832d7c05fd64161e0db78e85978e8082"),
 		ZRXToken:            common.HexToAddress("0x871dd7c2b4b25e1aa18728e9d5f2af4c4e431f5c"),
 		ChaiBridge:          common.HexToAddress("0x2c530e4ecc573f11bd72cf5fdf580d134d25f15f"),
-		ChaiToken:           common.HexToAddress("0x0000000000000000000000000000000000000000"),
-		MaximumGasPrice:     common.HexToAddress("0x2c530e4ecc573f11bd72cf5fdf580d134d25f15f"),
+		// NOTE(jalextowle): This is deployed by the `TestChaiBridge` contract, but the address
+		// is deterministic because it is always the first (and only contract) deployed by the
+		// `TestChaiBridge` contract, which will always have the same address in our snapshot.
+		ChaiToken:       common.HexToAddress("0x33fcfda585cddae7992d2149b98a6f91c5b77148"),
+		MaximumGasPrice: common.HexToAddress("0x2c530e4ecc573f11bd72cf5fdf580d134d25f15f"),
 	}
 }

--- a/integration-tests/constants.go
+++ b/integration-tests/constants.go
@@ -32,6 +32,8 @@ var (
 	makerAddress                = constants.GanacheAccount1
 	takerAddress                = constants.GanacheAccount2
 	eighteenDecimalsInBaseUnits = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
-	wethAmount                  = new(big.Int).Mul(big.NewInt(50), eighteenDecimalsInBaseUnits)
-	zrxAmount                   = new(big.Int).Mul(big.NewInt(100), eighteenDecimalsInBaseUnits)
+	wethAmount                  = new(big.Int).Mul(big.NewInt(5), eighteenDecimalsInBaseUnits)
+	zrxAmount                   = new(big.Int).Mul(big.NewInt(10), eighteenDecimalsInBaseUnits)
+	// FIXME(jalextowle): Why is this so much lower than the amount that I minted?
+	chaiAmount, _ = new(big.Int).SetString("5000000000000000000", 0)
 )

--- a/zeroex/ordervalidator/order_validator.go
+++ b/zeroex/ordervalidator/order_validator.go
@@ -391,6 +391,7 @@ func (o *OrderValidator) BatchValidate(ctx context.Context, rawSignedOrders []*z
 				for j, orderInfo := range results.OrdersInfo {
 					isValidSignature := results.IsValidSignature[j]
 					fillableTakerAssetAmount := results.FillableTakerAssetAmounts[j]
+					log.WithField("fillableTakerAssetAmount", fillableTakerAssetAmount).Info("FillableTakerAsset amount from order validation")
 					orderHash := common.Hash(orderInfo.OrderHash)
 					signedOrder := signedOrders[j]
 					orderStatus := zeroex.OrderStatus(orderInfo.OrderStatus)
@@ -673,6 +674,7 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*zeroex.SignedOr
 
 		isMakerAssetDataSupported := o.isSupportedAssetData(signedOrder.MakerAssetData)
 		if !isMakerAssetDataSupported {
+			log.Info("Unsupported")
 			rejectedOrderInfos = append(rejectedOrderInfos, &RejectedOrderInfo{
 				OrderHash:   orderHash,
 				SignedOrder: signedOrder,
@@ -735,30 +737,36 @@ func (o *OrderValidator) BatchOffchainValidation(signedOrders []*zeroex.SignedOr
 }
 
 func (o *OrderValidator) isSupportedAssetData(assetData []byte) bool {
+	log.Info("Got here")
 	assetDataName, err := o.assetDataDecoder.GetName(assetData)
 	if err != nil {
+		log.Info(1)
 		return false
 	}
 	switch assetDataName {
 	case "ERC20Token":
+		log.Info("Got here: ERC20")
 		var decodedAssetData zeroex.ERC20AssetData
 		err := o.assetDataDecoder.Decode(assetData, &decodedAssetData)
 		if err != nil {
 			return false
 		}
 	case "ERC721Token":
+		log.Info("Got here: ERC721")
 		var decodedAssetData zeroex.ERC721AssetData
 		err := o.assetDataDecoder.Decode(assetData, &decodedAssetData)
 		if err != nil {
 			return false
 		}
 	case "ERC1155Assets":
+		log.Info("Got here: ERC1155")
 		var decodedAssetData zeroex.ERC1155AssetData
 		err := o.assetDataDecoder.Decode(assetData, &decodedAssetData)
 		if err != nil {
 			return false
 		}
 	case "StaticCall":
+		log.Info("Got here: StaticCall")
 		var decodedAssetData zeroex.StaticCallAssetData
 		err := o.assetDataDecoder.Decode(assetData, &decodedAssetData)
 		if err != nil {
@@ -766,26 +774,33 @@ func (o *OrderValidator) isSupportedAssetData(assetData []byte) bool {
 		}
 		return o.isSupportedStaticCallData(decodedAssetData)
 	case "MultiAsset":
+		log.Info("Got here: MultiAsset")
 		var decodedAssetData zeroex.MultiAssetData
 		err := o.assetDataDecoder.Decode(assetData, &decodedAssetData)
 		if err != nil {
 			return false
 		}
 	case "ERC20Bridge":
+		log.Info("Got here: ERC20Bridge")
 		var decodedAssetData zeroex.ERC20BridgeAssetData
 		err := o.assetDataDecoder.Decode(assetData, &decodedAssetData)
 		if err != nil {
+			log.Info(2)
 			return false
 		}
 		// We currently restrict ERC20Bridge orders to those referencing the
 		// Chai bridge. If the ChaiBridge is not deployed on the selected network
 		// we also reject the ERC20Bridge asset.
 		if o.contractAddresses.ChaiBridge == constants.NullAddress || decodedAssetData.BridgeAddress != o.contractAddresses.ChaiBridge {
+			log.Info(3)
 			return false
 		}
 	default:
+		log.Info("Got here: Default")
+		log.Info(4)
 		return false
 	}
+	log.Info(5)
 	return true
 }
 


### PR DESCRIPTION
## Description
This PR adds an integration test for using `AddOrders` with an order with `ChaiBridge` asset data. I suspect that this does not currently work; however, the test will determine this. 

In the process of writing this test, it was necessary to create a new ganache snapshot. The branch that contains those changes can be found here: https://github.com/0xProject/0x-monorepo/tree/mesh/chai-bridge-snapshot. 