### PR TITLE
Move browser-conversion-tests out of make test-go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,20 +41,8 @@ jobs:
           name: Build the TypeScript monorepo
           command: yarn build
       - run:
-          name: Run TypeScript tests
-          command: yarn test
-      - run:
-          name: Run Go tests
-          command: make test-go
-      - run:
-          name: Run WebAssembly tests in Node.js
-          command: make test-wasm-node
-      - run:
-          name: Run WebAssembly tests in a headless browser
-          command: make test-wasm-browser
-      - run:
-          name: Run browser integration tests
-          command: make test-browser-integration
+          name: Run all tests
+          command: make test-all 
       - run:
           name: Test installing Mesh without CGO
           command: CGO_ENABLED=0 go install ./...

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ deps-ts-no-lockfile:
 
 
 .PHONY: test-all
-test-all: test-go test-wasm-node test-wasm-browser test-ts
+test-all: test-go test-wasm-node test-wasm-browser test-ts test-browser-conversion test-browser-integration
 
 
 .PHONY: test-go
-test-go: test-go-parallel test-go-serial test-browser-conversion
+test-go: test-go-parallel test-go-serial
 
 
 .PHONY: test-go-parallel


### PR DESCRIPTION
I think this organization is a little more intuitive. `make test-go` should only run pure Go tests, not anything having to do with Wasm or JavaScript.
