### PR TITLE
Add workaround for Dexie transaction-related errors

### DIFF
--- a/packages/browser-lite/src/database.ts
+++ b/packages/browser-lite/src/database.ts
@@ -170,7 +170,7 @@ export class Database {
     public async addOrdersAsync(orders: Order[]): Promise<AddOrdersResult> {
         // TODO(albrow): Remove orders with max expiration time.
         const added: Order[] = [];
-        await this._db.transaction('rw', this._orders, async () => {
+        await this._db.transaction('rw!', this._orders, async () => {
             for (const order of orders) {
                 try {
                     await this._orders.add(order);
@@ -193,46 +193,48 @@ export class Database {
 
     // GetOrder(hash common.Hash) (*types.OrderWithMetadata, error)
     public async getOrderAsync(hash: string): Promise<Order> {
-        const order = await this._orders.get(hash);
-        if (order === undefined) {
-            throw newNotFoundError();
-        }
-        return order;
+        return this._db.transaction('rw!', this._orders, async () => {
+            const order = await this._orders.get(hash);
+            if (order === undefined) {
+                throw newNotFoundError();
+            }
+            return order;
+        });
     }
 
     // FindOrders(opts *OrderQuery) ([]*types.OrderWithMetadata, error)
     public async findOrdersAsync(query?: OrderQuery): Promise<Order[]> {
-        if (!canUseNativeDexieIndexes(this._orders, query)) {
-            // As a fallback, implement the query inefficiently (in-memory).
-            // Note(albrow): If needed we can optimize specific common queries with compound indexes.
-            return runQueryInMemoryAsync(this._orders, query);
-        }
-        const col = buildCollectionWithDexieIndexes(this._orders, query);
-        return col.toArray();
+        return this._db.transaction('rw!', this._orders, async () => {
+            return findRecordsAsync(this._orders, query);
+        });
     }
 
     // CountOrders(opts *OrderQuery) (int, error)
     public async countOrdersAsync(query?: OrderQuery): Promise<number> {
-        if (!canUseNativeDexieIndexes(this._orders, query)) {
-            // As a fallback, implement the query inefficiently (in-memory).
-            // Note(albrow): If needed we can optimize specific common queries with compound indexes.
-            const records = await runQueryInMemoryAsync(this._orders, query);
-            return records.length;
-        }
-        const col = buildCollectionWithDexieIndexes(this._orders, query);
-        return col.count();
+        return this._db.transaction('rw!', this._orders, async () => {
+            if (!canUseNativeDexieIndexes(this._orders, query)) {
+                // As a fallback, implement the query inefficiently (in-memory).
+                // Note(albrow): If needed we can optimize specific common queries with compound indexes.
+                const records = await runQueryInMemoryAsync(this._orders, query);
+                return records.length;
+            }
+            const col = buildCollectionWithDexieIndexes(this._orders, query);
+            return col.count();
+        });
     }
 
     // DeleteOrder(hash common.Hash) error
     public async deleteOrderAsync(hash: string): Promise<void> {
-        return this._orders.delete(hash);
+        return this._db.transaction('rw!', this._orders, async () => {
+            return this._orders.delete(hash);
+        });
     }
 
     // DeleteOrders(opts *OrderQuery) ([]*types.OrderWithMetadata, error)
     public async deleteOrdersAsync(query: OrderQuery | undefined): Promise<Order[]> {
         const deletedOrders: Order[] = [];
-        await this._db.transaction('rw', this._orders, async () => {
-            const orders = await this.findOrdersAsync(query);
+        await this._db.transaction('rw!', this._orders, async () => {
+            const orders = await findRecordsAsync(this._orders, query);
             for (const order of orders) {
                 await this._orders.delete(order.hash);
                 deletedOrders.push(order);
@@ -243,8 +245,11 @@ export class Database {
 
     // UpdateOrder(hash common.Hash, updateFunc func(existingOrder *types.OrderWithMetadata) (updatedOrder *types.OrderWithMetadata, err error)) error
     public async updateOrderAsync(hash: string, updateFunc: (existingOrder: Order) => Order): Promise<void> {
-        await this._db.transaction('rw', this._orders, async () => {
-            const existingOrder = await this.getOrderAsync(hash);
+        await this._db.transaction('rw!', this._orders, async () => {
+            const existingOrder = await this._orders.get(hash);
+            if (existingOrder === undefined) {
+                throw newNotFoundError();
+            }
             const updatedOrder = updateFunc(existingOrder);
             await this._orders.put(updatedOrder, hash);
         });
@@ -254,7 +259,7 @@ export class Database {
     public async addMiniHeadersAsync(miniHeaders: MiniHeader[]): Promise<AddMiniHeadersResult> {
         const added: MiniHeader[] = [];
         const removed: MiniHeader[] = [];
-        await this._db.transaction('rw', this._miniHeaders, async () => {
+        await this._db.transaction('rw!', this._miniHeaders, async () => {
             for (const miniHeader of miniHeaders) {
                 try {
                     await this._miniHeaders.add(miniHeader);
@@ -286,34 +291,34 @@ export class Database {
 
     // GetMiniHeader(hash common.Hash) (*types.MiniHeader, error)
     public async getMiniHeaderAsync(hash: string): Promise<MiniHeader> {
-        const miniHeader = await this._miniHeaders.get(hash);
-        if (miniHeader === undefined) {
-            throw newNotFoundError();
-        }
-        return miniHeader;
+        return this._db.transaction('rw!', this._miniHeaders, async () => {
+            const miniHeader = await this._miniHeaders.get(hash);
+            if (miniHeader === undefined) {
+                throw newNotFoundError();
+            }
+            return miniHeader;
+        });
     }
 
     // FindMiniHeaders(opts *MiniHeaderQuery) ([]*types.MiniHeader, error)
     public async findMiniHeadersAsync(query: MiniHeaderQuery): Promise<MiniHeader[]> {
-        if (!canUseNativeDexieIndexes(this._miniHeaders, query)) {
-            // As a fallback, implement the query inefficiently (in-memory).
-            // Note(albrow): If needed we can optimize specific common queries with compound indexes.
-            return runQueryInMemoryAsync(this._miniHeaders, query);
-        }
-        const col = buildCollectionWithDexieIndexes(this._miniHeaders, query);
-        return col.toArray();
+        return this._db.transaction('rw!', this._miniHeaders, async () => {
+            return findRecordsAsync(this._miniHeaders, query);
+        });
     }
 
     // DeleteMiniHeader(hash common.Hash) error
     public async deleteMiniHeaderAsync(hash: string): Promise<void> {
-        return this._miniHeaders.delete(hash);
+        return this._db.transaction('rw!', this._miniHeaders, async () => {
+            return this._miniHeaders.delete(hash);
+        });
     }
 
     // DeleteMiniHeaders(opts *MiniHeaderQuery) ([]*types.MiniHeader, error)
     public async deleteMiniHeadersAsync(query: MiniHeaderQuery): Promise<MiniHeader[]> {
         const deletedMiniHeaders: MiniHeader[] = [];
-        await this._db.transaction('rw', this._miniHeaders, async () => {
-            const miniHeaders = await this.findMiniHeadersAsync(query);
+        await this._db.transaction('rw!', this._miniHeaders, async () => {
+            const miniHeaders = await findRecordsAsync(this._miniHeaders, query);
             for (const miniHeader of miniHeaders) {
                 await this._miniHeaders.delete(miniHeader.hash);
                 deletedMiniHeaders.push(miniHeader);
@@ -324,6 +329,31 @@ export class Database {
 
     // GetMetadata() (*types.Metadata, error)
     public async getMetadataAsync(): Promise<Metadata> {
+        return this._db.transaction('rw!', this._metadata, async () => {
+            return this._getMetadataAsync();
+        });
+    }
+
+    // SaveMetadata(metadata *types.Metadata) error
+    public async saveMetadataAsync(metadata: Metadata): Promise<void> {
+        await this._db.transaction('rw!', this._metadata, async () => {
+            if ((await this._metadata.count()) > 0) {
+                throw newMetadataAlreadExistsError();
+            }
+            await this._metadata.add(metadata);
+        });
+    }
+
+    // UpdateMetadata(updateFunc func(oldmetadata *types.Metadata) (newMetadata *types.Metadata)) error
+    public async updateMetadataAsync(updateFunc: (existingMetadata: Metadata) => Metadata): Promise<void> {
+        await this._db.transaction('rw!', this._metadata, async () => {
+            const existingMetadata = await this._getMetadataAsync();
+            const updatedMetadata = updateFunc(existingMetadata);
+            await this._metadata.put(updatedMetadata);
+        });
+    }
+
+    private async _getMetadataAsync(): Promise<Metadata> {
         const count = await this._metadata.count();
         if (count === 0) {
             throw newNotFoundError();
@@ -337,25 +367,16 @@ export class Database {
         const metadatas = await this._metadata.toArray();
         return metadatas[0];
     }
+}
 
-    // SaveMetadata(metadata *types.Metadata) error
-    public async saveMetadataAsync(metadata: Metadata): Promise<void> {
-        await this._db.transaction('rw', this._metadata, async () => {
-            if ((await this._metadata.count()) > 0) {
-                throw newMetadataAlreadExistsError();
-            }
-            await this._metadata.add(metadata);
-        });
+async function findRecordsAsync<T extends Record, Key>(table: Dexie.Table<T, Key>, query?: Query<T>): Promise<T[]> {
+    if (!canUseNativeDexieIndexes(table, query)) {
+        // As a fallback, implement the query inefficiently (in-memory).
+        // Note(albrow): If needed we can optimize specific common queries with compound indexes.
+        return runQueryInMemoryAsync(table, query);
     }
-
-    // UpdateMetadata(updateFunc func(oldmetadata *types.Metadata) (newMetadata *types.Metadata)) error
-    public async updateMetadataAsync(updateFunc: (existingMetadata: Metadata) => Metadata): Promise<void> {
-        await this._db.transaction('rw', this._metadata, async () => {
-            const existingMetadata = await this.getMetadataAsync();
-            const updatedMetadata = updateFunc(existingMetadata);
-            await this._metadata.put(updatedMetadata);
-        });
-    }
+    const col = buildCollectionWithDexieIndexes(table, query);
+    return col.toArray();
 }
 
 function buildCollectionWithDexieIndexes<T extends Record, Key>(


### PR DESCRIPTION
This PR fixes an occasional bug that has to do with Dexie/IndexedDB and transactions. Dexie tries to re-use underlying IndexedDB transactions when possible under the hood, and [according to the documentation this feature is supposed to work with TypeScript and transpilation](https://dexie.org/docs/Dexie/Dexie.transaction()). Whether it is something with our exact TypeScript/Webpack setup, how Go runs JavaScript functions as part of its WebAssembly runtime, or simply a bug in Dexie, the re-use of transactions seems to sometimes get out of whack. The issue usually surfaces as an error that looks like this:

```
Failed to execute 'objectStore' on 'IDBTransaction': The specified object store was not found.
```

However it sometimes also manifests as other error messages, which always have something to do with an underlying `IDBTransaction`.

This PR works around the problem by taking more control over how transactions are created and shared between functions. We now always create a new transaction via the `'rw!'` option (the exclamation mark means "always create a new transaction") for every database method inside of __database.ts__. We don't rely on Dexie to share the transactions for us.