### PR TITLE
Revalidate affected orders regardless of ERC721 approval operator

### DIFF
--- a/scenario/scenario.go
+++ b/scenario/scenario.go
@@ -324,9 +324,7 @@ func setDummyERC721BalanceAndAllowance(t *testing.T, traderAddress common.Addres
 	waitTxnSuccessfullyMined(t, txn)
 
 	// Set allowance
-	// HACK(albrow): Our tests rely on unapproving/unsetting the allowance. You can't do
-	// that for individual tokens, so we use SetApprovalForAll here.
-	txn, err = dummyERC721Token.SetApprovalForAll(opts, ganacheAddresses.ERC721Proxy, true)
+	txn, err = dummyERC721Token.Approve(opts, ganacheAddresses.ERC721Proxy, tokenID)
 	require.NoError(t, err)
 	waitTxnSuccessfullyMined(t, txn)
 }

--- a/zeroex/orderwatch/order_watcher.go
+++ b/zeroex/orderwatch/order_watcher.go
@@ -582,10 +582,6 @@ func (w *Watcher) handleBlockEvents(
 					}
 					return err
 				}
-				// Ignores approvals set to anyone except the AssetProxy
-				if approvalEvent.Approved != w.contractAddresses.ERC721Proxy {
-					continue
-				}
 				contractEvent.Parameters = approvalEvent
 				orders, err = w.findOrdersByTokenAddressAndTokenID(approvalEvent.Owner, log.Address, approvalEvent.TokenId)
 				if err != nil {


### PR DESCRIPTION
This PR changes order watcher so that we revalidate any affected orders for ERC721 approval events regardless of the operator address. Previously, we only considered events where the operator was the ERC721Proxy.

Because of the way the ERC721 spec works, when using `Approve`, you can only have one operator for each token ID (this is independent from "account operators" which can be set via `SetApprovalForAll`). If a user sets the operator to a different address, that could mean that the ERC721Proxy no longer has approval, in which case we need to revalidate any affected orders.

This PR also updates the `scenario` package to approve individual ERC721 tokens when possible.