### PR TITLE
[expirationwatch] Fixes consistency bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ This changelog is a work in progress and may contain notes for versions which ha
 
 ### Features ✅
 
-- Mesh now ensures on startup that the chain ID of your Ethereum RPC endpoint matches config.EthereumChainID [#733](https://github.com/0xProject/0x-mesh/pull/733). 
+- Mesh now ensures on startup that the chain ID of your Ethereum RPC endpoint matches config.EthereumChainID [#733](https://github.com/0xProject/0x-mesh/pull/733).
 
 ### Bug fixes 🐞
 
 - Fixed a compatibility issue in `@0x/mesh-browser-lite` for Safari and some other browsers [#770](https://github.com/0xProject/0x-mesh/pull/770).
+- Fixes an issue that would allow expired orders to be returned in `GetOrders` [TBD](http://github.com/0xProject/0x-mesh/pull/tbd)
 
 
 ## v9.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 ### Bug fixes 🐞
 
 - Fixed a compatibility issue in `@0x/mesh-browser-lite` for Safari and some other browsers [#770](https://github.com/0xProject/0x-mesh/pull/770).
-- Fixes an issue that would allow expired orders to be returned in `GetOrders` [TBD](http://github.com/0xProject/0x-mesh/pull/tbd)
+- Fixes an issue that would allow expired orders to be returned in `GetOrders` [773](http://github.com/0xProject/0x-mesh/pull/773)
 
 
 ## v9.2.1

--- a/expirationwatch/expiration_watcher.go
+++ b/expirationwatch/expiration_watcher.go
@@ -72,7 +72,7 @@ func (w *Watcher) Remove(expirationTimestamp time.Time, id string) {
 	}
 }
 
-// Prune checks for any expired items given a timestamp and removes any expired 
+// Prune checks for any expired items given a timestamp and removes any expired
 // items from the expiration watcher and returns them to the caller
 func (w *Watcher) Prune(timestamp time.Time) []ExpiredItem {
 	pruned := []ExpiredItem{}
@@ -85,7 +85,7 @@ func (w *Watcher) Prune(timestamp time.Time) []ExpiredItem {
 		}
 		expirationTimeSeconds := int64(*key.(*rbt.Int64Key))
 		expirationTime := time.Unix(expirationTimeSeconds, 0)
-		if !timestamp.After(expirationTime) {
+		if timestamp.Before(expirationTime) {
 			break
 		}
 		ids := value.(stringset.Set)

--- a/expirationwatch/expiration_watcher_test.go
+++ b/expirationwatch/expiration_watcher_test.go
@@ -57,6 +57,21 @@ func TestPrunesTwoExpiredItemsWithSameExpiration(t *testing.T) {
 	}
 }
 
+func TestPrunesBarelyExpiredItem(t *testing.T) {
+	watcher := New()
+
+	current := time.Now().Truncate(time.Second)
+	expiryEntryOne := ExpiredItem{
+		ExpirationTimestamp: current,
+		ID:                  "0x8e209dda7e515025d0c34aa61a0d1156a631248a4318576a2ce0fb408d97385e",
+	}
+	watcher.Add(expiryEntryOne.ExpirationTimestamp, expiryEntryOne.ID)
+
+	pruned := watcher.Prune(current)
+	assert.Len(t, pruned, 1, "one expired item should get pruned")
+	assert.Equal(t, expiryEntryOne, pruned[0])
+}
+
 func TestKeepsUnexpiredItem(t *testing.T) {
 	watcher := New()
 


### PR DESCRIPTION
## Description
An order becomes expired when `order.expirationTimeSeconds <= block.timestamp` ([source](https://github.com/0xProject/0x-monorepo/blob/development/contracts/exchange/contracts/src/MixinExchangeCore.sol#L171)). Previously, Mesh pruned orders once `timestamp.After(expirationTime) == true`, which would allow `GetOrders` to return invalid orders when `timestamp == expirationTime`.

Big thanks to @dekz for reporting the bug!