### PR TITLE
Post v9.4.0 Cleanup

### DIFF
--- a/packages/browser-lite/package.json
+++ b/packages/browser-lite/package.json
@@ -15,7 +15,6 @@
         "docsPath": "../../docs/browser-bindings/browser-lite"
     },
     "dependencies": {
-        "@0x/contract-addresses": "^4.9.0",
         "@0x/order-utils": "^10.2.0",
         "@0x/utils": "^5.4.0",
         "ajv": "^6.12.2",

--- a/packages/browser-lite/src/schema_validator.ts
+++ b/packages/browser-lite/src/schema_validator.ts
@@ -1,3 +1,11 @@
+/**
+ * @hidden
+ */
+
+/**
+ * NOTE(jalextowle): This comment must be here so that typedoc knows that the above
+ * comment is a module comment
+ */
 import * as ajv from 'ajv';
 
 interface SynchronousValidationFunction {
@@ -44,7 +52,6 @@ export function createSchemaValidator(
     }
 
     const orderValidate = AJV.getSchema('/rootOrder');
-    // tslint:disable-next-line:no-non-null-assertion
     if (orderValidate === undefined) {
         throw new Error('Cannot find "/rootOrder" schema in AJV');
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,7 +166,6 @@
 "@0x/mesh-browser-lite@file:packages/browser-lite":
   version "1.0.0"
   dependencies:
-    "@0x/contract-addresses" "^4.9.0"
     "@0x/order-utils" "^10.2.0"
     "@0x/utils" "^5.4.0"
     ajv "^6.12.2"
@@ -177,7 +176,7 @@
 "@0x/mesh-browser@file:packages/browser":
   version "1.0.0"
   dependencies:
-    "@0x/mesh-browser-lite" "file:../Library/Caches/Yarn/v6/npm-@0x-mesh-browser-1.0.0-73cc8d3a-b4a7-4f11-8cf8-894df8ce8128-1590603454455/node_modules/@0x/browser-lite"
+    "@0x/mesh-browser-lite" "file:../Library/Caches/Yarn/v6/npm-@0x-mesh-browser-1.0.0-6d494689-b59f-40df-bfab-789e9a30ac08-1591289540232/node_modules/@0x/browser-lite"
     base64-arraybuffer "^0.2.0"
     browserfs "^1.4.3"
     ethereum-types "^3.0.0"


### PR DESCRIPTION
## Changes
- Hides the `schema_validator` module so that our documentation does not include these un-exported (from `index.ts`) types and functions.
- Removes the `@0x/contract-addresses` dependency from `@0x/mesh-browser-lite`.