### PR TITLE
p2p: Don't call HandleMessages if there are no messages to handle

### DIFF
--- a/p2p/node.go
+++ b/p2p/node.go
@@ -569,6 +569,9 @@ func (n *Node) receiveAndHandleMessages(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if len(incoming) == 0 {
+		return nil
+	}
 	if err := n.messageHandler.HandleMessages(ctx, incoming); err != nil {
 		return fmt.Errorf("could not validate or store messages: %s", err.Error())
 	}


### PR DESCRIPTION
This is a quick and easy optimization to prevent us from spending time processing an empty batch of orders. Prior to this PR, we would perform a small amount of computational work (including logging and acquiring some locks) even if there were no orders to validate.