### PR TITLE
Don't emit STOPPED_WATCHING events for orders that were already stored

### DIFF
--- a/db/common.go
+++ b/db/common.go
@@ -31,7 +31,7 @@ var (
 )
 
 type Database interface {
-	AddOrders(orders []*types.OrderWithMetadata) (added []*types.OrderWithMetadata, removed []*types.OrderWithMetadata, err error)
+	AddOrders(orders []*types.OrderWithMetadata) (alreadyStored []common.Hash, added []*types.OrderWithMetadata, removed []*types.OrderWithMetadata, err error)
 	GetOrder(hash common.Hash) (*types.OrderWithMetadata, error)
 	GetOrderStatuses(hashes []common.Hash) (statuses []*StoredOrderStatus, err error)
 	FindOrders(opts *OrderQuery) ([]*types.OrderWithMetadata, error)


### PR DESCRIPTION
This PR fixes a subtle bug in orderwatcher.

We call `DB.AddOrders` and assume that any order which does not appear in either `added` or `removed` was not added because its expiration time was too far in the future, so we emit a `STOPPED_WATCHING` event. But there is another explanation which is that the order was already stored. So we were erroneously emitting `STOPPED_WATCHING` events for orders which we were still watching.

This PR fixes the problem by adding a third return value to `DB.AddOrders`: `alreadyStored` which contains the orders which weren’t added because they are already stored in the database.