### PR TITLE
scenario: Add ability to create multiple orders in a single batch

### DIFF
--- a/integration-tests/rpc_integration_test.go
+++ b/integration-tests/rpc_integration_test.go
@@ -127,12 +127,9 @@ func runGetOrdersTest(t *testing.T, rpcEndpointPrefix, rpcServerType string, rpc
 	require.NoError(t, err)
 
 	// Create 10 new valid orders.
-	// TODO(albrow): Update this when scenario supports creating orders in a batch.
 	numOrders := 10
-	signedTestOrders := make([]*zeroex.SignedOrder, numOrders)
-	for i := 0; i < numOrders; i++ {
-		signedTestOrders[i] = scenario.NewSignedTestOrder(t, orderopts.SetupMakerState(true))
-	}
+	orderOptions := scenario.OptionsForAll(orderopts.SetupMakerState(true))
+	signedTestOrders := scenario.NewSignedTestOrdersBatch(t, numOrders, orderOptions)
 	// Creating a valid order involves transferring sufficient funds to the maker, and setting their allowance for
 	// the maker asset. These transactions must be mined and Mesh's BlockWatcher poller must process these blocks
 	// in order for the order validation run at order submission to occur at a block number equal or higher then

--- a/scenario/scenario.go
+++ b/scenario/scenario.go
@@ -118,7 +118,7 @@ func NewSignedTestOrdersBatch(t *testing.T, numOrders int, optionsForIndex func(
 			}
 		}
 
-		// Crate the order based on the cfg.
+		// Create the order based on the cfg.
 		order := newTestOrder(cfg)
 		signedOrder, err := zeroex.SignTestOrder(order)
 		require.NoError(t, err, "could not sign order")
@@ -145,7 +145,7 @@ func NewSignedTestOrdersBatch(t *testing.T, numOrders int, optionsForIndex func(
 		}
 	}
 
-	// Setup all the rquired balances.
+	// Setup all the required balances.
 	for traderAddress, requiredBalances := range allRequiredBalances {
 		setupBalanceAndAllowance(t, traderAddress, requiredBalances)
 	}


### PR DESCRIPTION
This PR is a follow-up on #779 and adds support for creating more than one order in a single batch via the `NewSignedTestOrdersBatch` function. This is a huge performance optimization because we only set the required balances and allowances once instead of doing it (and waiting for the corresponding transaction to be mined) for each order one at a time. This is not just optimization for the sake of optimization; it will enable important new test cases by making it practical to create hundreds of orders at a time (see https://github.com/0xProject/0x-mesh/pull/760 for an example of how this limitation has blocked us in the past).
