### PR TITLE
Update TypeScript compiler target to ES2016

### DIFF
--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -2,7 +2,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es5",
+        "target": "es2016",
         "lib": ["es2017", "dom"],
         "experimentalDecorators": true,
         "downlevelIteration": true,


### PR DESCRIPTION
ES2016 was selected by starting with browsers that support WebAssembly and choosing the latest ECMAScript version that does not exclude any of those. The browsers that were considered for compatibility are: Chrome, Firefox, Safari, and Edge. Mesh is not compatible with Internet Explorer because it does not support WebAssembly. We cannot target ES2017 because not all features are supported by Firefox and Safari.

- [Which browsers support WebAssembly](https://caniuse.com/#feat=wasm)
- [Which browsers support ES2016+ features](http://kangax.github.io/compat-table/es2016plus/)

