### PR TITLE
Break up `MatchOrder` and `ValidateOrder` to prevent UI stutter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ lint: lint-go lint-ts lint-prettier
 
 .PHONY: lint-go
 lint-go:
-	golangci-lint run
+	golangci-lint run --timeout 2m
 
 
 .PHONY: lint-ts

--- a/core/ordersync_subprotocols_js.go
+++ b/core/ordersync_subprotocols_js.go
@@ -1,0 +1,55 @@
+// +build js, wasm
+
+package core
+
+import (
+	"context"
+	"time"
+
+	"github.com/0xProject/0x-mesh/common/types"
+	"github.com/0xProject/0x-mesh/orderfilter"
+	"github.com/0xProject/0x-mesh/packages/browser/go/jsutil"
+	"github.com/0xProject/0x-mesh/zeroex"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+const batchSize = 100
+
+func filterOrdersForRequest(f *orderfilter.Filter, orderInfos []*types.OrderInfo, filteredOrders []*zeroex.SignedOrder) ([]*zeroex.SignedOrder, error) {
+	nextTick()
+	for i, orderInfo := range orderInfos {
+		if i%batchSize == batchSize-1 {
+			nextTick()
+		}
+		if matches, err := f.MatchOrder(orderInfo.SignedOrder); err != nil {
+			return nil, err
+		} else if matches {
+			filteredOrders = append(filteredOrders, orderInfo.SignedOrder)
+		}
+	}
+	return filteredOrders, nil
+}
+
+func filterOrdersForResponse(a *App, f *orderfilter.Filter, providerID peer.ID, orders []*zeroex.SignedOrder) ([]*zeroex.SignedOrder, error) {
+	nextTick()
+	var filteredOrders []*zeroex.SignedOrder
+	for i, order := range orders {
+		if i%batchSize == batchSize-1 {
+			nextTick()
+		}
+		if matches, err := f.MatchOrder(order); err != nil {
+			return nil, err
+		} else if matches {
+			filteredOrders = append(filteredOrders, order)
+		} else if !matches {
+			a.handlePeerScoreEvent(providerID, psReceivedOrderDoesNotMatchFilter)
+		}
+	}
+	return filteredOrders, nil
+}
+
+func nextTick() {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	jsutil.NextTick(ctx)
+	cancel()
+}

--- a/core/ordersync_subprotocols_native.go
+++ b/core/ordersync_subprotocols_native.go
@@ -1,0 +1,35 @@
+// +build !js
+
+package core
+
+import (
+	"github.com/0xProject/0x-mesh/common/types"
+	"github.com/0xProject/0x-mesh/orderfilter"
+	"github.com/0xProject/0x-mesh/zeroex"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+func filterOrdersForRequest(f *orderfilter.Filter, orderInfos []*types.OrderInfo, filteredOrders []*zeroex.SignedOrder) ([]*zeroex.SignedOrder, error) {
+	for _, orderInfo := range orderInfos {
+		if matches, err := f.MatchOrder(orderInfo.SignedOrder); err != nil {
+			return nil, err
+		} else if matches {
+			filteredOrders = append(filteredOrders, orderInfo.SignedOrder)
+		}
+	}
+	return filteredOrders, nil
+}
+
+func filterOrdersForResponse(a *App, f *orderfilter.Filter, providerID peer.ID, orders []*zeroex.SignedOrder) ([]*zeroex.SignedOrder, error) {
+	var filteredOrders []*zeroex.SignedOrder
+	for _, order := range orders {
+		if matches, err := f.MatchOrder(order); err != nil {
+			return nil, err
+		} else if matches {
+			filteredOrders = append(filteredOrders, order)
+		} else if !matches {
+			a.handlePeerScoreEvent(providerID, psReceivedOrderDoesNotMatchFilter)
+		}
+	}
+	return filteredOrders, nil
+}

--- a/orderfilter/validate_js.go
+++ b/orderfilter/validate_js.go
@@ -33,10 +33,9 @@ func (s *SchemaValidationResult) Errors() []*SchemaValidationError {
 // ValidateOrderJSON Validates a JSON encoded signed order using the AJV javascript library.
 // This libarary is used to increase the performance of Mesh nodes that run in the browser.
 func (f *Filter) ValidateOrderJSON(orderJSON []byte) (*SchemaValidationResult, error) {
-	jsResult := f.orderValidator.Invoke(string(orderJSON))
-	fatal := jsResult.Get("fatal")
-	if !jsutil.IsNullOrUndefined(fatal) {
-		return nil, errors.New(fatal.String())
+	jsResult, err := jsutil.AwaitPromise(f.orderValidator.Invoke(string(orderJSON)))
+	if err != nil {
+		return nil, err
 	}
 	valid := jsResult.Get("success").Bool()
 	jsErrors := jsResult.Get("errors")
@@ -48,10 +47,9 @@ func (f *Filter) ValidateOrderJSON(orderJSON []byte) (*SchemaValidationResult, e
 }
 
 func (f *Filter) MatchOrderMessageJSON(messageJSON []byte) (bool, error) {
-	jsResult := f.messageValidator.Invoke(string(messageJSON))
-	fatal := jsResult.Get("fatal")
-	if !jsutil.IsNullOrUndefined(fatal) {
-		return false, errors.New(fatal.String())
+	jsResult, err := jsutil.AwaitPromise(f.messageValidator.Invoke(string(messageJSON)))
+	if err != nil {
+		return false, err
 	}
 	return jsResult.Get("success").Bool(), nil
 }

--- a/orderfilter/validate_js.go
+++ b/orderfilter/validate_js.go
@@ -3,9 +3,7 @@
 package orderfilter
 
 import (
-	"context"
 	"errors"
-	"time"
 
 	"github.com/0xProject/0x-mesh/packages/browser/go/jsutil"
 	"github.com/0xProject/0x-mesh/zeroex"
@@ -35,9 +33,6 @@ func (s *SchemaValidationResult) Errors() []*SchemaValidationError {
 // ValidateOrderJSON Validates a JSON encoded signed order using the AJV javascript library.
 // This libarary is used to increase the performance of Mesh nodes that run in the browser.
 func (f *Filter) ValidateOrderJSON(orderJSON []byte) (*SchemaValidationResult, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	jsutil.NextTick(ctx)
 	result, err := jsutil.AwaitPromiseContext(ctx, f.orderValidator.Invoke(string(orderJSON)))
 	if err != nil {
 		return nil, err
@@ -52,9 +47,6 @@ func (f *Filter) ValidateOrderJSON(orderJSON []byte) (*SchemaValidationResult, e
 }
 
 func (f *Filter) MatchOrderMessageJSON(messageJSON []byte) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	jsutil.NextTick(ctx)
 	result, err := jsutil.AwaitPromiseContext(ctx, f.messageValidator.Invoke(string(messageJSON)))
 	if err != nil {
 		return false, err

--- a/orderfilter/validate_js.go
+++ b/orderfilter/validate_js.go
@@ -11,6 +11,10 @@ import (
 	"github.com/0xProject/0x-mesh/zeroex"
 )
 
+// sleepTime is used to force processes that block the event loop to give the
+// event loop time to continue. This should be as low as possible.
+const sleepTime = 175 * time.Microsecond
+
 type SchemaValidationError struct {
 	err error
 }
@@ -38,8 +42,7 @@ func (f *Filter) ValidateOrderJSON(orderJSON []byte) (*SchemaValidationResult, e
 	resultChan := make(chan js.Value, 1)
 	errChan := make(chan error, 1)
 	go func() {
-		// FIXME(jalextowle): Reduce this if possible
-		time.Sleep(time.Millisecond)
+		time.Sleep(sleepTime)
 		result, err := jsutil.AwaitPromise(f.orderValidator.Invoke(string(orderJSON)))
 		if err != nil {
 			errChan <- err
@@ -65,8 +68,7 @@ func (f *Filter) MatchOrderMessageJSON(messageJSON []byte) (bool, error) {
 	resultChan := make(chan js.Value, 1)
 	errChan := make(chan error, 1)
 	go func() {
-		// FIXME(jalextowle): Reduce this if possible
-		time.Sleep(time.Millisecond)
+		time.Sleep(sleepTime)
 		result, err := jsutil.AwaitPromise(f.messageValidator.Invoke(string(messageJSON)))
 		if err != nil {
 			errChan <- err

--- a/orderfilter/validate_js.go
+++ b/orderfilter/validate_js.go
@@ -11,10 +11,6 @@ import (
 	"github.com/0xProject/0x-mesh/zeroex"
 )
 
-// sleepTime is used to force processes that block the event loop to give the
-// event loop time to continue. This should be as low as possible.
-const sleepTime = 500 * time.Microsecond
-
 type SchemaValidationError struct {
 	err error
 }

--- a/orderfilter/validate_js.go
+++ b/orderfilter/validate_js.go
@@ -13,7 +13,7 @@ import (
 
 // sleepTime is used to force processes that block the event loop to give the
 // event loop time to continue. This should be as low as possible.
-const sleepTime = 175 * time.Microsecond
+const sleepTime = 500 * time.Microsecond
 
 type SchemaValidationError struct {
 	err error

--- a/packages/browser-lite/package.json
+++ b/packages/browser-lite/package.json
@@ -15,8 +15,8 @@
         "docsPath": "../../docs/browser-bindings/browser-lite"
     },
     "devDependencies": {
-        "@types/dexie": "^1.3.1",
         "@0x/ts-doc-gen": "^0.0.16",
+        "@types/dexie": "^1.3.1",
         "shx": "^0.3.2",
         "typedoc": "^0.15.0",
         "typescript": "^3.9.3"

--- a/packages/browser/go/jsutil/jsutil.go
+++ b/packages/browser/go/jsutil/jsutil.go
@@ -16,6 +16,19 @@ func ErrorToJS(err error) js.Value {
 	return js.Global().Get("Error").New(err.Error())
 }
 
+func NextTick(ctx context.Context) {
+	var executor js.Func
+	executor = js.FuncOf(func(this js.Value, args []js.Value) interface{} {
+		resolve := args[0]
+		go func() {
+			defer executor.Release()
+			js.Global().Call("setTimeout", resolve, 0)
+		}()
+		return nil
+	})
+	AwaitPromiseContext(ctx, js.Global().Get("Promise").New(executor))
+}
+
 // IsNullOrUndefined returns true if the given JavaScript value is either null
 // or undefined.
 func IsNullOrUndefined(value js.Value) bool {

--- a/zeroex/ordervalidator/order_validator.go
+++ b/zeroex/ordervalidator/order_validator.go
@@ -856,37 +856,6 @@ func (o *OrderValidator) computeABIEncodedSignedOrderByteLength(signedOrder *zer
 	return encodedSignedOrderByteLength, nil
 }
 
-// computeOptimalChunkSizes splits the signedOrders into chunks where the payload size of each chunk
-// is beneath the maxRequestContentLength. It does this by implementing a greedy algorithm which ABI
-// encodes signedOrders one at a time until the computed payload size is as close to the
-// maxRequestContentLength as possible.
-func (o *OrderValidator) computeOptimalChunkSizes(signedOrders []*zeroex.SignedOrder) []int {
-	chunkSizes := []int{}
-
-	payloadLength := jsonRPCPayloadByteLength
-	nextChunkSize := 0
-	for _, signedOrder := range signedOrders {
-		encodedSignedOrderByteLength, _ := o.computeABIEncodedSignedOrderByteLength(signedOrder)
-		if payloadLength+encodedSignedOrderByteLength < o.maxRequestContentLength {
-			payloadLength += encodedSignedOrderByteLength
-			nextChunkSize++
-		} else {
-			if nextChunkSize == 0 {
-				// This case should never be hit since we enforce that EthereumRPCMaxContentLength >= maxOrderSizeInBytes
-				log.WithField("signedOrder", signedOrder).Panic("EthereumRPCMaxContentLength is set so low, a single 0x order cannot fit beneath the payload limit")
-			}
-			chunkSizes = append(chunkSizes, nextChunkSize)
-			nextChunkSize = 1
-			payloadLength = jsonRPCPayloadByteLength + encodedSignedOrderByteLength
-		}
-	}
-	if nextChunkSize != 0 {
-		chunkSizes = append(chunkSizes, nextChunkSize)
-	}
-
-	return chunkSizes
-}
-
 func isSupportedSignature(signature []byte, orderHash common.Hash) bool {
 	signatureType := zeroex.SignatureType(signature[len(signature)-1])
 

--- a/zeroex/ordervalidator/order_validator_js.go
+++ b/zeroex/ordervalidator/order_validator_js.go
@@ -3,17 +3,14 @@
 package ordervalidator
 
 import (
-	"sync"
+	"context"
 	"syscall/js"
 	"time"
 
+	"github.com/0xProject/0x-mesh/packages/browser/go/jsutil"
 	"github.com/0xProject/0x-mesh/zeroex"
 	log "github.com/sirupsen/logrus"
 )
-
-// sleepTime is used to force processes that block the event loop to give the
-// event loop time to continue. This should be as low as possible.
-const sleepTime = 175 * time.Microsecond
 
 func (v ValidationResults) JSValue() js.Value {
 	accepted := make([]interface{}, len(v.Accepted))
@@ -55,7 +52,9 @@ func (s RejectedOrderStatus) JSValue() js.Value {
 	})
 }
 
-const computeOptimalChunkBatchSize = 3
+// computeOptimalChunkBatchSize is the number of computations that we do in
+// computeOptimalChunkSizes before waiting for the next tick of the event loop.
+const computeOptimalChunkBatchSize = 10
 
 // computeOptimalChunkSizes splits the signedOrders into chunks where the payload size of each chunk
 // is beneath the maxRequestContentLength. It does this by implementing a greedy algorithm which ABI
@@ -66,32 +65,33 @@ func (o *OrderValidator) computeOptimalChunkSizes(signedOrders []*zeroex.SignedO
 
 	payloadLength := jsonRPCPayloadByteLength
 	nextChunkSize := 0
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		batchIdx := 0
-		for _, signedOrder := range signedOrders {
-			if batchIdx%computeOptimalChunkBatchSize == 2 {
-				time.Sleep(sleepTime)
-			}
-			encodedSignedOrderByteLength, _ := o.computeABIEncodedSignedOrderByteLength(signedOrder)
-			if payloadLength+encodedSignedOrderByteLength < o.maxRequestContentLength {
-				payloadLength += encodedSignedOrderByteLength
-				nextChunkSize++
-			} else {
-				if nextChunkSize == 0 {
-					// This case should never be hit since we enforce that EthereumRPCMaxContentLength >= maxOrderSizeInBytes
-					log.WithField("signedOrder", signedOrder).Panic("EthereumRPCMaxContentLength is set so low, a single 0x order cannot fit beneath the payload limit")
-				}
-				chunkSizes = append(chunkSizes, nextChunkSize)
-				nextChunkSize = 1
-				payloadLength = jsonRPCPayloadByteLength + encodedSignedOrderByteLength
-			}
-			batchIdx = batchIdx + 1
+	batchIdx := 0
+	for _, signedOrder := range signedOrders {
+		// NOTE(jalextowle): We need to occasionally wait for the next tick
+		// of the Javascript event loop in order to break up the execution
+		// of this function. Doing this too often will significantly slow
+		// down the execution of the Mesh node, so we sleep after executing
+		// "batches" of computations.
+		if batchIdx%computeOptimalChunkBatchSize == computeOptimalChunkBatchSize-1 {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			jsutil.NextTick(ctx)
+			cancel()
 		}
-		wg.Done()
-	}()
-	wg.Wait()
+		encodedSignedOrderByteLength, _ := o.computeABIEncodedSignedOrderByteLength(signedOrder)
+		if payloadLength+encodedSignedOrderByteLength < o.maxRequestContentLength {
+			payloadLength += encodedSignedOrderByteLength
+			nextChunkSize++
+		} else {
+			if nextChunkSize == 0 {
+				// This case should never be hit since we enforce that EthereumRPCMaxContentLength >= maxOrderSizeInBytes
+				log.WithField("signedOrder", signedOrder).Panic("EthereumRPCMaxContentLength is set so low, a single 0x order cannot fit beneath the payload limit")
+			}
+			chunkSizes = append(chunkSizes, nextChunkSize)
+			nextChunkSize = 1
+			payloadLength = jsonRPCPayloadByteLength + encodedSignedOrderByteLength
+		}
+		batchIdx = batchIdx + 1
+	}
 	if nextChunkSize != 0 {
 		chunkSizes = append(chunkSizes, nextChunkSize)
 	}

--- a/zeroex/ordervalidator/order_validator_js.go
+++ b/zeroex/ordervalidator/order_validator_js.go
@@ -10,6 +10,10 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// sleepTime is used to force processes that block the event loop to give the
+// event loop time to continue. This should be as low as possible.
+const sleepTime = 175 * time.Microsecond
+
 func (v ValidationResults) JSValue() js.Value {
 	accepted := make([]interface{}, len(v.Accepted))
 	for i, info := range v.Accepted {
@@ -62,7 +66,7 @@ func (o *OrderValidator) computeOptimalChunkSizes(signedOrders []*zeroex.SignedO
 	encodedSignedOrderByteLengthChan := make(chan int, 1)
 	for _, signedOrder := range signedOrders {
 		go func() {
-			time.Sleep(250 * time.Microsecond)
+			time.Sleep(sleepTime)
 			encodedSignedOrderByteLength, _ := o.computeABIEncodedSignedOrderByteLength(signedOrder)
 			encodedSignedOrderByteLengthChan <- encodedSignedOrderByteLength
 		}()

--- a/zeroex/ordervalidator/order_validator_js.go
+++ b/zeroex/ordervalidator/order_validator_js.go
@@ -73,7 +73,7 @@ func (o *OrderValidator) computeOptimalChunkSizes(signedOrders []*zeroex.SignedO
 		// down the execution of the Mesh node, so we sleep after executing
 		// "batches" of computations.
 		if batchIdx%computeOptimalChunkBatchSize == computeOptimalChunkBatchSize-1 {
-			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			jsutil.NextTick(ctx)
 			cancel()
 		}

--- a/zeroex/ordervalidator/order_validator_js.go
+++ b/zeroex/ordervalidator/order_validator_js.go
@@ -54,6 +54,8 @@ func (s RejectedOrderStatus) JSValue() js.Value {
 	})
 }
 
+const computeOptimalChunkBatchSize = 3
+
 // computeOptimalChunkSizes splits the signedOrders into chunks where the payload size of each chunk
 // is beneath the maxRequestContentLength. It does this by implementing a greedy algorithm which ABI
 // encodes signedOrders one at a time until the computed payload size is as close to the
@@ -63,27 +65,29 @@ func (o *OrderValidator) computeOptimalChunkSizes(signedOrders []*zeroex.SignedO
 
 	payloadLength := jsonRPCPayloadByteLength
 	nextChunkSize := 0
-	encodedSignedOrderByteLengthChan := make(chan int, 1)
-	for _, signedOrder := range signedOrders {
-		go func() {
+	go func() {
+		batchIdx := 0
+		for _, signedOrder := range signedOrders {
+			if batchIdx%computeOptimalChunkBatchSize == 2 {
+				time.Sleep(sleepTime)
+			}
 			time.Sleep(sleepTime)
 			encodedSignedOrderByteLength, _ := o.computeABIEncodedSignedOrderByteLength(signedOrder)
-			encodedSignedOrderByteLengthChan <- encodedSignedOrderByteLength
-		}()
-		encodedSignedOrderByteLength := <-encodedSignedOrderByteLengthChan
-		if payloadLength+encodedSignedOrderByteLength < o.maxRequestContentLength {
-			payloadLength += encodedSignedOrderByteLength
-			nextChunkSize++
-		} else {
-			if nextChunkSize == 0 {
-				// This case should never be hit since we enforce that EthereumRPCMaxContentLength >= maxOrderSizeInBytes
-				log.WithField("signedOrder", signedOrder).Panic("EthereumRPCMaxContentLength is set so low, a single 0x order cannot fit beneath the payload limit")
+			if payloadLength+encodedSignedOrderByteLength < o.maxRequestContentLength {
+				payloadLength += encodedSignedOrderByteLength
+				nextChunkSize++
+			} else {
+				if nextChunkSize == 0 {
+					// This case should never be hit since we enforce that EthereumRPCMaxContentLength >= maxOrderSizeInBytes
+					log.WithField("signedOrder", signedOrder).Panic("EthereumRPCMaxContentLength is set so low, a single 0x order cannot fit beneath the payload limit")
+				}
+				chunkSizes = append(chunkSizes, nextChunkSize)
+				nextChunkSize = 1
+				payloadLength = jsonRPCPayloadByteLength + encodedSignedOrderByteLength
 			}
-			chunkSizes = append(chunkSizes, nextChunkSize)
-			nextChunkSize = 1
-			payloadLength = jsonRPCPayloadByteLength + encodedSignedOrderByteLength
+			batchIdx = batchIdx + 1
 		}
-	}
+	}()
 	if nextChunkSize != 0 {
 		chunkSizes = append(chunkSizes, nextChunkSize)
 	}

--- a/zeroex/ordervalidator/order_validator_native.go
+++ b/zeroex/ordervalidator/order_validator_native.go
@@ -1,0 +1,39 @@
+// +build !js
+
+package ordervalidator
+
+import (
+	"github.com/0xProject/0x-mesh/zeroex"
+	log "github.com/sirupsen/logrus"
+)
+
+// computeOptimalChunkSizes splits the signedOrders into chunks where the payload size of each chunk
+// is beneath the maxRequestContentLength. It does this by implementing a greedy algorithm which ABI
+// encodes signedOrders one at a time until the computed payload size is as close to the
+// maxRequestContentLength as possible.
+func (o *OrderValidator) computeOptimalChunkSizes(signedOrders []*zeroex.SignedOrder) []int {
+	chunkSizes := []int{}
+
+	payloadLength := jsonRPCPayloadByteLength
+	nextChunkSize := 0
+	for _, signedOrder := range signedOrders {
+		encodedSignedOrderByteLength, _ := o.computeABIEncodedSignedOrderByteLength(signedOrder)
+		if payloadLength+encodedSignedOrderByteLength < o.maxRequestContentLength {
+			payloadLength += encodedSignedOrderByteLength
+			nextChunkSize++
+		} else {
+			if nextChunkSize == 0 {
+				// This case should never be hit since we enforce that EthereumRPCMaxContentLength >= maxOrderSizeInBytes
+				log.WithField("signedOrder", signedOrder).Panic("EthereumRPCMaxContentLength is set so low, a single 0x order cannot fit beneath the payload limit")
+			}
+			chunkSizes = append(chunkSizes, nextChunkSize)
+			nextChunkSize = 1
+			payloadLength = jsonRPCPayloadByteLength + encodedSignedOrderByteLength
+		}
+	}
+	if nextChunkSize != 0 {
+		chunkSizes = append(chunkSizes, nextChunkSize)
+	}
+
+	return chunkSizes
+}


### PR DESCRIPTION
# Description

Despite becoming significantly faster after #809, calls to `MatchOrder` still clog up the event loop for up to 50 ms (with an average of around 20 ms). This PR makes validation asynchronous, which significantly improves this situation.

Another related issue is that the event loop is held up by the `resume` call that ultimately calls `HandleOrderSyncResponse`. This can take up to 1 second to be processed, which is an untenable amount of time. This problem is tracked in an issue on the Golang Github repository https://github.com/golang/go/issues/39620.
