### PR TITLE
fix: Wait for high quality peers to fully respond during ordersync

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -61,7 +61,7 @@ const (
 	version          = "development"
 	// ordersyncMinPeers is the minimum amount of peers to receive orders from
 	// before considering the ordersync process finished.
-	ordersyncMinPeers = 5
+	ordersyncMinPeers = 3
 	// ordersyncApproxDelay is the approximate amount of time to wait between each
 	// run of the ordersync protocol (as a requester). We always request orders
 	// immediately on startup. This delay only applies to subsequent runs.
@@ -641,6 +641,7 @@ func (app *App) Start() error {
 			orderSyncErrChan <- err
 		}
 		log.WithField("stats", stats).Warn("After ordersync completion stats")
+		panic("Ended")
 		/* END FIXME */
 	}()
 

--- a/core/core.go
+++ b/core/core.go
@@ -56,7 +56,8 @@ const (
 	// for different Ethereum networks, but it should be good enough.
 	estimatedNonPollingEthereumRPCRequestsPer24Hrs = 50000
 	// logStatsInterval is how often to log stats for this node.
-	logStatsInterval = 5 * time.Minute
+	// FIXME - Change back to every 5 minutes
+	logStatsInterval = 1 * time.Minute
 	version          = "development"
 	// ordersyncMinPeers is the minimum amount of peers to receive orders from
 	// before considering the ordersync process finished.
@@ -634,6 +635,13 @@ func (app *App) Start() error {
 		if err := app.ordersyncService.PeriodicallyGetOrders(innerCtx, ordersyncMinPeers, ordersyncApproxDelay); err != nil {
 			orderSyncErrChan <- err
 		}
+		/* FIXME */
+		stats, err := app.GetStats()
+		if err != nil {
+			orderSyncErrChan <- err
+		}
+		log.WithField("stats", stats).Warn("After ordersync completion stats")
+		/* END FIXME */
 	}()
 
 	// Start the p2p node.
@@ -1041,6 +1049,8 @@ func (app *App) GetStats() (*types.Stats, error) {
 func (app *App) periodicallyLogStats(ctx context.Context) {
 	<-app.started
 
+	log.Warn("Periodically Log Stats has started")
+
 	ticker := time.NewTicker(logStatsInterval)
 	for {
 		select {
@@ -1055,6 +1065,7 @@ func (app *App) periodicallyLogStats(ctx context.Context) {
 			log.WithError(err).Error("could not get stats")
 			continue
 		}
+		// FIXME - Change back to `Info`
 		log.WithFields(log.Fields{
 			"version":                           stats.Version,
 			"pubSubTopic":                       stats.PubSubTopic,
@@ -1069,7 +1080,7 @@ func (app *App) periodicallyLogStats(ctx context.Context) {
 			"startOfCurrentUTCDay":              stats.StartOfCurrentUTCDay,
 			"ethRPCRequestsSentInCurrentUTCDay": stats.EthRPCRequestsSentInCurrentUTCDay,
 			"ethRPCRateLimitExpiredRequests":    stats.EthRPCRateLimitExpiredRequests,
-		}).Info("current stats")
+		}).Warn("current stats")
 	}
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -56,12 +56,11 @@ const (
 	// for different Ethereum networks, but it should be good enough.
 	estimatedNonPollingEthereumRPCRequestsPer24Hrs = 50000
 	// logStatsInterval is how often to log stats for this node.
-	// FIXME - Change back to every 5 minutes
-	logStatsInterval = 1 * time.Minute
+	logStatsInterval = 5 * time.Minute
 	version          = "development"
 	// ordersyncMinPeers is the minimum amount of peers to receive orders from
 	// before considering the ordersync process finished.
-	ordersyncMinPeers = 3
+	ordersyncMinPeers = 5
 	// ordersyncApproxDelay is the approximate amount of time to wait between each
 	// run of the ordersync protocol (as a requester). We always request orders
 	// immediately on startup. This delay only applies to subsequent runs.
@@ -635,14 +634,6 @@ func (app *App) Start() error {
 		if err := app.ordersyncService.PeriodicallyGetOrders(innerCtx, ordersyncMinPeers, ordersyncApproxDelay); err != nil {
 			orderSyncErrChan <- err
 		}
-		/* FIXME */
-		stats, err := app.GetStats()
-		if err != nil {
-			orderSyncErrChan <- err
-		}
-		log.WithField("stats", stats).Warn("After ordersync completion stats")
-		panic("Ended")
-		/* END FIXME */
 	}()
 
 	// Start the p2p node.
@@ -1066,7 +1057,6 @@ func (app *App) periodicallyLogStats(ctx context.Context) {
 			log.WithError(err).Error("could not get stats")
 			continue
 		}
-		// FIXME - Change back to `Info`
 		log.WithFields(log.Fields{
 			"version":                           stats.Version,
 			"pubSubTopic":                       stats.PubSubTopic,
@@ -1081,7 +1071,7 @@ func (app *App) periodicallyLogStats(ctx context.Context) {
 			"startOfCurrentUTCDay":              stats.StartOfCurrentUTCDay,
 			"ethRPCRequestsSentInCurrentUTCDay": stats.EthRPCRequestsSentInCurrentUTCDay,
 			"ethRPCRateLimitExpiredRequests":    stats.EthRPCRateLimitExpiredRequests,
-		}).Warn("current stats")
+		}).Info("current stats")
 	}
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -1041,8 +1041,6 @@ func (app *App) GetStats() (*types.Stats, error) {
 func (app *App) periodicallyLogStats(ctx context.Context) {
 	<-app.started
 
-	log.Warn("Periodically Log Stats has started")
-
 	ticker := time.NewTicker(logStatsInterval)
 	for {
 		select {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -236,7 +236,7 @@ func runOrdersyncTestCase(t *testing.T, testCase ordersyncTestCase) func(t *test
 			defer wg.Done()
 			if err := originalNode.Start(); err != nil && err != context.Canceled {
 				// context.Canceled is expected. For any other error, fail the test.
-				require.NoError(t, err)
+				panic(err)
 			}
 		}()
 
@@ -258,7 +258,7 @@ func runOrdersyncTestCase(t *testing.T, testCase ordersyncTestCase) func(t *test
 			defer wg.Done()
 			if err := newNode.Start(); err != nil && err != context.Canceled {
 				// context.Canceled is expected. For any other error, fail the test.
-				require.NoError(t, err)
+				panic(err)
 			}
 		}()
 		<-newNode.started


### PR DESCRIPTION
Partially Addresses: #871 

This PR fixes two issues:
* Ordersync sub-protocols previously considered a sync that yielded 0 orders in total a success. This was a bug, and was resolved by this PR.
* A subtle issue that was introduced by #848. Because the parallelized version of ordersync would connect to several peers and would cancel the context when we had synced with a sufficient number of extra peers, it was possible for the response of several peers with a small amount of orders to short-circuit ordersync runs with other peers that had more orders. This would lead to the node not always getting all of the orders during ordersync.

After this PR, we will only make as many parallel requests as can actually be resolved without going over `ordersyncMinPeers`. Future PRs should refine the process of determining when ordersync has completed.
