### PR TITLE
expirationwatch: prune orders expiring at exactly block timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This changelog is a work in progress and may contain notes for versions which ha
 ### Bug fixes 🐞
 
 - Fixed a compatibility issue in `@0x/mesh-browser-lite` for Safari and some other browsers [#770](https://github.com/0xProject/0x-mesh/pull/770).
-
+- Fix bug causing orders expiring at _exactly_ the next block timestamp from not being pruned until the next block is mined [#777](https://github.com/0xProject/0x-mesh/pull/777).
 
 ## v9.2.1
 

--- a/expirationwatch/expiration_watcher.go
+++ b/expirationwatch/expiration_watcher.go
@@ -72,7 +72,7 @@ func (w *Watcher) Remove(expirationTimestamp time.Time, id string) {
 	}
 }
 
-// Prune checks for any expired items given a timestamp and removes any expired 
+// Prune checks for any expired items given a timestamp and removes any expired
 // items from the expiration watcher and returns them to the caller
 func (w *Watcher) Prune(timestamp time.Time) []ExpiredItem {
 	pruned := []ExpiredItem{}
@@ -85,7 +85,7 @@ func (w *Watcher) Prune(timestamp time.Time) []ExpiredItem {
 		}
 		expirationTimeSeconds := int64(*key.(*rbt.Int64Key))
 		expirationTime := time.Unix(expirationTimeSeconds, 0)
-		if !timestamp.After(expirationTime) {
+		if timestamp != expirationTime && !timestamp.After(expirationTime) {
 			break
 		}
 		ids := value.(stringset.Set)

--- a/expirationwatch/expiration_watcher_test.go
+++ b/expirationwatch/expiration_watcher_test.go
@@ -29,6 +29,27 @@ func TestPrunesExpiredItems(t *testing.T) {
 	assert.Equal(t, expiryEntryTwo, pruned[1])
 }
 
+func TestPrunesItemsExpiringAtCurrentTime(t *testing.T) {
+	watcher := New()
+
+	current := time.Now().Truncate(time.Second)
+	expiryEntryOne := ExpiredItem{
+		ExpirationTimestamp: current,
+		ID:                  "0x8e209dda7e515025d0c34aa61a0d1156a631248a4318576a2ce0fb408d97385e",
+	}
+	watcher.Add(expiryEntryOne.ExpirationTimestamp, expiryEntryOne.ID)
+
+	expiryEntryTwo := ExpiredItem{
+		ExpirationTimestamp: current.Add(5 * time.Second),
+		ID:                  "0x12ab7edd34515025d0c34aa61a0d1156a631248a4318576a2ce0fb408d3bee521",
+	}
+	watcher.Add(expiryEntryTwo.ExpirationTimestamp, expiryEntryTwo.ID)
+
+	pruned := watcher.Prune(current)
+	assert.Len(t, pruned, 1, "one expired item should get pruned")
+	assert.Equal(t, expiryEntryOne, pruned[0])
+}
+
 func TestPrunesTwoExpiredItemsWithSameExpiration(t *testing.T) {
 	watcher := New()
 


### PR DESCRIPTION
Fix bug causing orders expiring at _exactly_ the next block timestamp from not being pruned until the next block is mined.