### PR TITLE
Parallelize requesting from peers in `ordersync`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ lint: lint-go lint-ts lint-prettier
 
 .PHONY: lint-go
 lint-go:
-	golangci-lint run
+	golangci-lint run --timeout 2m 
 
 
 .PHONY: lint-ts

--- a/core/ordersync/ordersync.go
+++ b/core/ordersync/ordersync.go
@@ -294,6 +294,8 @@ func (s *Service) GetOrders(ctx context.Context, minPeers int) error {
 		i := 0
 		wg := &sync.WaitGroup{}
 		waitChan := make(chan struct{}, 1)
+		innerCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		for _, peerID := range currentNeighbors {
 			if len(successfullySyncedPeers) >= minPeers {
 				return nil
@@ -329,7 +331,7 @@ func (s *Service) GetOrders(ctx context.Context, minPeers int) error {
 			wg.Add(1)
 			go func(id peer.ID) {
 				defer wg.Done()
-				if err := s.getOrdersFromPeer(ctx, id); err != nil {
+				if err := s.getOrdersFromPeer(innerCtx, id); err != nil {
 					log.WithFields(log.Fields{
 						"error":    err.Error(),
 						"provider": id.Pretty(),

--- a/core/ordersync/ordersync.go
+++ b/core/ordersync/ordersync.go
@@ -47,7 +47,7 @@ const (
 	ordersyncJitterAmount = 0.1
 	// maxRequestPeersInParallel is the largest number of peers that `GetOrders`
 	// will try to pull orders from at once.
-	maxRequestPeersInParallel = 15
+	maxRequestPeersInParallel = 10
 )
 
 var (

--- a/core/ordersync/ordersync.go
+++ b/core/ordersync/ordersync.go
@@ -338,10 +338,8 @@ func (s *Service) GetOrders(ctx context.Context, minPeers int) error {
 					}).Trace("succesfully got orders from peer via ordersync")
 					m.Lock()
 					successfullySyncedPeers.Add(id.Pretty())
-					m.Unlock()
-					m.RLock()
 					successfullySyncedPeerLength := len(successfullySyncedPeers)
-					m.RUnlock()
+					m.Unlock()
 					if successfullySyncedPeerLength >= minPeers {
 						cancel()
 					}

--- a/core/ordersync/ordersync.go
+++ b/core/ordersync/ordersync.go
@@ -335,8 +335,15 @@ func (s *Service) GetOrders(ctx context.Context, minPeers int) error {
 						"provider": id.Pretty(),
 					}).Trace("succesfully got orders from peer via ordersync")
 					successfullySyncedPeers.Add(id.Pretty())
+					if len(successfullySyncedPeers) >= minPeers {
+						cancel()
+					}
 				}
 			}(peerID)
+		}
+
+		if innerCtx.Err() == context.Canceled {
+			return nil
 		}
 
 		wg.Wait()


### PR DESCRIPTION
# Description

This PR addresses one of the lowest hanging pieces of fruit in `ordersync`. Previously, the `GetOrders` function would try to get orders from peers one at a time. This was easy to understand, but was also suboptimal from a performance perspective. This PR makes changes that allows this function to request orders from multiple peers at once.