### PR TITLE
[zeroex/orderwatch] Fixed race-condition in test

### DIFF
--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -959,6 +959,12 @@ func TestOrderWatcherBatchEmitsAddedEvents(t *testing.T) {
 	signedOrders := []*zeroex.SignedOrder{}
 	for i := 0; i < 2; i++ {
 		signedOrder := scenario.CreateZRXForWETHSignedTestOrder(t, ethClient, makerAddress, takerAddress, big.NewInt(1000), big.NewInt(1000))
+		// Creating a valid order involves transferring sufficient funds to the maker, and setting their allowance for
+		// the maker asset. These transactions must be mined and Mesh's BlockWatcher poller must process these blocks
+		// in order for the order validation run at order submission to occur at a block number equal or higher then
+		// the one where these state changes were included. With the BlockWatcher poller configured to run every 200ms,
+		// we wait 500ms here to give it ample time to run before submitting the above order to the Mesh node.
+		time.Sleep(500 * time.Millisecond)
 		signedOrders = append(signedOrders, signedOrder)
 	}
 


### PR DESCRIPTION
## Description
Fixes a race condition in one of the `orderwatcher` tests between funding an order and validating it. The fix was taken from `integration-tests`. It does not appear that any other test cases in `zeroex/orderwatcher/order_watcher_test.go` are affected by this race condition because they all include at least one contract call prior to calling `syncToLatestBlock`.
