### PR TITLE
fix: Mark an ordersync that yields zero orders unsuccessful

### DIFF
--- a/core/ordersync_subprotocols.go
+++ b/core/ordersync_subprotocols.go
@@ -145,18 +145,18 @@ func (p *FilteredPaginationSubProtocolV0) HandleOrderSyncRequest(ctx context.Con
 // HandleOrderSyncResponse handles the orders for one page by validating them, storing them
 // in the database, and firing the appropriate events. It also returns the next request to
 // be sent. This is the implementation for the "requester" side of the subprotocol.
-func (p *FilteredPaginationSubProtocolV0) HandleOrderSyncResponse(ctx context.Context, res *ordersync.Response) (*ordersync.Request, error) {
+func (p *FilteredPaginationSubProtocolV0) HandleOrderSyncResponse(ctx context.Context, res *ordersync.Response) (*ordersync.Request, []*zeroex.SignedOrder, error) {
 	if res.Metadata == nil {
-		return nil, errors.New("FilteredPaginationSubProtocolV0 received response with nil metadata")
+		return nil, nil, errors.New("FilteredPaginationSubProtocolV0 received response with nil metadata")
 	}
 	metadata, ok := res.Metadata.(*FilteredPaginationResponseMetadataV0)
 	if !ok {
-		return nil, fmt.Errorf("FilteredPaginationSubProtocolV0 received response with wrong metadata type (got %T)", res.Metadata)
+		return nil, nil, fmt.Errorf("FilteredPaginationSubProtocolV0 received response with wrong metadata type (got %T)", res.Metadata)
 	}
 	filteredOrders := []*zeroex.SignedOrder{}
 	for _, order := range res.Orders {
 		if matches, err := p.orderFilter.MatchOrder(order); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if matches {
 			filteredOrders = append(filteredOrders, order)
 		} else if !matches {
@@ -165,7 +165,7 @@ func (p *FilteredPaginationSubProtocolV0) HandleOrderSyncResponse(ctx context.Co
 	}
 	validationResults, err := p.app.orderWatcher.ValidateAndStoreValidOrders(ctx, filteredOrders, false, p.app.chainID)
 	if err != nil {
-		return nil, err
+		return nil, filteredOrders, err
 	}
 	for _, acceptedOrderInfo := range validationResults.Accepted {
 		if acceptedOrderInfo.IsNew {
@@ -188,7 +188,7 @@ func (p *FilteredPaginationSubProtocolV0) HandleOrderSyncResponse(ctx context.Co
 			Page:       metadata.Page + 1,
 			SnapshotID: metadata.SnapshotID,
 		},
-	}, nil
+	}, filteredOrders, nil
 }
 
 func (p *FilteredPaginationSubProtocolV0) ParseRequestMetadata(metadata json.RawMessage) (interface{}, error) {
@@ -320,18 +320,18 @@ func (p *FilteredPaginationSubProtocolV1) HandleOrderSyncRequest(ctx context.Con
 // HandleOrderSyncResponse handles the orders for one page by validating them, storing them
 // in the database, and firing the appropriate events. It also returns the next request to
 // be sent. This is the implementation for the "requester" side of the subprotocol.
-func (p *FilteredPaginationSubProtocolV1) HandleOrderSyncResponse(ctx context.Context, res *ordersync.Response) (*ordersync.Request, error) {
+func (p *FilteredPaginationSubProtocolV1) HandleOrderSyncResponse(ctx context.Context, res *ordersync.Response) (*ordersync.Request, []*zeroex.SignedOrder, error) {
 	if res.Metadata == nil {
-		return nil, errors.New("FilteredPaginationSubProtocolV1 received response with nil metadata")
+		return nil, nil, errors.New("FilteredPaginationSubProtocolV1 received response with nil metadata")
 	}
 	_, ok := res.Metadata.(*FilteredPaginationResponseMetadataV1)
 	if !ok {
-		return nil, fmt.Errorf("FilteredPaginationSubProtocolV1 received response with wrong metadata type (got %T)", res.Metadata)
+		return nil, nil, fmt.Errorf("FilteredPaginationSubProtocolV1 received response with wrong metadata type (got %T)", res.Metadata)
 	}
 	filteredOrders := []*zeroex.SignedOrder{}
 	for _, order := range res.Orders {
 		if matches, err := p.orderFilter.MatchOrder(order); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if matches {
 			filteredOrders = append(filteredOrders, order)
 		} else if !matches {
@@ -340,7 +340,7 @@ func (p *FilteredPaginationSubProtocolV1) HandleOrderSyncResponse(ctx context.Co
 	}
 	validationResults, err := p.app.orderWatcher.ValidateAndStoreValidOrders(ctx, filteredOrders, false, p.app.chainID)
 	if err != nil {
-		return nil, err
+		return nil, filteredOrders, err
 	}
 	for _, acceptedOrderInfo := range validationResults.Accepted {
 		if acceptedOrderInfo.IsNew {
@@ -364,7 +364,7 @@ func (p *FilteredPaginationSubProtocolV1) HandleOrderSyncResponse(ctx context.Co
 	if len(res.Orders) > 0 {
 		hash, err := res.Orders[len(res.Orders)-1].ComputeOrderHash()
 		if err != nil {
-			return nil, err
+			return nil, filteredOrders, err
 		}
 		nextMinOrderHash = hash
 	}
@@ -372,7 +372,7 @@ func (p *FilteredPaginationSubProtocolV1) HandleOrderSyncResponse(ctx context.Co
 		Metadata: &FilteredPaginationRequestMetadataV1{
 			MinOrderHash: nextMinOrderHash,
 		},
-	}, nil
+	}, filteredOrders, nil
 }
 
 func (p *FilteredPaginationSubProtocolV1) ParseRequestMetadata(metadata json.RawMessage) (interface{}, error) {


### PR DESCRIPTION
Prior to this PR, a sync would be marked as a success provided that there was a nonzero number of orders returned in an ordersync response. Upon closer inspection, this was not strict enough since these orders may not pass the `orderfilter`. In this PR, we addressed the issue by keeping track of how many orders that match the filter have been contributed by a given ordersync peer.