### PR TITLE
Check for already stored orders in a single batch

### DIFF
--- a/db/common.go
+++ b/db/common.go
@@ -33,6 +33,7 @@ var (
 type Database interface {
 	AddOrders(orders []*types.OrderWithMetadata) (added []*types.OrderWithMetadata, removed []*types.OrderWithMetadata, err error)
 	GetOrder(hash common.Hash) (*types.OrderWithMetadata, error)
+	GetOrderStatuses(hashes []common.Hash) (statuses []int, err error)
 	FindOrders(opts *OrderQuery) ([]*types.OrderWithMetadata, error)
 	CountOrders(opts *OrderQuery) (int, error)
 	DeleteOrder(hash common.Hash) error

--- a/db/common.go
+++ b/db/common.go
@@ -33,7 +33,7 @@ var (
 type Database interface {
 	AddOrders(orders []*types.OrderWithMetadata) (added []*types.OrderWithMetadata, removed []*types.OrderWithMetadata, err error)
 	GetOrder(hash common.Hash) (*types.OrderWithMetadata, error)
-	GetOrderStatuses(hashes []common.Hash) (statuses []int, err error)
+	GetOrderStatuses(hashes []common.Hash) (statuses []StoredOrderStatus, err error)
 	FindOrders(opts *OrderQuery) ([]*types.OrderWithMetadata, error)
 	CountOrders(opts *OrderQuery) (int, error)
 	DeleteOrder(hash common.Hash) error
@@ -138,6 +138,12 @@ type OrderFilter struct {
 	Field OrderField  `json:"field"`
 	Kind  FilterKind  `json:"kind"`
 	Value interface{} `json:"value"`
+}
+
+type StoredOrderStatus struct {
+	IsStored                 bool     `json:"isStored"`
+	IsMarkedRemoved          bool     `json:"isMarkedRemoved"`
+	FillableTakerAssetAmount *big.Int `json:"fillableTakerAssetAmount"`
 }
 
 // MakerAssetIncludesTokenAddressAndTokenID is a helper method which returns a filter that will match orders

--- a/db/common.go
+++ b/db/common.go
@@ -33,7 +33,7 @@ var (
 type Database interface {
 	AddOrders(orders []*types.OrderWithMetadata) (added []*types.OrderWithMetadata, removed []*types.OrderWithMetadata, err error)
 	GetOrder(hash common.Hash) (*types.OrderWithMetadata, error)
-	GetOrderStatuses(hashes []common.Hash) (statuses []StoredOrderStatus, err error)
+	GetOrderStatuses(hashes []common.Hash) (statuses []*StoredOrderStatus, err error)
 	FindOrders(opts *OrderQuery) ([]*types.OrderWithMetadata, error)
 	CountOrders(opts *OrderQuery) (int, error)
 	DeleteOrder(hash common.Hash) error

--- a/db/dexie_implementation.go
+++ b/db/dexie_implementation.go
@@ -10,14 +10,19 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"syscall/js"
+	"time"
 
 	"github.com/0xProject/0x-mesh/common/types"
 	"github.com/0xProject/0x-mesh/db/dexietypes"
 	"github.com/0xProject/0x-mesh/packages/mesh-browser/go/jsutil"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gibson042/canonicaljson-go"
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 )
+
+const slowQueryDuration = 1 * time.Second
 
 var _ Database = (*DB)(nil)
 
@@ -84,6 +89,8 @@ func (db *DB) AddOrders(orders []*types.OrderWithMetadata) (added []*types.Order
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, fmt.Sprintf("AddOrders with %d orders", len(orders)))
 	jsOrders, err := jsutil.InefficientlyConvertToJS(dexietypes.OrdersFromCommonType(orders))
 	if err != nil {
 		return nil, nil, err
@@ -111,6 +118,8 @@ func (db *DB) GetOrder(hash common.Hash) (order *types.OrderWithMetadata, err er
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, "GetOrder")
 	jsOrder, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("getOrderAsync", hash.Hex()))
 	if err != nil {
 		return nil, convertJSError(err)
@@ -122,6 +131,29 @@ func (db *DB) GetOrder(hash common.Hash) (order *types.OrderWithMetadata, err er
 	return dexietypes.OrderToCommonType(&dexieOrder), nil
 }
 
+func (db *DB) GetOrderStatuses(hashes []common.Hash) (statuses []int, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = recoverError(r)
+		}
+	}()
+	start := time.Now()
+	defer logDuration(start, fmt.Sprintf("GetOrderStatuses with %d hashes", len(hashes)))
+	stringHashes := make([]interface{}, len(hashes))
+	for i, hash := range hashes {
+		stringHashes[i] = hash.Hex()
+	}
+	jsResults, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("getOrderStatusesAsync", stringHashes))
+	if err != nil {
+		return nil, convertJSError(err)
+	}
+	statuses = make([]int, jsResults.Length())
+	for i := 0; i < len(statuses); i++ {
+		statuses[i] = jsResults.Index(i).Int()
+	}
+	return statuses, nil
+}
+
 func (db *DB) FindOrders(query *OrderQuery) (orders []*types.OrderWithMetadata, err error) {
 	if err := checkOrderQuery(query); err != nil {
 		return nil, err
@@ -131,6 +163,8 @@ func (db *DB) FindOrders(query *OrderQuery) (orders []*types.OrderWithMetadata, 
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, fmt.Sprintf("FindOrders %s", spew.Sdump(query)))
 	query = formatOrderQuery(query)
 	jsOrders, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("findOrdersAsync", query))
 	if err != nil {
@@ -152,6 +186,8 @@ func (db *DB) CountOrders(query *OrderQuery) (count int, err error) {
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, fmt.Sprintf("CountOrders %s", spew.Sdump(query)))
 	query = formatOrderQuery(query)
 	jsCount, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("countOrdersAsync", query))
 	if err != nil {
@@ -166,6 +202,8 @@ func (db *DB) DeleteOrder(hash common.Hash) (err error) {
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, "DeleteOrder")
 	_, jsErr := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("deleteOrderAsync", hash.Hex()))
 	if jsErr != nil {
 		return convertJSError(jsErr)
@@ -182,6 +220,8 @@ func (db *DB) DeleteOrders(query *OrderQuery) (deletedOrders []*types.OrderWithM
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, fmt.Sprintf("DeleteOrders %s", spew.Sdump(query)))
 	query = formatOrderQuery(query)
 	jsOrders, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("deleteOrdersAsync", query))
 	if err != nil {
@@ -200,6 +240,8 @@ func (db *DB) UpdateOrder(hash common.Hash, updateFunc func(existingOrder *types
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, "UpdateOrder")
 	jsUpdateFunc := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
 		jsExistingOrder := args[0]
 		var dexieExistingOrder dexietypes.Order
@@ -231,6 +273,8 @@ func (db *DB) AddMiniHeaders(miniHeaders []*types.MiniHeader) (added []*types.Mi
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, fmt.Sprintf("AddMiniHeaders with %d miniHeaders", len(miniHeaders)))
 	jsMiniHeaders := dexietypes.MiniHeadersFromCommonType(miniHeaders)
 	jsResult, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("addMiniHeadersAsync", jsMiniHeaders))
 	if err != nil {
@@ -249,6 +293,8 @@ func (db *DB) ResetMiniHeaders(newMiniHeaders []*types.MiniHeader) (err error) {
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, fmt.Sprintf("ResetMiniHeaders with %d newMiniHeaders", len(newMiniHeaders)))
 	jsNewMiniHeaders := dexietypes.MiniHeadersFromCommonType(newMiniHeaders)
 	_, err = jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("resetMiniHeadersAsync", jsNewMiniHeaders))
 	if err != nil {
@@ -263,6 +309,8 @@ func (db *DB) GetMiniHeader(hash common.Hash) (miniHeader *types.MiniHeader, err
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, "GetMiniHeader")
 	jsMiniHeader, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("getMiniHeaderAsync", hash.Hex()))
 	if err != nil {
 		return nil, convertJSError(err)
@@ -279,6 +327,8 @@ func (db *DB) FindMiniHeaders(query *MiniHeaderQuery) (miniHeaders []*types.Mini
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, fmt.Sprintf("FindMiniHeaders %s", spew.Sdump(query)))
 	query = formatMiniHeaderQuery(query)
 	jsMiniHeaders, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("findMiniHeadersAsync", query))
 	if err != nil {
@@ -293,6 +343,8 @@ func (db *DB) DeleteMiniHeader(hash common.Hash) (err error) {
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, "DeleteMiniHeader")
 	_, jsErr := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("deleteMiniHeaderAsync", hash.Hex()))
 	if jsErr != nil {
 		return convertJSError(jsErr)
@@ -309,6 +361,8 @@ func (db *DB) DeleteMiniHeaders(query *MiniHeaderQuery) (deleted []*types.MiniHe
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, fmt.Sprintf("DeleteMiniHeaders %s", spew.Sdump(query)))
 	query = formatMiniHeaderQuery(query)
 	jsMiniHeaders, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("deleteMiniHeadersAsync", query))
 	if err != nil {
@@ -323,6 +377,8 @@ func (db *DB) GetMetadata() (metadata *types.Metadata, err error) {
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, "GetMetadata")
 	jsMetadata, err := jsutil.AwaitPromiseContext(db.ctx, db.dexie.Call("getMetadataAsync"))
 	if err != nil {
 		return nil, convertJSError(err)
@@ -340,6 +396,8 @@ func (db *DB) SaveMetadata(metadata *types.Metadata) (err error) {
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, "SaveMetadata")
 	dexieMetadata := dexietypes.MetadataFromCommonType(metadata)
 	jsMetadata, err := jsutil.InefficientlyConvertToJS(dexieMetadata)
 	if err != nil {
@@ -358,6 +416,8 @@ func (db *DB) UpdateMetadata(updateFunc func(oldmetadata *types.Metadata) (newMe
 			err = recoverError(r)
 		}
 	}()
+	start := time.Now()
+	defer logDuration(start, "UpdateMetadata")
 	jsUpdateFunc := js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
 		jsExistingMetadata := args[0]
 		var dexieExistingMetadata dexietypes.Metadata
@@ -459,5 +519,15 @@ func assetDataIncludesTokenAddressAndTokenID(field OrderField, tokenAddress comm
 		Field: field,
 		Kind:  Contains,
 		Value: string(filterValueJSON),
+	}
+}
+
+func logDuration(start time.Time, msg string) {
+	duration := time.Since(start)
+	if duration > slowQueryDuration {
+		logrus.WithFields(logrus.Fields{
+			"message":  msg,
+			"duration": fmt.Sprint(duration),
+		}).Error("slow query")
 	}
 }

--- a/db/sql_implementation.go
+++ b/db/sql_implementation.go
@@ -353,6 +353,10 @@ func (db *DB) GetOrder(hash common.Hash) (order *types.OrderWithMetadata, err er
 	return sqltypes.OrderToCommonType(&foundOrder), nil
 }
 
+func (db *DB) GetOrderStatuses(hashes []common.Hash) (statuses []int, err error) {
+	return nil, errors.New("not yet implemented")
+}
+
 func (db *DB) FindOrders(query *OrderQuery) (orders []*types.OrderWithMetadata, err error) {
 	defer func() {
 		err = convertErr(err)
@@ -386,7 +390,7 @@ func (db *DB) CountOrders(query *OrderQuery) (count int, err error) {
 		return 0, err
 	}
 	db.mu.RLock()
-	gotCount, err := stmt.GetCount()
+	gotCount, err := stmt.GetCountContext(db.ctx)
 	db.mu.RUnlock()
 	if err != nil {
 		return 0, err

--- a/db/sql_implementation.go
+++ b/db/sql_implementation.go
@@ -353,7 +353,7 @@ func (db *DB) GetOrder(hash common.Hash) (order *types.OrderWithMetadata, err er
 	return sqltypes.OrderToCommonType(&foundOrder), nil
 }
 
-func (db *DB) GetOrderStatuses(hashes []common.Hash) (statuses []int, err error) {
+func (db *DB) GetOrderStatuses(hashes []common.Hash) (statuses []StoredOrderStatus, err error) {
 	return nil, errors.New("not yet implemented")
 }
 

--- a/db/sql_implementation.go
+++ b/db/sql_implementation.go
@@ -353,8 +353,45 @@ func (db *DB) GetOrder(hash common.Hash) (order *types.OrderWithMetadata, err er
 	return sqltypes.OrderToCommonType(&foundOrder), nil
 }
 
-func (db *DB) GetOrderStatuses(hashes []common.Hash) (statuses []StoredOrderStatus, err error) {
-	return nil, errors.New("not yet implemented")
+func (db *DB) GetOrderStatuses(hashes []common.Hash) (statuses []*StoredOrderStatus, err error) {
+	defer func() {
+		err = convertErr(err)
+	}()
+	orderStatuses := make([]*StoredOrderStatus, len(hashes))
+	err = db.ReadWriteTransactionalContext(db.ctx, nil, func(txn *sqlz.Tx) error {
+		for i, hash := range hashes {
+			var foundOrder sqltypes.Order
+			err := db.sqldb.GetContext(db.ctx, &foundOrder, "SELECT isRemoved, fillableTakerAssetAmount FROM orders WHERE hash = $1", hash)
+			if err != nil {
+				if err == sql.ErrNoRows {
+					orderStatuses[i] = &StoredOrderStatus{
+						IsStored:                 false,
+						IsMarkedRemoved:          false,
+						FillableTakerAssetAmount: nil,
+					}
+				} else {
+					return err
+				}
+			} else if foundOrder.IsRemoved {
+				orderStatuses[i] = &StoredOrderStatus{
+					IsStored:                 true,
+					IsMarkedRemoved:          true,
+					FillableTakerAssetAmount: foundOrder.FillableTakerAssetAmount.Int,
+				}
+			} else {
+				orderStatuses[i] = &StoredOrderStatus{
+					IsStored:                 true,
+					IsMarkedRemoved:          false,
+					FillableTakerAssetAmount: foundOrder.FillableTakerAssetAmount.Int,
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return orderStatuses, nil
 }
 
 func (db *DB) FindOrders(query *OrderQuery) (orders []*types.OrderWithMetadata, err error) {

--- a/packages/mesh-browser-lite/src/database.ts
+++ b/packages/mesh-browser-lite/src/database.ts
@@ -85,7 +85,7 @@ export interface Order {
 export interface StoredOrderStatus {
     isStored: boolean;
     isMarkedRemoved: boolean;
-    fillableTakerAssetAmount: string;
+    fillableTakerAssetAmount?: string;
 }
 
 export type OrderField = keyof Order;
@@ -237,7 +237,6 @@ export class Database {
                     statuses.push({
                         isStored: false,
                         isMarkedRemoved: false,
-                        fillableTakerAssetAmount: '0',
                     });
                 } else if (order.isRemoved) {
                     statuses.push({

--- a/packages/mesh-browser-lite/src/database.ts
+++ b/packages/mesh-browser-lite/src/database.ts
@@ -221,6 +221,27 @@ export class Database {
         });
     }
 
+    // GetOrderStatuses(hashes []common.Hash) (statuses []int, err error)
+    public async getOrderStatusesAsync(hashes: string[]): Promise<number[]> {
+        const statuses: number[] = [];
+        await this._db.transaction('rw!', this._orders, async () => {
+            for (const hash of hashes) {
+                const order = await this._orders.get(hash);
+                if (order === undefined) {
+                    // 0 means not stored
+                    statuses.push(0);
+                } else if (order.isRemoved) {
+                    // 1 means stored but marked as removed
+                    statuses.push(1);
+                } else {
+                    // 2 means store and not marked as removed
+                    statuses.push(2);
+                }
+            }
+        });
+        return statuses;
+    }
+
     // FindOrders(opts *OrderQuery) ([]*types.OrderWithMetadata, error)
     public async findOrdersAsync(query?: OrderQuery): Promise<Order[]> {
         return this._db.transaction('rw!', this._orders, async () => {


### PR DESCRIPTION
This PR optimizes how we check for already stored orders in `meshSpecificOrderValidation`. It introduces a new database method, `GetOrderStatuses` which accepts an array of order hashes and checks each one.

It also adds some new log messages to identify slow queries. This can help point us toward future areas of improvement.