### PR TITLE
update deployment with telemetry doc with log opts

### DIFF
--- a/docs/deployment_with_telemetry.md
+++ b/docs/deployment_with_telemetry.md
@@ -61,6 +61,12 @@ services:
 
     fluentbit:
         image: 0xorg/mesh-fluent-bit:latest
+        logging:
+            driver: json-file
+            # Configure maximum amount of logs stored
+            options:
+                max-size: "100M"
+                max-file: "3"
         links:
             - esproxy
         ports:


### PR DESCRIPTION
This PR simply cherry-picked the last commit from #885. That PR was based on `master`, which caused it's history to be very out of date.