### PR TITLE
fix: Prevent blockwatcher from missing contract events on startup

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -337,7 +337,10 @@ func newWithPrivateConfig(ctx context.Context, config Config, pConfig privateCon
 		Topics:          topics,
 		Client:          blockWatcherClient,
 	}
-	blockWatcher := blockwatch.New(blockRetentionLimit, blockWatcherConfig)
+	blockWatcher, err := blockwatch.New(blockRetentionLimit, blockWatcherConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	// Initialize the order validator
 	orderValidator, err := ordervalidator.New(

--- a/ethereum/blockwatch/block_watcher.go
+++ b/ethereum/blockwatch/block_watcher.go
@@ -92,15 +92,19 @@ type Watcher struct {
 }
 
 // New creates a new Watcher instance.
-func New(retentionLimit int, config Config) *Watcher {
+func New(retentionLimit int, config Config) (*Watcher, error) {
+	existingMiniHeaders, err := config.DB.FindMiniHeaders(nil)
+	if err != nil {
+		return nil, err
+	}
 	return &Watcher{
 		pollingInterval: config.PollingInterval,
 		db:              config.DB,
-		stack:           simplestack.New(retentionLimit, []*types.MiniHeader{}),
+		stack:           simplestack.New(retentionLimit, existingMiniHeaders),
 		client:          config.Client,
 		withLogs:        config.WithLogs,
 		topics:          config.Topics,
-	}
+	}, nil
 }
 
 func (w *Watcher) GetNumberOfBlocksBehind(ctx context.Context) (int, int, error) {

--- a/ethereum/blockwatch/block_watcher_test.go
+++ b/ethereum/blockwatch/block_watcher_test.go
@@ -519,7 +519,9 @@ func setupOrderWatcher(t *testing.T, ctx context.Context, client Client) *Watche
 	require.NoError(t, err)
 	config.Client = client
 	config.DB = database
-	return New(blockRetentionLimit, config)
+	watcher, err := New(blockRetentionLimit, config)
+	require.NoError(t, err)
+	return watcher
 }
 
 func aRange(from, to int) string {

--- a/ethereum/blockwatch/block_watcher_test.go
+++ b/ethereum/blockwatch/block_watcher_test.go
@@ -69,7 +69,7 @@ func TestNewWatcher(t *testing.T) {
 				found = true
 			}
 		}
-		assert.True(t, found)
+		assert.True(t, found, "miniHeader with hash %q was not stored in watcher.stack", expectedMiniHeader.Hash.Hex())
 	}
 }
 

--- a/ethereum/blockwatch/block_watcher_test.go
+++ b/ethereum/blockwatch/block_watcher_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -40,24 +41,36 @@ func dbOptions() *db.Options {
 func TestNewWatcher(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	database, err := db.New(ctx, db.TestOptions())
+	dbOpts := dbOptions()
+	database, err := db.New(ctx, dbOpts)
 	require.NoError(t, err)
 	config.DB = database
 
-	miniHeader := &types.MiniHeader{
-		Hash:   common.Hash{},
-		Number: big.NewInt(1),
+	expectedMiniHeaders := make([]*types.MiniHeader, dbOpts.MaxMiniHeaders)
+	for i := range expectedMiniHeaders {
+		expectedMiniHeaders[i] = &types.MiniHeader{
+			Hash:   common.HexToHash(strconv.Itoa(i)),
+			Number: big.NewInt(int64(i)),
+		}
+
 	}
-	added, _, err := database.AddMiniHeaders([]*types.MiniHeader{miniHeader})
+	added, _, err := database.AddMiniHeaders(expectedMiniHeaders)
 	require.NoError(t, err)
-	require.Len(t, added, 1)
+	require.Len(t, added, len(expectedMiniHeaders))
 
-	watcher, err := New(db.TestOptions().MaxMiniHeaders, config)
+	watcher, err := New(dbOpts.MaxMiniHeaders, config)
 	require.NoError(t, err)
-
-	miniHeaders := watcher.stack.PeekAll()
-	assert.Len(t, miniHeaders, 1)
-	assert.Equal(t, miniHeader, miniHeaders[0])
+	actualMiniHeaders := watcher.stack.PeekAll()
+	for _, expectedMiniHeader := range expectedMiniHeaders {
+		found := false
+		for _, actualMiniHeader := range actualMiniHeaders {
+			if expectedMiniHeader.Number.Cmp(actualMiniHeader.Number) == 0 {
+				assert.Equal(t, expectedMiniHeader, actualMiniHeader)
+				found = true
+			}
+		}
+		assert.True(t, found)
+	}
 }
 
 func TestWatcher(t *testing.T) {

--- a/zeroex/orderwatch/order_watcher_test.go
+++ b/zeroex/orderwatch/order_watcher_test.go
@@ -1959,7 +1959,7 @@ func setupOrderWatcherWithValidator(ctx context.Context, t *testing.T, ethRPCCli
 		Topics:          topics,
 		Client:          blockWatcherClient,
 	}
-	blockWatcher := blockwatch.New(maxMiniHeaders, blockWatcherConfig)
+	blockWatcher, err := blockwatch.New(maxMiniHeaders, blockWatcherConfig)
 	require.NoError(t, err)
 	orderWatcher, err := New(Config{
 		DB:                database,


### PR DESCRIPTION
<!-- 

Please read our contribution guide before opening your PR: https://github.com/0xProject/0x-mesh/blob/master/CONTRIBUTING.md.
All PRs should be based on the development branch.


-->
Credit to @albrow for finding the problem and identifying the fix.