### PR TITLE
Add back INVALID order event end state

### DIFF
--- a/packages/mesh-graphql-client/src/types.ts
+++ b/packages/mesh-graphql-client/src/types.ts
@@ -194,6 +194,8 @@ export enum OrderEventEndState {
     Cancelled = 'CANCELLED',
     // The order expired and is no longer fillable.
     Expired = 'EXPIRED',
+    // Catch all 'Invalid' state when invalid orders are submitted.
+    Invalid = 'INVALID',
     // The order was previously expired, but due to a block re-org it is no longer considered expired (should be rare).
     Unexpired = 'UNEXPIRED',
     // The order has become unfunded and is no longer fillable. This can happen if the maker makes a transfer or changes their allowance.

--- a/zeroex/ordervalidator/order_validator.go
+++ b/zeroex/ordervalidator/order_validator.go
@@ -195,6 +195,7 @@ func ConvertRejectOrderCodeToOrderEventEndState(rejectedOrderStatus RejectedOrde
 		return zeroex.ESOrderBecameUnfunded, true
 	default:
 		// Catch-all returns Invalid OrderEventEndState
+		log.WithField("rejectedOrderStatus", string(rejectedOrderStatus)).Info("Unexpected RejectedOrderStatus")
 		return zeroex.ESInvalid, false
 	}
 }


### PR DESCRIPTION

<!--

Please read our contribution guide before opening your PR: https://github.com/0xProject/0x-mesh/blob/master/CONTRIBUTING.md.
All PRs should be based on the development branch.


-->
The "INVALID" order event end state pops up in Mesh rejected orders response, but the typescript enum doesn't handle it. This PR adds `INVALID` back to the typescript enum. 

https://github.com/0xProject/0x-mesh/blob/29a468866e7a750022d8b3d25c2947c5ed533385/zeroex/ordervalidator/order_validator.go#L186-L200

https://github.com/0xProject/0x-mesh/blob/development-v4/zeroex/order.go#L317


